### PR TITLE
Replace tmux with per-session Rust PTY daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8822,6 +8822,7 @@ dependencies = [
  "futures-util",
  "glob-match",
  "hostname",
+ "nix 0.29.0",
  "png 0.17.16",
  "portable-pty",
  "rand 0.9.2",

--- a/crates/zremote-agent/Cargo.toml
+++ b/crates/zremote-agent/Cargo.toml
@@ -38,6 +38,7 @@ dirs = "6"
 arboard.workspace = true
 png.workspace = true
 clap = { version = "4", features = ["derive"] }
+nix = { version = "0.29", features = ["signal", "process", "user"] }
 tower-http = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/zremote-agent/src/config.rs
+++ b/crates/zremote-agent/src/config.rs
@@ -119,12 +119,56 @@ impl std::fmt::Display for ConfigError {
 
 impl std::error::Error for ConfigError {}
 
+/// Session persistence backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistenceBackend {
+    /// Per-session PTY daemon processes (preferred, no external deps).
+    Daemon,
+    /// tmux-backed sessions (legacy).
+    Tmux,
+    /// No persistence - plain PTY sessions die with the agent.
+    None,
+}
+
 /// Check if tmux is available on the system.
 pub fn detect_tmux() -> bool {
     std::process::Command::new("tmux")
         .arg("-V")
         .output()
         .is_ok_and(|o| o.status.success())
+}
+
+/// Detect the best available persistence backend.
+///
+/// Priority: Daemon (always available) > Tmux (if installed) > None.
+/// Currently defaults to Daemon, with Tmux as fallback controlled by
+/// `ZREMOTE_SESSION_BACKEND` env var.
+pub fn detect_persistence_backend() -> PersistenceBackend {
+    // Allow explicit override via env var
+    if let Ok(val) = std::env::var("ZREMOTE_SESSION_BACKEND") {
+        match val.to_lowercase().as_str() {
+            "daemon" => return PersistenceBackend::Daemon,
+            "tmux" => {
+                if detect_tmux() {
+                    return PersistenceBackend::Tmux;
+                }
+                tracing::warn!(
+                    "ZREMOTE_SESSION_BACKEND=tmux but tmux not found, falling back to daemon"
+                );
+                return PersistenceBackend::Daemon;
+            }
+            "none" | "pty" => return PersistenceBackend::None,
+            other => {
+                tracing::warn!(
+                    value = other,
+                    "unknown ZREMOTE_SESSION_BACKEND value, using daemon"
+                );
+            }
+        }
+    }
+
+    // Default: daemon (always available, no external deps)
+    PersistenceBackend::Daemon
 }
 
 #[cfg(test)]
@@ -220,6 +264,29 @@ mod tests {
         // On CI or systems without tmux, this will be false; on dev machines, true.
         // We can't assert either way, but we verify it runs without error.
         let _ = result;
+    }
+
+    #[test]
+    fn detect_persistence_backend_returns_value() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { remove_env("ZREMOTE_SESSION_BACKEND") };
+
+        let backend = super::detect_persistence_backend();
+        // Default should be Daemon
+        assert_eq!(backend, super::PersistenceBackend::Daemon);
+    }
+
+    #[test]
+    fn persistence_backend_none_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { set_env("ZREMOTE_SESSION_BACKEND", "none") };
+
+        let backend = super::detect_persistence_backend();
+        assert_eq!(backend, super::PersistenceBackend::None);
+
+        unsafe { remove_env("ZREMOTE_SESSION_BACKEND") };
     }
 
     #[test]

--- a/crates/zremote-agent/src/connection.rs
+++ b/crates/zremote-agent/src/connection.rs
@@ -128,7 +128,7 @@ async fn send_message(ws: &mut WsStream, msg: &AgentMessage) -> Result<(), Conne
 async fn register(
     ws: &mut WsStream,
     config: &AgentConfig,
-    use_tmux: bool,
+    supports_persistence: bool,
 ) -> Result<HostId, ConnectionError> {
     let hostname = hostname::get()
         .map_err(ConnectionError::Hostname)?
@@ -141,7 +141,7 @@ async fn register(
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
         token: config.token.clone(),
-        supports_persistent_sessions: use_tmux,
+        supports_persistent_sessions: supports_persistence,
     };
 
     send_message(ws, &register_msg).await?;
@@ -257,7 +257,7 @@ async fn read_worktree_settings_server(
 
 /// Handle a `SessionCreate` message: spawn a PTY and send `SessionCreated` or `Error`.
 #[allow(clippy::too_many_arguments)]
-fn handle_session_create(
+async fn handle_session_create(
     session_manager: &mut SessionManager,
     outbound_tx: &mpsc::Sender<AgentMessage>,
     session_id: SessionId,
@@ -269,7 +269,10 @@ fn handle_session_create(
     initial_command: Option<&str>,
 ) {
     let shell = shell.unwrap_or(default_shell());
-    match session_manager.create(session_id, shell, cols, rows, working_dir, env) {
+    match session_manager
+        .create(session_id, shell, cols, rows, working_dir, env)
+        .await
+    {
         Ok(pid) => {
             let tmux_name = if session_manager.use_tmux() {
                 Some(format!("zremote-{session_id}"))
@@ -320,14 +323,15 @@ fn handle_session_create(
 pub async fn run_connection(
     config: &AgentConfig,
     shutdown: tokio::sync::watch::Receiver<bool>,
-    use_tmux: bool,
+    backend: crate::config::PersistenceBackend,
 ) -> Result<(), ConnectionError> {
+    let supports_persistence = backend != crate::config::PersistenceBackend::None;
     tracing::info!(server_url = %config.server_url, "connecting to server");
 
     let mut ws = connect(config).await?;
     tracing::info!("WebSocket connection established");
 
-    let host_id = register(&mut ws, config, use_tmux).await?;
+    let host_id = register(&mut ws, config, supports_persistence).await?;
 
     // Split the WebSocket for concurrent read/write
     let (mut ws_sink, mut ws_stream) = ws.split();
@@ -339,11 +343,11 @@ pub async fn run_connection(
     let (pty_output_tx, mut pty_output_rx) = mpsc::channel::<crate::session::PtyOutput>(256);
 
     // Session manager
-    let mut session_manager = SessionManager::new(pty_output_tx.clone(), use_tmux);
+    let mut session_manager = SessionManager::new(pty_output_tx.clone(), backend);
 
-    // Discover and report recovered tmux sessions
+    // Discover and report recovered sessions
     {
-        let recovered = session_manager.discover_existing();
+        let recovered = session_manager.discover_existing().await;
         if !recovered.is_empty() {
             let sessions: Vec<zremote_protocol::RecoveredSession> = recovered
                 .iter()
@@ -527,7 +531,7 @@ pub async fn run_connection(
                                     &agentic_tx,
                                     knowledge_sender.as_ref(),
                                     &session_mapper,
-                                );
+                                ).await;
                             }
                             Err(e) => {
                                 tracing::warn!(error = %e, "failed to parse server message, ignoring");
@@ -639,8 +643,8 @@ pub async fn run_connection(
         }
     };
 
-    // Clean up sessions: detach tmux (they survive), kill PTY
-    if session_manager.use_tmux() {
+    // Clean up sessions: detach persistent ones (they survive), kill plain PTY
+    if session_manager.supports_persistence() {
         session_manager.detach_all();
     } else {
         session_manager.close_all();
@@ -696,7 +700,7 @@ fn set_clipboard_image_and_send_paste(
 
 /// Handle a server message, dispatching session-related messages to the session manager.
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
-fn handle_server_message(
+async fn handle_server_message(
     msg: &ServerMessage,
     host_id: &HostId,
     session_manager: &mut SessionManager,
@@ -730,7 +734,8 @@ fn handle_server_message(
                 working_dir.as_deref(),
                 env.as_ref(),
                 initial_command.as_deref(),
-            );
+            )
+            .await;
         }
         ServerMessage::SessionClose { session_id } => {
             // Clean up agentic loop if any
@@ -1282,7 +1287,8 @@ fn handle_server_message(
             });
         }
         ServerMessage::ClaudeAction(claude_msg) => {
-            handle_claude_server_message(claude_msg, session_manager, outbound_tx, session_mapper);
+            handle_claude_server_message(claude_msg, session_manager, outbound_tx, session_mapper)
+                .await;
         }
         ServerMessage::KnowledgeAction(knowledge_msg) => {
             if let Some(tx) = knowledge_tx {
@@ -1391,7 +1397,7 @@ fn handle_server_message(
 
 /// Handle a Claude server message: start sessions, discover sessions, etc.
 #[allow(clippy::too_many_lines)]
-fn handle_claude_server_message(
+async fn handle_claude_server_message(
     msg: &ClaudeServerMessage,
     session_manager: &mut SessionManager,
     outbound_tx: &mpsc::Sender<AgentMessage>,
@@ -1466,7 +1472,10 @@ fn handle_claude_server_message(
 
             // Spawn PTY session using default shell
             let shell = default_shell();
-            match session_manager.create(*session_id, shell, 120, 40, Some(working_dir), None) {
+            match session_manager
+                .create(*session_id, shell, 120, 40, Some(working_dir), None)
+                .await
+            {
                 Ok(pid) => {
                     tracing::info!(
                         session_id = %session_id,
@@ -1603,7 +1612,7 @@ mod tests {
         SessionMapper,
     ) {
         let (pty_tx, _pty_rx) = mpsc::channel(16);
-        let session_manager = SessionManager::new(pty_tx, false);
+        let session_manager = SessionManager::new(pty_tx, crate::config::PersistenceBackend::None);
         let agentic_manager = AgenticLoopManager::new();
         let project_scanner = ProjectScanner::new();
         let (outbound_tx, outbound_rx) = mpsc::channel(16);
@@ -1679,7 +1688,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1699,7 +1709,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1719,7 +1730,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1738,7 +1750,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
 
         // Should send SessionClosed with exit_code = None
         let sent = orx.try_recv().unwrap();
@@ -1772,7 +1785,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1794,7 +1808,8 @@ mod tests {
             &atx,
             ktx.as_ref(),
             &mapper,
-        );
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/zremote-agent/src/daemon/discovery.rs
+++ b/crates/zremote-agent/src/daemon/discovery.rs
@@ -1,0 +1,467 @@
+use std::path::PathBuf;
+
+use tokio::sync::mpsc;
+use zremote_protocol::SessionId;
+
+use super::DaemonStateFile;
+use super::session::DaemonSession;
+use crate::session::PtyOutput;
+
+use super::socket_dir;
+
+/// Discover running daemon sessions from a previous agent lifecycle.
+///
+/// Scans the socket directory for `*.json` state files, checks each daemon
+/// process is alive (via `kill(pid, 0)` + `started_at` for PID reuse protection),
+/// reconnects, and retrieves scrollback data.
+///
+/// Returns a list of `(DaemonSession, scrollback)` for successfully reconnected daemons.
+pub async fn discover_daemon_sessions(
+    output_tx: mpsc::Sender<PtyOutput>,
+) -> Vec<(DaemonSession, Option<Vec<u8>>)> {
+    let dir = socket_dir();
+    if !dir.exists() {
+        return Vec::new();
+    }
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to read socket directory");
+            return Vec::new();
+        }
+    };
+
+    let mut recovered = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != "json" {
+            continue;
+        }
+
+        // Read and parse state file
+        let Some(state) = read_state_file(&path) else {
+            continue;
+        };
+
+        // Parse session_id
+        let session_id: SessionId = match state.session_id.parse() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::debug!(error = %e, file = %path.display(), "invalid session_id in state file");
+                continue;
+            }
+        };
+
+        // Check if daemon process is alive
+        if !is_daemon_alive(state.daemon_pid, &state.started_at) {
+            tracing::debug!(
+                session_id = %session_id,
+                daemon_pid = state.daemon_pid,
+                "daemon not alive, skipping"
+            );
+            continue;
+        }
+
+        // Build socket path
+        let socket_path = dir.join(format!("{session_id}.sock"));
+        if !socket_path.exists() {
+            tracing::debug!(
+                session_id = %session_id,
+                "socket file missing, skipping"
+            );
+            continue;
+        }
+
+        // Try to reconnect
+        match DaemonSession::reconnect(
+            session_id,
+            socket_path,
+            path.clone(),
+            state.daemon_pid,
+            state.shell_pid,
+            output_tx.clone(),
+        )
+        .await
+        {
+            Ok((session, scrollback, daemon_started_at)) => {
+                // PID reuse protection: verify the daemon's reported started_at
+                // matches the state file. If they differ, this is a different process
+                // that reused the PID.
+                if let Some(ref reported) = daemon_started_at
+                    && reported != &state.started_at
+                {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        state_file_started_at = %state.started_at,
+                        daemon_started_at = %reported,
+                        "started_at mismatch: PID reuse detected, skipping"
+                    );
+                    session.detach();
+                    continue;
+                }
+
+                tracing::info!(
+                    session_id = %session_id,
+                    shell_pid = state.shell_pid,
+                    daemon_pid = state.daemon_pid,
+                    "recovered daemon session"
+                );
+                recovered.push((session, scrollback));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "failed to reconnect to daemon"
+                );
+            }
+        }
+    }
+
+    recovered
+}
+
+/// Clean up stale daemon files (state + socket) where the daemon is dead.
+///
+/// Removes files for daemons that are no longer running, with a 24-hour
+/// staleness threshold to avoid removing files from very recently started daemons.
+pub fn cleanup_stale_daemons() {
+    let dir = socket_dir();
+    if !dir.exists() {
+        return;
+    }
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to read socket dir for cleanup");
+            return;
+        }
+    };
+
+    let now = chrono::Utc::now();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != "json" {
+            continue;
+        }
+
+        let Some(state) = read_state_file(&path) else {
+            // Unparseable state file - clean it up
+            let _ = std::fs::remove_file(&path);
+            continue;
+        };
+
+        // Check if daemon is alive first. If dead, clean up immediately.
+        // Only use 24h threshold for alive daemons whose shell may have exited.
+        if is_daemon_alive(state.daemon_pid, &state.started_at) {
+            // Daemon is alive - only clean up if older than 24h (shell may have exited
+            // but daemon is still running due to some edge case)
+            if let Ok(started) = chrono::DateTime::parse_from_rfc3339(&state.started_at) {
+                let age = now.signed_duration_since(started);
+                if age < chrono::Duration::hours(24) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        // Daemon is dead or stale - clean up
+        tracing::info!(
+            session_id = %state.session_id,
+            daemon_pid = state.daemon_pid,
+            "cleaning up stale daemon files"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let socket_path = path.with_extension("sock");
+        let _ = std::fs::remove_file(&socket_path);
+    }
+}
+
+/// Read and parse a daemon state file.
+fn read_state_file(path: &std::path::Path) -> Option<DaemonStateFile> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Check if a daemon process is alive using `kill(pid, 0)` and verify
+/// the process identity hasn't changed due to PID reuse.
+///
+/// On Linux, uses `/proc/{pid}/stat` starttime for precise PID reuse detection.
+/// On all platforms, falls back to a wall-clock sanity check on `started_at`.
+///
+/// The real PID reuse protection happens during reconnect: the daemon's
+/// `GetState` response includes its own `started_at` which must match
+/// the state file's value.
+fn is_daemon_alive(daemon_pid: u32, started_at: &str) -> bool {
+    let pid = match i32::try_from(daemon_pid) {
+        Ok(p) => nix::unistd::Pid::from_raw(p),
+        Err(_) => return false,
+    };
+
+    // Step 1: Check if process exists via signal 0
+    if nix::sys::signal::kill(pid, None).is_err() {
+        return false;
+    }
+
+    // Step 2 (Linux only): Precise verification via /proc/{pid}/stat
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(false) = verify_proc_starttime(daemon_pid, started_at) {
+            return false; // Definitively a different process (PID was reused)
+        }
+        // If verify_proc_starttime returns None (can't read /proc), fall through to wall-clock check
+    }
+
+    // Step 3: Wall-clock sanity check (all platforms, fallback for Linux without /proc)
+    if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(started_at) {
+        // Reject if started_at is in the future
+        if ts > chrono::Utc::now() {
+            return false;
+        }
+    } else {
+        return false; // Can't parse timestamp
+    }
+
+    true
+}
+
+/// Tolerance in seconds for comparing process start times.
+/// Accounts for clock granularity and small timing differences.
+#[cfg(target_os = "linux")]
+const PROC_TIME_TOLERANCE_SECS: i64 = 5;
+
+/// Verify that the process at `pid` was started at approximately `started_at`
+/// by reading its start time from `/proc/{pid}/stat`.
+///
+/// Returns:
+/// - `Some(true)` if the start times match within tolerance
+/// - `Some(false)` if the start times definitively don't match (PID reuse)
+/// - `None` if `/proc` is unavailable or unparseable (caller should fall back)
+#[cfg(target_os = "linux")]
+fn verify_proc_starttime(pid: u32, started_at: &str) -> Option<bool> {
+    let starttime_ticks = parse_proc_stat_starttime(pid)?;
+    let boot_time_secs = system_boot_time()?;
+    let ticks_per_sec = clock_ticks_per_sec();
+
+    // Compute absolute start time in seconds since epoch
+    // Use saturating_add to prevent integer overflow
+    let proc_start_secs = boot_time_secs.saturating_add(starttime_ticks / ticks_per_sec);
+
+    let claimed_start = chrono::DateTime::parse_from_rfc3339(started_at).ok()?;
+    let claimed_secs = claimed_start.timestamp();
+
+    // Compare with tolerance
+    let proc_start_i64 = i64::try_from(proc_start_secs).ok()?;
+    let diff = (proc_start_i64 - claimed_secs).abs();
+    Some(diff <= PROC_TIME_TOLERANCE_SECS)
+}
+
+/// Parse field 22 (starttime) from `/proc/{pid}/stat`.
+///
+/// The comm field (field 2) can contain spaces and parentheses, so we find
+/// the last ')' to reliably skip it before parsing remaining fields.
+#[cfg(target_os = "linux")]
+fn parse_proc_stat_starttime(pid: u32) -> Option<u64> {
+    let stat_content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+
+    // Find the closing ')' of the comm field (field 2)
+    let after_comm = stat_content.rfind(')')? + 1;
+    let remaining = stat_content.get(after_comm..)?.trim_start();
+
+    // Fields after comm: state(3), ppid(4), pgrp(5), session(6), tty_nr(7),
+    // tpgid(8), flags(9), minflt(10), cminflt(11), majflt(12), cmajflt(13),
+    // utime(14), stime(15), cutime(16), cstime(17), priority(18), nice(19),
+    // num_threads(20), itrealvalue(21), starttime(22)
+    // starttime is the 20th field after the closing ')' (index 19, 0-based)
+    let fields: Vec<&str> = remaining.split_whitespace().collect();
+    // Index: 0=state, 1=ppid, ..., 19=starttime
+    fields.get(19)?.parse().ok()
+}
+
+/// Read system boot time from `/proc/stat` (the `btime` line).
+#[cfg(target_os = "linux")]
+fn system_boot_time() -> Option<u64> {
+    let stat_content = std::fs::read_to_string("/proc/stat").ok()?;
+    for line in stat_content.lines() {
+        if let Some(rest) = line.strip_prefix("btime ") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Get the number of clock ticks per second (CLK_TCK).
+#[cfg(target_os = "linux")]
+fn clock_ticks_per_sec() -> u64 {
+    // sysconf returns Option<c_long>; CLK_TCK is always available on Linux.
+    // Default to 100 (standard Linux value) if sysconf fails.
+    nix::unistd::sysconf(nix::unistd::SysconfVar::CLK_TCK)
+        .ok()
+        .flatten()
+        .and_then(|v| u64::try_from(v).ok())
+        .unwrap_or(100)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_dir_format() {
+        let dir = socket_dir();
+        let uid = nix::unistd::getuid();
+        assert_eq!(dir, PathBuf::from(format!("/tmp/zremote-pty-{uid}")));
+    }
+
+    #[test]
+    fn read_state_file_nonexistent() {
+        let result = read_state_file(std::path::Path::new("/tmp/nonexistent-state-abc.json"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn read_state_file_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("test.json");
+        let state = DaemonStateFile {
+            version: 1,
+            session_id: "test-id".to_string(),
+            shell: "/bin/sh".to_string(),
+            shell_pid: 100,
+            daemon_pid: 101,
+            cols: 80,
+            rows: 24,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        std::fs::write(&path, serde_json::to_string(&state).unwrap()).unwrap();
+
+        let result = read_state_file(&path).unwrap();
+        assert_eq!(result.session_id, "test-id");
+    }
+
+    #[test]
+    fn read_state_file_invalid_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bad.json");
+        std::fs::write(&path, "not json").unwrap();
+
+        let result = read_state_file(&path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn is_daemon_alive_nonexistent_pid() {
+        // PID 99999999 almost certainly doesn't exist
+        let result = is_daemon_alive(99_999_999, "2026-01-01T00:00:00Z");
+        assert!(!result);
+    }
+
+    #[test]
+    fn is_daemon_alive_current_process() {
+        let pid = std::process::id();
+        // Compute the actual process start time to avoid fragility on slow machines.
+        // On non-Linux, fall back to Utc::now() which is fine (no /proc check).
+        let started_at = {
+            #[cfg(target_os = "linux")]
+            {
+                let ticks = super::parse_proc_stat_starttime(pid).unwrap();
+                let boot = super::system_boot_time().unwrap();
+                let clk = super::clock_ticks_per_sec();
+                let secs = boot.saturating_add(ticks / clk);
+                chrono::DateTime::from_timestamp(secs as i64, 0)
+                    .unwrap()
+                    .to_rfc3339()
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                chrono::Utc::now().to_rfc3339()
+            }
+        };
+        let result = is_daemon_alive(pid, &started_at);
+        assert!(result);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_based_verification_current_process() {
+        // Verify that /proc-based starttime verification works for the current process.
+        let pid = std::process::id();
+
+        // parse_proc_stat_starttime should succeed for our own process
+        let starttime_ticks = super::parse_proc_stat_starttime(pid);
+        assert!(
+            starttime_ticks.is_some(),
+            "should be able to read own /proc stat"
+        );
+
+        // system_boot_time should succeed on Linux
+        let btime = super::system_boot_time();
+        assert!(btime.is_some(), "should be able to read boot time");
+
+        // Compute the actual process start time and use it as started_at.
+        // This avoids fragility: Utc::now() would fail if test binary ran >5s.
+        let ticks = starttime_ticks.unwrap();
+        let boot = btime.unwrap();
+        let clk = super::clock_ticks_per_sec();
+        let actual_start_secs = boot.saturating_add(ticks / clk);
+        let actual_start = chrono::DateTime::from_timestamp(actual_start_secs as i64, 0)
+            .unwrap()
+            .to_rfc3339();
+
+        // verify_proc_starttime with the actual start time should return Some(true)
+        let result = super::verify_proc_starttime(pid, &actual_start);
+        assert_eq!(
+            result,
+            Some(true),
+            "current process should match its own start time"
+        );
+
+        // verify_proc_starttime with an old timestamp should return Some(false)
+        let old = "2000-01-01T00:00:00Z";
+        let result = super::verify_proc_starttime(pid, old);
+        assert_eq!(
+            result,
+            Some(false),
+            "current process should not match year-2000 timestamp"
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_daemons_no_dir() {
+        // Should not panic when directory doesn't exist
+        cleanup_stale_daemons();
+    }
+
+    #[tokio::test]
+    async fn discover_empty_dir() {
+        // Create a temp dir and override socket_dir logic by directly testing
+        // that discover returns empty when the socket dir has no state files.
+        let tmp = tempfile::tempdir().unwrap();
+        // Verify no .json files yields empty results
+        let entries = std::fs::read_dir(tmp.path()).unwrap();
+        let json_count = entries
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .count();
+        assert_eq!(json_count, 0, "temp dir should have no json files");
+
+        // The actual discover_daemon_sessions uses a fixed socket_dir(),
+        // so we just verify it doesn't panic with whatever state exists.
+        let (tx, _rx) = mpsc::channel(64);
+        let result = discover_daemon_sessions(tx).await;
+        // Result depends on environment, but must not panic
+        drop(result);
+    }
+}

--- a/crates/zremote-agent/src/daemon/discovery.rs
+++ b/crates/zremote-agent/src/daemon/discovery.rs
@@ -439,9 +439,170 @@ mod tests {
     }
 
     #[test]
+    fn is_daemon_alive_invalid_timestamp() {
+        // Unparseable timestamp should return false even for an alive PID
+        let pid = std::process::id();
+        assert!(!is_daemon_alive(pid, "not-a-timestamp"));
+    }
+
+    #[test]
+    fn is_daemon_alive_future_timestamp() {
+        // Future timestamp should return false
+        let pid = std::process::id();
+        assert!(!is_daemon_alive(pid, "2099-12-31T23:59:59Z"));
+    }
+
+    #[test]
+    fn is_daemon_alive_pid_zero() {
+        // PID 0 (kernel) - kill(0, 0) sends to process group, but we test the path
+        // This exercises the i32 conversion path
+        let result = is_daemon_alive(0, "2026-01-01T00:00:00Z");
+        // Result varies by platform/permissions, but must not panic
+        let _ = result;
+    }
+
+    #[test]
+    fn is_daemon_alive_max_pid() {
+        // u32::MAX should fail i32 conversion or not exist
+        let result = is_daemon_alive(u32::MAX, "2026-01-01T00:00:00Z");
+        assert!(!result, "u32::MAX PID should not be alive");
+    }
+
+    #[test]
+    fn read_state_file_with_extra_fields() {
+        // State file with extra fields should still parse (forward compat)
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("extra.json");
+        let json = r#"{
+            "version": 1,
+            "session_id": "extra-test",
+            "shell": "/bin/sh",
+            "shell_pid": 100,
+            "daemon_pid": 101,
+            "cols": 80,
+            "rows": 24,
+            "started_at": "2026-01-01T00:00:00Z",
+            "unknown_field": "should be ignored"
+        }"#;
+        std::fs::write(&path, json).unwrap();
+        let result = read_state_file(&path);
+        // serde by default ignores unknown fields, so this should work
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().session_id, "extra-test");
+    }
+
+    #[test]
+    fn read_state_file_missing_required_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("incomplete.json");
+        // Missing shell_pid
+        let json = r#"{
+            "version": 1,
+            "session_id": "test",
+            "shell": "/bin/sh",
+            "daemon_pid": 101,
+            "cols": 80,
+            "rows": 24,
+            "started_at": "2026-01-01T00:00:00Z"
+        }"#;
+        std::fs::write(&path, json).unwrap();
+        let result = read_state_file(&path);
+        assert!(result.is_none(), "missing required field should fail parse");
+    }
+
+    #[test]
+    fn read_state_file_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("empty.json");
+        std::fs::write(&path, "").unwrap();
+        let result = read_state_file(&path);
+        assert!(result.is_none(), "empty file should fail parse");
+    }
+
+    #[test]
+    fn cleanup_stale_daemons_removes_dead_daemon_files() {
+        // Create a temp dir that mimics the socket directory structure
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("dead-session.json");
+        let socket_path = tmp.path().join("dead-session.sock");
+
+        // Write a state file with a PID that doesn't exist
+        let state = DaemonStateFile {
+            version: 1,
+            session_id: "dead-session".to_string(),
+            shell: "/bin/sh".to_string(),
+            shell_pid: 99_999_998,
+            daemon_pid: 99_999_999,
+            cols: 80,
+            rows: 24,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        std::fs::write(&state_path, serde_json::to_string(&state).unwrap()).unwrap();
+        std::fs::write(&socket_path, "fake-socket").unwrap();
+
+        // We can't directly call cleanup_stale_daemons with a custom dir,
+        // but we can verify the internal logic by calling read_state_file + is_daemon_alive
+        let parsed = read_state_file(&state_path).unwrap();
+        assert!(!is_daemon_alive(parsed.daemon_pid, &parsed.started_at));
+    }
+
+    #[test]
     fn cleanup_stale_daemons_no_dir() {
         // Should not panic when directory doesn't exist
         cleanup_stale_daemons();
+    }
+
+    #[test]
+    fn cleanup_stale_daemons_removes_unparseable_state_files() {
+        // Verify the logic: unparseable state files are cleaned up
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bad.json");
+        std::fs::write(&path, "not valid json").unwrap();
+
+        // read_state_file returns None for unparseable files
+        assert!(read_state_file(&path).is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_starttime_for_pid_1() {
+        // PID 1 (init/systemd) should always be readable if /proc is available
+        let result = super::parse_proc_stat_starttime(1);
+        // May be None if running in a restricted container, but should not panic
+        let _ = result;
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_starttime_nonexistent_pid() {
+        let result = super::parse_proc_stat_starttime(99_999_999);
+        assert!(result.is_none(), "nonexistent PID should return None");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn system_boot_time_returns_some() {
+        let result = super::system_boot_time();
+        assert!(result.is_some(), "boot time should be readable on Linux");
+        // Boot time should be a reasonable value (after year 2000)
+        let btime = result.unwrap();
+        assert!(btime > 946_684_800, "boot time should be after year 2000");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn clock_ticks_per_sec_returns_reasonable_value() {
+        let ticks = super::clock_ticks_per_sec();
+        // Typical values: 100 (most Linux), sometimes 250, 300, 1000
+        assert!(ticks > 0, "CLK_TCK should be positive");
+        assert!(ticks <= 10000, "CLK_TCK should be reasonable");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_proc_starttime_nonexistent_pid() {
+        let result = super::verify_proc_starttime(99_999_999, "2026-01-01T00:00:00Z");
+        assert!(result.is_none(), "nonexistent PID should return None");
     }
 
     #[tokio::test]

--- a/crates/zremote-agent/src/daemon/mod.rs
+++ b/crates/zremote-agent/src/daemon/mod.rs
@@ -389,7 +389,7 @@ pub async fn run_pty_daemon(
 }
 
 /// Write state file atomically (write .tmp then rename).
-fn write_state_file_atomic(path: &Path, state: &DaemonStateFile) -> std::io::Result<()> {
+pub(crate) fn write_state_file_atomic(path: &Path, state: &DaemonStateFile) -> std::io::Result<()> {
     let tmp_path = path.with_extension("json.tmp");
     let data = serde_json::to_string_pretty(state).map_err(std::io::Error::other)?;
     std::fs::write(&tmp_path, &data)?;
@@ -403,7 +403,7 @@ fn write_state_file_atomic(path: &Path, state: &DaemonStateFile) -> std::io::Res
 }
 
 /// Remove socket and state files on exit.
-fn cleanup(socket_path: &Path, state_file_path: &Path) {
+pub(crate) fn cleanup(socket_path: &Path, state_file_path: &Path) {
     let _ = std::fs::remove_file(socket_path);
     let _ = std::fs::remove_file(state_file_path);
     tracing::info!(
@@ -414,3 +414,153 @@ fn cleanup(socket_path: &Path, state_file_path: &Path) {
 }
 
 use std::io::Write;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> DaemonStateFile {
+        DaemonStateFile {
+            version: 1,
+            session_id: "test-session-001".to_string(),
+            shell: "/bin/sh".to_string(),
+            shell_pid: 12345,
+            daemon_pid: 12346,
+            cols: 80,
+            rows: 24,
+            started_at: "2026-03-25T10:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn write_state_file_atomic_creates_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let state = sample_state();
+        write_state_file_atomic(&path, &state).unwrap();
+
+        assert!(path.exists(), "state file should exist after write");
+        // Tmp file should not remain
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "tmp file should be cleaned up"
+        );
+
+        // Read back and verify
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let decoded: DaemonStateFile = serde_json::from_str(&contents).unwrap();
+        assert_eq!(decoded.session_id, "test-session-001");
+        assert_eq!(decoded.shell, "/bin/sh");
+        assert_eq!(decoded.shell_pid, 12345);
+        assert_eq!(decoded.daemon_pid, 12346);
+        assert_eq!(decoded.cols, 80);
+        assert_eq!(decoded.rows, 24);
+    }
+
+    #[test]
+    fn write_state_file_atomic_overwrites_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let mut state = sample_state();
+        write_state_file_atomic(&path, &state).unwrap();
+
+        // Overwrite with different data
+        state.session_id = "updated-session".to_string();
+        state.cols = 120;
+        state.rows = 40;
+        write_state_file_atomic(&path, &state).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let decoded: DaemonStateFile = serde_json::from_str(&contents).unwrap();
+        assert_eq!(decoded.session_id, "updated-session");
+        assert_eq!(decoded.cols, 120);
+        assert_eq!(decoded.rows, 40);
+    }
+
+    #[test]
+    fn write_state_file_atomic_sets_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.json");
+        let state = sample_state();
+        write_state_file_atomic(&path, &state).unwrap();
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "state file should have 0600 permissions");
+    }
+
+    #[test]
+    fn write_state_file_atomic_fails_on_bad_path() {
+        let state = sample_state();
+        let result = write_state_file_atomic(Path::new("/nonexistent/dir/state.json"), &state);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cleanup_removes_both_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("test.sock");
+        let state_path = tmp.path().join("test.json");
+
+        // Create both files
+        std::fs::write(&socket_path, "socket").unwrap();
+        std::fs::write(&state_path, "state").unwrap();
+        assert!(socket_path.exists());
+        assert!(state_path.exists());
+
+        cleanup(&socket_path, &state_path);
+
+        assert!(!socket_path.exists(), "socket should be removed");
+        assert!(!state_path.exists(), "state file should be removed");
+    }
+
+    #[test]
+    fn cleanup_handles_missing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("missing.sock");
+        let state_path = tmp.path().join("missing.json");
+
+        // Should not panic even if files don't exist
+        cleanup(&socket_path, &state_path);
+    }
+
+    #[test]
+    fn cleanup_handles_partial_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("test.sock");
+        let state_path = tmp.path().join("test.json");
+
+        // Only socket exists
+        std::fs::write(&socket_path, "socket").unwrap();
+        cleanup(&socket_path, &state_path);
+        assert!(!socket_path.exists());
+
+        // Only state exists
+        std::fs::write(&state_path, "state").unwrap();
+        cleanup(&socket_path, &state_path);
+        assert!(!state_path.exists());
+    }
+
+    #[test]
+    fn socket_dir_format() {
+        let uid = nix::unistd::getuid();
+        let dir = socket_dir();
+        assert_eq!(dir, PathBuf::from(format!("/tmp/zremote-pty-{uid}")));
+    }
+
+    #[test]
+    fn daemon_state_file_pretty_json() {
+        let state = sample_state();
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        assert!(json.contains("test-session-001"));
+        assert!(json.contains("version"));
+        assert!(json.contains("shell_pid"));
+        // Verify it round-trips through pretty format
+        let decoded: DaemonStateFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.version, 1);
+    }
+}

--- a/crates/zremote-agent/src/daemon/mod.rs
+++ b/crates/zremote-agent/src/daemon/mod.rs
@@ -1,0 +1,416 @@
+pub mod discovery;
+pub mod protocol;
+pub mod session;
+
+use std::collections::VecDeque;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use tokio::net::UnixListener;
+use tokio::signal::unix::SignalKind;
+use tokio::sync::mpsc;
+
+use protocol::{DaemonRequest, DaemonResponse, RING_BUFFER_CAPACITY, read_request, send_response};
+
+/// State file structure written after socket bind.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct DaemonStateFile {
+    pub version: u32,
+    pub session_id: String,
+    pub shell: String,
+    pub shell_pid: u32,
+    pub daemon_pid: u32,
+    pub cols: u16,
+    pub rows: u16,
+    pub started_at: String,
+}
+
+/// Return the socket directory for the current user.
+pub fn socket_dir() -> PathBuf {
+    let uid = nix::unistd::getuid();
+    PathBuf::from(format!("/tmp/zremote-pty-{uid}"))
+}
+
+/// Run the PTY daemon event loop.
+///
+/// IMPORTANT: `setsid()` must be called BEFORE this function (in main, before tokio runtime).
+#[allow(clippy::too_many_arguments)]
+pub async fn run_pty_daemon(
+    session_id: String,
+    socket_path: PathBuf,
+    state_file_path: PathBuf,
+    shell: String,
+    cols: u16,
+    rows: u16,
+    working_dir: Option<PathBuf>,
+    extra_env: std::collections::HashMap<String, String>,
+) {
+    // 1. Ignore SIGHUP (safe, no unsafe block)
+    let mut sighup = tokio::signal::unix::signal(SignalKind::hangup())
+        .expect("failed to register SIGHUP handler");
+    tokio::spawn(async move {
+        loop {
+            sighup.recv().await;
+        }
+    });
+
+    // 2. Open PTY via portable-pty
+    let pty_system = native_pty_system();
+    let size = PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    let pair = match pty_system.openpty(size) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to open PTY");
+            return;
+        }
+    };
+
+    // 3. Spawn shell
+    let mut cmd = CommandBuilder::new(&shell);
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    for (key, value) in &extra_env {
+        cmd.env(key, value);
+    }
+    if let Some(dir) = &working_dir {
+        cmd.cwd(dir);
+    }
+
+    let child = match pair.slave.spawn_command(cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to spawn shell");
+            return;
+        }
+    };
+
+    let shell_pid = child.process_id().unwrap_or(0);
+    let daemon_pid = std::process::id();
+
+    let master = pair.master;
+    let mut writer = match master.take_writer() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to take PTY writer");
+            return;
+        }
+    };
+    let mut reader = match master.try_clone_reader() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to clone PTY reader");
+            return;
+        }
+    };
+
+    // 4. Create socket directory with 0700 permissions (atomic via DirBuilder mode)
+    let socket_dir = socket_path.parent().expect("socket path must have parent");
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        if let Err(e) = std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(socket_dir)
+        {
+            tracing::error!(error = %e, "failed to create socket directory");
+            return;
+        }
+        // Always enforce permissions even if dir already existed (may have wrong perms)
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = std::fs::set_permissions(socket_dir, std::fs::Permissions::from_mode(0o700))
+        {
+            tracing::error!(error = %e, "failed to set socket directory permissions");
+            return;
+        }
+    }
+
+    // 5. Unlink socket if it exists (cleanup after SIGKILL)
+    let _ = std::fs::remove_file(&socket_path);
+
+    // Validate socket path < 104 bytes (macOS sun_path limit)
+    let socket_path_str = socket_path.to_string_lossy();
+    if socket_path_str.len() >= 104 {
+        tracing::error!(
+            path = %socket_path_str,
+            len = socket_path_str.len(),
+            "socket path too long (>= 104 bytes, macOS sun_path limit)"
+        );
+        return;
+    }
+
+    // 6. Bind Unix socket listener
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(error = %e, path = %socket_path.display(), "failed to bind Unix socket");
+            return;
+        }
+    };
+
+    // Set socket file permissions to 0600 (owner-only access)
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
+        {
+            tracing::error!(error = %e, "failed to set socket file permissions");
+            return;
+        }
+    }
+
+    tracing::info!(
+        session_id = %session_id,
+        socket = %socket_path.display(),
+        shell_pid,
+        daemon_pid,
+        "daemon socket bound"
+    );
+
+    // 7. Write state file AFTER bind (atomic: write .tmp then rename)
+    let started_at = chrono::Utc::now().to_rfc3339();
+    let state = DaemonStateFile {
+        version: 1,
+        session_id: session_id.clone(),
+        shell: shell.clone(),
+        shell_pid,
+        daemon_pid,
+        cols,
+        rows,
+        started_at: started_at.clone(),
+    };
+
+    if let Err(e) = write_state_file_atomic(&state_file_path, &state) {
+        tracing::error!(error = %e, "failed to write state file");
+        return;
+    }
+
+    tracing::info!(
+        state_file = %state_file_path.display(),
+        "daemon state file written"
+    );
+
+    // 8. Event loop
+    let mut ring_buffer: VecDeque<u8> = VecDeque::with_capacity(RING_BUFFER_CAPACITY);
+    let mut current_cols = cols;
+    let mut current_rows = rows;
+
+    // Channel for PTY output from blocking reader
+    let (pty_tx, mut pty_rx) = mpsc::channel::<Vec<u8>>(256);
+    let (pty_eof_tx, mut pty_eof_rx) = mpsc::channel::<Option<i32>>(1);
+
+    // Spawn blocking PTY reader
+    let child_arc = std::sync::Arc::new(std::sync::Mutex::new(child));
+    let child_for_reader = child_arc.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => {
+                    // EOF or error - shell exited
+                    let exit_code = child_for_reader
+                        .lock()
+                        .ok()
+                        .and_then(|mut c| c.try_wait().ok().flatten())
+                        .map(|s| s.exit_code().cast_signed());
+                    let _ = pty_eof_tx.blocking_send(exit_code);
+                    break;
+                }
+                Ok(n) => {
+                    if pty_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Accept loop runs in background, forwarding new connections
+    let (new_conn_tx, mut new_conn_rx) = mpsc::channel::<tokio::net::UnixStream>(4);
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    if new_conn_tx.send(stream).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to accept connection");
+                }
+            }
+        }
+    });
+
+    // Current client write half (Option because no client initially)
+    let mut client_writer: Option<tokio::io::WriteHalf<tokio::net::UnixStream>> = None;
+    let mut reader_handle: Option<tokio::task::JoinHandle<()>> = None;
+    // Create a new channel pair for each client connection to avoid request leakage.
+    // Initial sender is unused (overwritten on first connection).
+    let (mut client_tx, mut client_rx) = mpsc::channel::<DaemonRequest>(64);
+    let _ = &client_tx; // suppress unused_assignments for initial value
+
+    loop {
+        tokio::select! {
+            // New client connection
+            Some(stream) = new_conn_rx.recv() => {
+                // Drop old reader task
+                if let Some(handle) = reader_handle.take() {
+                    handle.abort();
+                }
+
+                // Create a fresh channel for the new connection so old requests don't leak
+                let (new_tx, new_rx) = mpsc::channel::<DaemonRequest>(64);
+                client_tx = new_tx;
+                client_rx = new_rx;
+
+                let (read_half, write_half) = tokio::io::split(stream);
+                client_writer = Some(write_half);
+
+                // Spawn reader for this client
+                let req_tx = client_tx.clone();
+                reader_handle = Some(tokio::spawn(async move {
+                    let mut reader = read_half;
+                    while let Ok(req) = read_request(&mut reader).await {
+                        if req_tx.send(req).await.is_err() {
+                            break;
+                        }
+                    }
+                }));
+
+                tracing::debug!("new client connected");
+            }
+
+            // PTY output from blocking reader
+            Some(data) = pty_rx.recv() => {
+                // Append to ring buffer
+                ring_buffer.extend(&data);
+                let overflow = ring_buffer.len().saturating_sub(RING_BUFFER_CAPACITY);
+                if overflow > 0 {
+                    ring_buffer.drain(..overflow);
+                }
+
+                // Forward to connected client (with timeout, skip on failure)
+                if let Some(ref mut w) = client_writer {
+                    let resp = DaemonResponse::Output { data };
+                    let result = tokio::time::timeout(
+                        std::time::Duration::from_millis(100),
+                        send_response(w, &resp),
+                    ).await;
+                    if result.is_err() || result.is_ok_and(|r| r.is_err()) {
+                        // Write failed or timed out - data is in ring buffer
+                        tracing::debug!("socket write failed/timeout, data in ring buffer only");
+                    }
+                }
+            }
+
+            // Shell exited
+            Some(exit_code) = pty_eof_rx.recv() => {
+                tracing::info!(session_id = %session_id, ?exit_code, "shell exited");
+
+                // Notify connected client
+                if let Some(ref mut w) = client_writer {
+                    let resp = DaemonResponse::Exited { code: exit_code };
+                    let _ = send_response(w, &resp).await;
+                }
+
+                // Cleanup
+                cleanup(&socket_path, &state_file_path);
+                return;
+            }
+
+            // Client request
+            Some(req) = client_rx.recv() => {
+                match req {
+                    DaemonRequest::Input { data } => {
+                        // NOTE: Blocking write is acceptable here because the daemon runs on a
+                        // single-thread tokio runtime. PTY writes are typically fast (kernel buffer).
+                        if let Err(e) = writer.write_all(&data) {
+                            tracing::warn!(error = %e, "failed to write to PTY");
+                        }
+                        let _ = writer.flush();
+                    }
+                    DaemonRequest::Resize { cols: new_cols, rows: new_rows } => {
+                        current_cols = new_cols;
+                        current_rows = new_rows;
+                        let _ = master.resize(PtySize {
+                            rows: new_rows,
+                            cols: new_cols,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        });
+                    }
+                    DaemonRequest::GetState => {
+                        if let Some(ref mut w) = client_writer {
+                            let scrollback: Vec<u8> = ring_buffer.iter().copied().collect();
+                            let resp = DaemonResponse::State {
+                                session_id: session_id.clone(),
+                                shell_pid,
+                                daemon_pid,
+                                cols: current_cols,
+                                rows: current_rows,
+                                scrollback,
+                                started_at: started_at.clone(),
+                            };
+                            let _ = send_response(w, &resp).await;
+                        }
+                    }
+                    DaemonRequest::Shutdown => {
+                        tracing::info!(session_id = %session_id, "shutdown requested");
+                        // Kill shell
+                        if let Ok(mut c) = child_arc.lock() {
+                            let _ = c.kill();
+                        }
+                        cleanup(&socket_path, &state_file_path);
+                        return;
+                    }
+                    DaemonRequest::Ping => {
+                        if let Some(ref mut w) = client_writer {
+                            let _ = send_response(w, &DaemonResponse::Pong).await;
+                        }
+                    }
+                }
+            }
+
+            else => {
+                // All channels closed
+                tracing::info!("all channels closed, daemon exiting");
+                cleanup(&socket_path, &state_file_path);
+                return;
+            }
+        }
+    }
+}
+
+/// Write state file atomically (write .tmp then rename).
+fn write_state_file_atomic(path: &Path, state: &DaemonStateFile) -> std::io::Result<()> {
+    let tmp_path = path.with_extension("json.tmp");
+    let data = serde_json::to_string_pretty(state).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp_path, &data)?;
+    // Set 0600 on the tmp file BEFORE rename to avoid a window with open perms
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// Remove socket and state files on exit.
+fn cleanup(socket_path: &Path, state_file_path: &Path) {
+    let _ = std::fs::remove_file(socket_path);
+    let _ = std::fs::remove_file(state_file_path);
+    tracing::info!(
+        socket = %socket_path.display(),
+        state = %state_file_path.display(),
+        "daemon cleaned up"
+    );
+}
+
+use std::io::Write;

--- a/crates/zremote-agent/src/daemon/protocol.rs
+++ b/crates/zremote-agent/src/daemon/protocol.rs
@@ -1,0 +1,335 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Maximum frame size: 1 MB.
+pub const MAX_FRAME_SIZE: u32 = 1_048_576;
+
+/// Ring buffer capacity for scrollback: 100 KB.
+pub const RING_BUFFER_CAPACITY: usize = 102_400;
+
+/// Requests sent from the agent to the daemon.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum DaemonRequest {
+    /// Write data to PTY stdin.
+    Input { data: Vec<u8> },
+    /// Resize the PTY terminal.
+    Resize { cols: u16, rows: u16 },
+    /// Request current daemon state + scrollback.
+    GetState,
+    /// Gracefully shut down the daemon.
+    Shutdown,
+    /// Keepalive ping.
+    Ping,
+}
+
+/// Responses sent from the daemon to the agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum DaemonResponse {
+    /// PTY output data.
+    Output { data: Vec<u8> },
+    /// Shell process exited.
+    Exited { code: Option<i32> },
+    /// Current daemon state with scrollback.
+    State {
+        session_id: String,
+        shell_pid: u32,
+        daemon_pid: u32,
+        cols: u16,
+        rows: u16,
+        scrollback: Vec<u8>,
+        started_at: String,
+    },
+    /// Keepalive pong.
+    Pong,
+}
+
+/// Write a length-prefixed frame to an async writer.
+pub async fn write_frame<W: AsyncWriteExt + Unpin>(writer: &mut W, data: &[u8]) -> io::Result<()> {
+    let len = u32::try_from(data.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "frame data exceeds u32::MAX bytes",
+        )
+    })?;
+    if len > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("frame size {len} exceeds MAX_FRAME_SIZE {MAX_FRAME_SIZE}"),
+        ));
+    }
+    writer.write_all(&len.to_le_bytes()).await?;
+    writer.write_all(data).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read a length-prefixed frame from an async reader.
+pub async fn read_frame<R: AsyncReadExt + Unpin>(reader: &mut R) -> io::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf);
+
+    if len > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame size {len} exceeds MAX_FRAME_SIZE {MAX_FRAME_SIZE}"),
+        ));
+    }
+
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+/// Send a serialized request over the stream.
+pub async fn send_request<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    request: &DaemonRequest,
+) -> io::Result<()> {
+    let data =
+        serde_json::to_vec(request).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    write_frame(writer, &data).await
+}
+
+/// Send a serialized response over the stream.
+pub async fn send_response<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    response: &DaemonResponse,
+) -> io::Result<()> {
+    let data =
+        serde_json::to_vec(response).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    write_frame(writer, &data).await
+}
+
+/// Read and deserialize a request from the stream.
+pub async fn read_request<R: AsyncReadExt + Unpin>(reader: &mut R) -> io::Result<DaemonRequest> {
+    let data = read_frame(reader).await?;
+    serde_json::from_slice(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Read and deserialize a response from the stream.
+pub async fn read_response<R: AsyncReadExt + Unpin>(reader: &mut R) -> io::Result<DaemonResponse> {
+    let data = read_frame(reader).await?;
+    serde_json::from_slice(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_request_serde_round_trip_input() {
+        let req = DaemonRequest::Input {
+            data: vec![0x1b, 0x5b, 0x41],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn daemon_request_serde_round_trip_resize() {
+        let req = DaemonRequest::Resize {
+            cols: 120,
+            rows: 40,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn daemon_request_serde_round_trip_get_state() {
+        let req = DaemonRequest::GetState;
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn daemon_request_serde_round_trip_shutdown() {
+        let req = DaemonRequest::Shutdown;
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn daemon_request_serde_round_trip_ping() {
+        let req = DaemonRequest::Ping;
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn daemon_response_serde_round_trip_output() {
+        let resp = DaemonResponse::Output {
+            data: b"hello world".to_vec(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: DaemonResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn daemon_response_serde_round_trip_exited() {
+        let resp = DaemonResponse::Exited { code: Some(0) };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: DaemonResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(resp, decoded);
+
+        let resp_none = DaemonResponse::Exited { code: None };
+        let json_none = serde_json::to_string(&resp_none).unwrap();
+        let decoded_none: DaemonResponse = serde_json::from_str(&json_none).unwrap();
+        assert_eq!(resp_none, decoded_none);
+    }
+
+    #[test]
+    fn daemon_response_serde_round_trip_state() {
+        let resp = DaemonResponse::State {
+            session_id: "abc-123".to_string(),
+            shell_pid: 1234,
+            daemon_pid: 1235,
+            cols: 80,
+            rows: 24,
+            scrollback: vec![0x41, 0x42, 0x43],
+            started_at: "2026-03-25T10:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: DaemonResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn daemon_response_serde_round_trip_pong() {
+        let resp = DaemonResponse::Pong;
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: DaemonResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[tokio::test]
+    async fn frame_encode_decode_round_trip() {
+        let data = b"hello frame protocol";
+        let mut buf = Vec::new();
+        write_frame(&mut buf, data).await.unwrap();
+
+        let mut cursor = io::Cursor::new(buf);
+        let decoded = read_frame(&mut cursor).await.unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[tokio::test]
+    async fn frame_encode_decode_empty() {
+        let data = b"";
+        let mut buf = Vec::new();
+        write_frame(&mut buf, data).await.unwrap();
+
+        let mut cursor = io::Cursor::new(buf);
+        let decoded = read_frame(&mut cursor).await.unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[tokio::test]
+    async fn frame_max_size_rejection_on_read() {
+        // Craft a frame header claiming a size larger than MAX_FRAME_SIZE
+        let bad_len = (MAX_FRAME_SIZE + 1).to_le_bytes();
+        let mut cursor = io::Cursor::new(bad_len.to_vec());
+        let result = read_frame(&mut cursor).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("MAX_FRAME_SIZE"),
+            "error should mention MAX_FRAME_SIZE, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn frame_max_size_rejection_on_write() {
+        let big_data = vec![0u8; (MAX_FRAME_SIZE + 1) as usize];
+        let mut buf = Vec::new();
+        let result = write_frame(&mut buf, &big_data).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_and_read_request_round_trip() {
+        let req = DaemonRequest::Resize {
+            cols: 200,
+            rows: 50,
+        };
+        let mut buf = Vec::new();
+        send_request(&mut buf, &req).await.unwrap();
+
+        let mut cursor = io::Cursor::new(buf);
+        let decoded = read_request(&mut cursor).await.unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[tokio::test]
+    async fn send_and_read_response_round_trip() {
+        let resp = DaemonResponse::Output {
+            data: b"test output".to_vec(),
+        };
+        let mut buf = Vec::new();
+        send_response(&mut buf, &resp).await.unwrap();
+
+        let mut cursor = io::Cursor::new(buf);
+        let decoded = read_response(&mut cursor).await.unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn ring_buffer_push_and_truncate() {
+        use std::collections::VecDeque;
+
+        let mut ring: VecDeque<u8> = VecDeque::with_capacity(RING_BUFFER_CAPACITY);
+
+        // Fill past capacity
+        let chunk = vec![0x41u8; 1000];
+        for _ in 0..110 {
+            ring.extend(&chunk);
+        }
+        // Should be 110_000 bytes now (over RING_BUFFER_CAPACITY of 102_400)
+        assert_eq!(ring.len(), 110_000);
+
+        // Truncate front to capacity using drain (same pattern as daemon event loop)
+        let overflow = ring.len().saturating_sub(RING_BUFFER_CAPACITY);
+        ring.drain(..overflow);
+        assert_eq!(ring.len(), RING_BUFFER_CAPACITY);
+
+        // Add more data and verify truncation
+        ring.extend(&[0x42u8; 5000]);
+        let overflow = ring.len().saturating_sub(RING_BUFFER_CAPACITY);
+        ring.drain(..overflow);
+        assert_eq!(ring.len(), RING_BUFFER_CAPACITY);
+
+        // Last bytes should be 0x42
+        assert_eq!(ring.back().copied(), Some(0x42));
+    }
+
+    #[test]
+    fn request_json_has_type_tag() {
+        let req = DaemonRequest::Ping;
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains(r#""type":"Ping"#),
+            "JSON should contain type tag: {json}"
+        );
+    }
+
+    #[test]
+    fn response_json_has_type_tag() {
+        let resp = DaemonResponse::Pong;
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            json.contains(r#""type":"Pong"#),
+            "JSON should contain type tag: {json}"
+        );
+    }
+}

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -1,0 +1,475 @@
+use std::path::PathBuf;
+
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use zremote_protocol::SessionId;
+
+use super::DaemonStateFile;
+use super::protocol::{DaemonRequest, DaemonResponse, read_response, send_request};
+use crate::session::PtyOutput;
+
+/// Client-side handle to a PTY daemon process.
+///
+/// Each `DaemonSession` corresponds to one daemon process holding a single
+/// PTY master fd. Communication happens over a Unix domain socket using
+/// length-prefixed JSON frames.
+pub struct DaemonSession {
+    session_id: SessionId,
+    socket_path: PathBuf,
+    state_path: PathBuf,
+    daemon_pid: u32,
+    shell_pid: u32,
+    writer_tx: mpsc::Sender<DaemonRequest>,
+    reader_handle: JoinHandle<()>,
+    writer_handle: JoinHandle<()>,
+}
+
+impl DaemonSession {
+    /// Spawn a new PTY daemon process and connect to it.
+    ///
+    /// Tries `systemd-run --scope --user` first, falls back to direct spawn.
+    /// Waits for the daemon state file (poll every 100ms, timeout 3s).
+    ///
+    /// Returns `(session, shell_pid)`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn spawn(
+        session_id: SessionId,
+        shell: &str,
+        cols: u16,
+        rows: u16,
+        working_dir: Option<&str>,
+        env: Option<&std::collections::HashMap<String, String>>,
+        output_tx: mpsc::Sender<PtyOutput>,
+    ) -> Result<(Self, u32), Box<dyn std::error::Error + Send + Sync>> {
+        let exe = std::env::current_exe()?;
+        let uid = nix::unistd::getuid();
+        let sock_dir = PathBuf::from(format!("/tmp/zremote-pty-{uid}"));
+        let socket_path = sock_dir.join(format!("{session_id}.sock"));
+        let state_path = sock_dir.join(format!("{session_id}.json"));
+
+        // Build args for the daemon subprocess
+        let mut args = vec![
+            "pty-daemon".to_string(),
+            "--session-id".to_string(),
+            session_id.to_string(),
+            "--socket".to_string(),
+            socket_path.to_string_lossy().to_string(),
+            "--state-file".to_string(),
+            state_path.to_string_lossy().to_string(),
+            "--shell".to_string(),
+            shell.to_string(),
+            "--cols".to_string(),
+            cols.to_string(),
+            "--rows".to_string(),
+            rows.to_string(),
+        ];
+        if let Some(dir) = working_dir {
+            args.push("--working-dir".to_string());
+            args.push(dir.to_string());
+        }
+        if let Some(env_vars) = env {
+            for (key, value) in env_vars {
+                args.push("--env".to_string());
+                args.push(format!("{key}={value}"));
+            }
+        }
+
+        // Try systemd-run first, fall back to direct spawn
+        let spawn_result = spawn_via_systemd(&exe, &args, &session_id);
+        if spawn_result.is_err() {
+            tracing::debug!("systemd-run unavailable, falling back to direct spawn");
+            spawn_direct(&exe, &args)?;
+        }
+
+        // Wait for state file (poll 100ms, timeout 3s)
+        let state = wait_for_state_file(&state_path).await?;
+
+        // Connect to the Unix socket
+        let stream = UnixStream::connect(&socket_path).await.map_err(|e| {
+            format!(
+                "failed to connect to daemon socket {}: {e}",
+                socket_path.display()
+            )
+        })?;
+
+        let (reader_handle, writer_handle, writer_tx) =
+            start_io_tasks(session_id, stream, output_tx);
+
+        let session = Self {
+            session_id,
+            socket_path,
+            state_path,
+            daemon_pid: state.daemon_pid,
+            shell_pid: state.shell_pid,
+            writer_tx,
+            reader_handle,
+            writer_handle,
+        };
+
+        Ok((session, state.shell_pid))
+    }
+
+    /// Write data to the daemon's PTY stdin.
+    pub fn write(&self, data: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.writer_tx
+            .try_send(DaemonRequest::Input {
+                data: data.to_vec(),
+            })
+            .map_err(|e| format!("failed to send input to daemon: {e}"))?;
+        Ok(())
+    }
+
+    /// Resize the daemon's PTY terminal.
+    pub fn resize(
+        &self,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.writer_tx
+            .try_send(DaemonRequest::Resize { cols, rows })
+            .map_err(|e| format!("failed to send resize to daemon: {e}"))?;
+        Ok(())
+    }
+
+    /// Send shutdown request to the daemon (kills shell, cleans up).
+    pub fn kill(&self) {
+        let _ = self.writer_tx.try_send(DaemonRequest::Shutdown);
+    }
+
+    /// Detach from the daemon without sending shutdown.
+    /// The daemon process and shell survive.
+    pub fn detach(self) {
+        self.reader_handle.abort();
+        self.writer_handle.abort();
+        // Drop writer_tx without sending Shutdown - daemon stays alive
+    }
+
+    /// Return the shell process PID.
+    pub fn pid(&self) -> u32 {
+        self.shell_pid
+    }
+
+    /// Check if the daemon process is still alive.
+    /// Returns `None` if alive, `Some(exit_code)` if dead (exit code unavailable, returns 1).
+    pub fn try_wait(&self) -> Option<i32> {
+        let pid = nix::unistd::Pid::from_raw(i32::try_from(self.daemon_pid).unwrap_or(i32::MAX));
+        // Signal 0 = check if process exists without actually signaling
+        match nix::sys::signal::kill(pid, None) {
+            Ok(()) => None,    // Process is alive
+            Err(_) => Some(1), // Process is dead (or we don't have permission)
+        }
+    }
+
+    /// Reconnect to an existing daemon via its socket path.
+    ///
+    /// Sends `GetState` to retrieve scrollback, then starts new reader/writer tasks.
+    /// Returns `(session, scrollback_data, daemon_started_at)`.
+    pub async fn reconnect(
+        session_id: SessionId,
+        socket_path: PathBuf,
+        state_path: PathBuf,
+        daemon_pid: u32,
+        shell_pid: u32,
+        output_tx: mpsc::Sender<PtyOutput>,
+    ) -> Result<(Self, Option<Vec<u8>>, Option<String>), Box<dyn std::error::Error + Send + Sync>>
+    {
+        let stream = UnixStream::connect(&socket_path).await.map_err(|e| {
+            format!(
+                "failed to connect to daemon socket {}: {e}",
+                socket_path.display()
+            )
+        })?;
+
+        // Split stream to send GetState and read the response
+        let (mut read_half, mut write_half) = tokio::io::split(stream);
+
+        // Send GetState request
+        send_request(&mut write_half, &DaemonRequest::GetState).await?;
+
+        // Read state response
+        let (scrollback, daemon_started_at) = match read_response(&mut read_half).await {
+            Ok(DaemonResponse::State {
+                scrollback,
+                started_at,
+                ..
+            }) => {
+                let sb = if scrollback.is_empty() {
+                    None
+                } else {
+                    Some(scrollback)
+                };
+                (sb, Some(started_at))
+            }
+            Ok(other) => {
+                tracing::warn!(?other, "unexpected response to GetState");
+                (None, None)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to read GetState response");
+                (None, None)
+            }
+        };
+
+        // Reunite the stream halves for the IO tasks
+        let stream = read_half.unsplit(write_half);
+
+        let (reader_handle, writer_handle, writer_tx) =
+            start_io_tasks(session_id, stream, output_tx);
+
+        let session = Self {
+            session_id,
+            socket_path,
+            state_path,
+            daemon_pid,
+            shell_pid,
+            writer_tx,
+            reader_handle,
+            writer_handle,
+        };
+
+        Ok((session, scrollback, daemon_started_at))
+    }
+
+    /// Return the session ID.
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    /// Return the socket path.
+    pub fn socket_path(&self) -> &PathBuf {
+        &self.socket_path
+    }
+
+    /// Return the state file path.
+    pub fn state_path(&self) -> &PathBuf {
+        &self.state_path
+    }
+}
+
+impl Drop for DaemonSession {
+    fn drop(&mut self) {
+        self.reader_handle.abort();
+        self.writer_handle.abort();
+    }
+}
+
+/// Start reader and writer I/O tasks for the daemon socket connection.
+///
+/// Reader: reads `DaemonResponse` from socket, forwards Output/Exited to `output_tx`.
+/// Writer: reads `DaemonRequest` from `writer_tx`, sends to socket.
+fn start_io_tasks(
+    session_id: SessionId,
+    stream: UnixStream,
+    output_tx: mpsc::Sender<PtyOutput>,
+) -> (JoinHandle<()>, JoinHandle<()>, mpsc::Sender<DaemonRequest>) {
+    let (read_half, write_half) = tokio::io::split(stream);
+    let (writer_tx, mut writer_rx) = mpsc::channel::<DaemonRequest>(256);
+
+    // Reader task: socket -> output_tx
+    let reader_handle = tokio::spawn(async move {
+        let mut reader = read_half;
+        loop {
+            match read_response(&mut reader).await {
+                Ok(DaemonResponse::Output { data }) => {
+                    if output_tx
+                        .send(PtyOutput {
+                            session_id,
+                            pane_id: None,
+                            data,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(DaemonResponse::Exited { .. }) => {
+                    // Signal EOF
+                    let _ = output_tx
+                        .send(PtyOutput {
+                            session_id,
+                            pane_id: None,
+                            data: Vec::new(),
+                        })
+                        .await;
+                    break;
+                }
+                Ok(DaemonResponse::State { .. } | DaemonResponse::Pong) => {
+                    // Ignore state/pong in normal reader flow
+                }
+                Err(e) => {
+                    // Connection lost - signal EOF
+                    tracing::debug!(error = %e, session_id = %session_id, "daemon socket read error");
+                    let _ = output_tx
+                        .send(PtyOutput {
+                            session_id,
+                            pane_id: None,
+                            data: Vec::new(),
+                        })
+                        .await;
+                    break;
+                }
+            }
+        }
+    });
+
+    // Writer task: writer_rx -> socket
+    let writer_handle = tokio::spawn(async move {
+        let mut writer = write_half;
+        while let Some(req) = writer_rx.recv().await {
+            if let Err(e) = send_request(&mut writer, &req).await {
+                tracing::debug!(error = %e, "daemon socket write error");
+                break;
+            }
+        }
+    });
+
+    (reader_handle, writer_handle, writer_tx)
+}
+
+/// Try to spawn the daemon via systemd-run for cgroup isolation.
+///
+/// Uses `--no-block` and `spawn()` to avoid waiting for the scope to finish.
+/// The state file poll in `wait_for_state_file()` handles daemon readiness.
+fn spawn_via_systemd(
+    exe: &std::path::Path,
+    args: &[String],
+    session_id: &SessionId,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let unit_name = format!("zremote-pty-{session_id}");
+    let mut cmd = tokio::process::Command::new("systemd-run");
+    cmd.arg("--scope")
+        .arg("--user")
+        .arg("--unit")
+        .arg(&unit_name)
+        .arg("--no-block")
+        .arg("--")
+        .arg(exe)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    cmd.spawn()?;
+    Ok(())
+}
+
+/// Spawn daemon directly via tokio Command (fallback when systemd is unavailable).
+fn spawn_direct(
+    exe: &std::path::Path,
+    args: &[String],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tokio::process::Command::new(exe)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    Ok(())
+}
+
+/// Wait for the daemon state file to appear (poll every 100ms, timeout 3s).
+async fn wait_for_state_file(
+    state_path: &std::path::Path,
+) -> Result<DaemonStateFile, Box<dyn std::error::Error + Send + Sync>> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        if tokio::fs::try_exists(state_path).await.unwrap_or(false) {
+            match tokio::fs::read_to_string(state_path).await {
+                Ok(contents) => match serde_json::from_str::<DaemonStateFile>(&contents) {
+                    Ok(state) => return Ok(state),
+                    Err(e) => {
+                        tracing::debug!(error = %e, "state file not ready yet (parse error)");
+                    }
+                },
+                Err(e) => {
+                    tracing::debug!(error = %e, "state file not ready yet (read error)");
+                }
+            }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "timeout waiting for daemon state file: {}",
+                state_path.display()
+            )
+            .into());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_dir_contains_uid() {
+        let uid = nix::unistd::getuid();
+        let dir = super::super::socket_dir();
+        assert!(
+            dir.to_string_lossy().contains(&uid.to_string()),
+            "socket dir should contain uid: {}",
+            dir.display()
+        );
+    }
+
+    #[test]
+    fn state_file_round_trip() {
+        let state = DaemonStateFile {
+            version: 1,
+            session_id: "test-123".to_string(),
+            shell: "/bin/zsh".to_string(),
+            shell_pid: 1234,
+            daemon_pid: 1235,
+            cols: 80,
+            rows: 24,
+            started_at: "2026-03-25T10:00:00Z".to_string(),
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let decoded: DaemonStateFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.session_id, "test-123");
+        assert_eq!(decoded.shell_pid, 1234);
+        assert_eq!(decoded.daemon_pid, 1235);
+    }
+
+    #[tokio::test]
+    async fn wait_for_state_file_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nonexistent.json");
+        let result = wait_for_state_file(&path).await;
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("timeout"),
+            "should mention timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_state_file_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let state = DaemonStateFile {
+            version: 1,
+            session_id: "abc".to_string(),
+            shell: "/bin/sh".to_string(),
+            shell_pid: 100,
+            daemon_pid: 101,
+            cols: 80,
+            rows: 24,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        // Write state file before calling wait
+        let json = serde_json::to_string(&state).unwrap();
+        std::fs::write(&path, json).unwrap();
+
+        let result = wait_for_state_file(&path).await.unwrap();
+        assert_eq!(result.session_id, "abc");
+        assert_eq!(result.shell_pid, 100);
+    }
+}

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -538,7 +538,7 @@ mod tests {
         use tokio::net::UnixStream;
 
         let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
-        let session_id: SessionId = uuid::Uuid::new_v4().into();
+        let session_id: SessionId = uuid::Uuid::new_v4();
 
         let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
 
@@ -584,7 +584,7 @@ mod tests {
         use tokio::net::UnixStream;
 
         let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
-        let session_id: SessionId = uuid::Uuid::new_v4().into();
+        let session_id: SessionId = uuid::Uuid::new_v4();
 
         let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
 
@@ -617,7 +617,7 @@ mod tests {
         use tokio::net::UnixStream;
 
         let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
-        let session_id: SessionId = uuid::Uuid::new_v4().into();
+        let session_id: SessionId = uuid::Uuid::new_v4();
 
         let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
 
@@ -645,7 +645,7 @@ mod tests {
         use tokio::net::UnixStream;
 
         let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
-        let session_id: SessionId = uuid::Uuid::new_v4().into();
+        let session_id: SessionId = uuid::Uuid::new_v4();
 
         let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
 
@@ -700,7 +700,7 @@ mod tests {
         use tokio::net::UnixStream;
 
         let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
-        let session_id: SessionId = uuid::Uuid::new_v4().into();
+        let session_id: SessionId = uuid::Uuid::new_v4();
 
         let (output_tx, _output_rx) = mpsc::channel::<PtyOutput>(64);
 

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -472,4 +472,308 @@ mod tests {
         assert_eq!(result.session_id, "abc");
         assert_eq!(result.shell_pid, 100);
     }
+
+    #[tokio::test]
+    async fn wait_for_state_file_delayed_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("delayed.json");
+        let path_clone = path.clone();
+
+        // Spawn a task that writes the state file after 500ms
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let state = DaemonStateFile {
+                version: 1,
+                session_id: "delayed".to_string(),
+                shell: "/bin/sh".to_string(),
+                shell_pid: 200,
+                daemon_pid: 201,
+                cols: 100,
+                rows: 30,
+                started_at: "2026-03-25T12:00:00Z".to_string(),
+            };
+            let json = serde_json::to_string(&state).unwrap();
+            std::fs::write(&path_clone, json).unwrap();
+        });
+
+        let result = wait_for_state_file(&path).await.unwrap();
+        assert_eq!(result.session_id, "delayed");
+        assert_eq!(result.shell_pid, 200);
+        assert_eq!(result.cols, 100);
+        assert_eq!(result.rows, 30);
+    }
+
+    #[tokio::test]
+    async fn wait_for_state_file_invalid_json_then_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("evolving.json");
+
+        // Write invalid JSON first
+        std::fs::write(&path, "not valid json yet").unwrap();
+
+        let path_clone = path.clone();
+        // After 500ms, overwrite with valid JSON
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let state = DaemonStateFile {
+                version: 1,
+                session_id: "evolved".to_string(),
+                shell: "/bin/sh".to_string(),
+                shell_pid: 300,
+                daemon_pid: 301,
+                cols: 80,
+                rows: 24,
+                started_at: "2026-03-25T13:00:00Z".to_string(),
+            };
+            let json = serde_json::to_string(&state).unwrap();
+            std::fs::write(&path_clone, json).unwrap();
+        });
+
+        let result = wait_for_state_file(&path).await.unwrap();
+        assert_eq!(result.session_id, "evolved");
+    }
+
+    #[tokio::test]
+    async fn start_io_tasks_forwards_output() {
+        use tokio::net::UnixStream;
+
+        let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
+        let session_id: SessionId = uuid::Uuid::new_v4().into();
+
+        let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
+
+        let (reader_handle, writer_handle, writer_tx) =
+            start_io_tasks(session_id, client_stream, output_tx);
+
+        // Simulate daemon sending an Output response on daemon_stream
+        let (mut daemon_read, mut daemon_write) = tokio::io::split(daemon_stream);
+        let resp = super::super::protocol::DaemonResponse::Output {
+            data: b"hello from daemon".to_vec(),
+        };
+        super::super::protocol::send_response(&mut daemon_write, &resp)
+            .await
+            .unwrap();
+
+        // Read from output_rx
+        let output = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .expect("should receive output within timeout")
+            .expect("channel should not be closed");
+        assert_eq!(output.data, b"hello from daemon");
+        assert_eq!(output.session_id, session_id);
+
+        // Test writer: send a request through writer_tx and read from daemon side
+        writer_tx.send(DaemonRequest::Ping).await.unwrap();
+
+        let req = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            super::super::protocol::read_request(&mut daemon_read),
+        )
+        .await
+        .expect("should receive request within timeout")
+        .unwrap();
+        assert_eq!(req, DaemonRequest::Ping);
+
+        // Clean up
+        reader_handle.abort();
+        writer_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn start_io_tasks_handles_exited() {
+        use tokio::net::UnixStream;
+
+        let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
+        let session_id: SessionId = uuid::Uuid::new_v4().into();
+
+        let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
+
+        let (reader_handle, writer_handle, _writer_tx) =
+            start_io_tasks(session_id, client_stream, output_tx);
+
+        // Daemon sends Exited
+        let (_daemon_read, mut daemon_write) = tokio::io::split(daemon_stream);
+        let resp = super::super::protocol::DaemonResponse::Exited { code: Some(0) };
+        super::super::protocol::send_response(&mut daemon_write, &resp)
+            .await
+            .unwrap();
+
+        // Should receive empty data (EOF signal)
+        let output = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed");
+        assert!(
+            output.data.is_empty(),
+            "Exited should produce empty data (EOF)"
+        );
+
+        reader_handle.abort();
+        writer_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn start_io_tasks_handles_disconnect() {
+        use tokio::net::UnixStream;
+
+        let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
+        let session_id: SessionId = uuid::Uuid::new_v4().into();
+
+        let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
+
+        let (reader_handle, _writer_handle, _writer_tx) =
+            start_io_tasks(session_id, client_stream, output_tx);
+
+        // Drop daemon side to simulate disconnect
+        drop(daemon_stream);
+
+        // Should receive EOF signal (empty data)
+        let output = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed");
+        assert!(
+            output.data.is_empty(),
+            "disconnect should produce empty data (EOF)"
+        );
+
+        reader_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn start_io_tasks_ignores_state_and_pong() {
+        use tokio::net::UnixStream;
+
+        let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
+        let session_id: SessionId = uuid::Uuid::new_v4().into();
+
+        let (output_tx, mut output_rx) = mpsc::channel::<PtyOutput>(64);
+
+        let (reader_handle, writer_handle, _writer_tx) =
+            start_io_tasks(session_id, client_stream, output_tx);
+
+        let (_daemon_read, mut daemon_write) = tokio::io::split(daemon_stream);
+
+        // Send State response (should be ignored by reader)
+        let state_resp = super::super::protocol::DaemonResponse::State {
+            session_id: session_id.to_string(),
+            shell_pid: 100,
+            daemon_pid: 101,
+            cols: 80,
+            rows: 24,
+            scrollback: vec![],
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        super::super::protocol::send_response(&mut daemon_write, &state_resp)
+            .await
+            .unwrap();
+
+        // Send Pong (should be ignored)
+        super::super::protocol::send_response(
+            &mut daemon_write,
+            &super::super::protocol::DaemonResponse::Pong,
+        )
+        .await
+        .unwrap();
+
+        // Send real Output after the ignored messages
+        let output_resp = super::super::protocol::DaemonResponse::Output {
+            data: b"real data".to_vec(),
+        };
+        super::super::protocol::send_response(&mut daemon_write, &output_resp)
+            .await
+            .unwrap();
+
+        // Should only receive the real output, State and Pong are silently ignored
+        let output = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed");
+        assert_eq!(output.data, b"real data");
+
+        reader_handle.abort();
+        writer_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn start_io_tasks_writer_sends_multiple_requests() {
+        use tokio::net::UnixStream;
+
+        let (client_stream, daemon_stream) = UnixStream::pair().unwrap();
+        let session_id: SessionId = uuid::Uuid::new_v4().into();
+
+        let (output_tx, _output_rx) = mpsc::channel::<PtyOutput>(64);
+
+        let (reader_handle, writer_handle, writer_tx) =
+            start_io_tasks(session_id, client_stream, output_tx);
+
+        let (mut daemon_read, _daemon_write) = tokio::io::split(daemon_stream);
+
+        // Send several requests
+        writer_tx
+            .send(DaemonRequest::Input {
+                data: b"ls\n".to_vec(),
+            })
+            .await
+            .unwrap();
+        writer_tx
+            .send(DaemonRequest::Resize {
+                cols: 120,
+                rows: 40,
+            })
+            .await
+            .unwrap();
+        writer_tx.send(DaemonRequest::GetState).await.unwrap();
+
+        // Read them all from daemon side
+        let req1 = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            super::super::protocol::read_request(&mut daemon_read),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            req1,
+            DaemonRequest::Input {
+                data: b"ls\n".to_vec()
+            }
+        );
+
+        let req2 = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            super::super::protocol::read_request(&mut daemon_read),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            req2,
+            DaemonRequest::Resize {
+                cols: 120,
+                rows: 40
+            }
+        );
+
+        let req3 = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            super::super::protocol::read_request(&mut daemon_read),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(req3, DaemonRequest::GetState);
+
+        reader_handle.abort();
+        writer_handle.abort();
+    }
+
+    #[test]
+    fn try_wait_for_dead_process() {
+        // We can't easily construct a DaemonSession without a real daemon,
+        // but we can test the kill-check logic via nix directly
+        let pid = nix::unistd::Pid::from_raw(99_999_999);
+        let result = nix::sys::signal::kill(pid, None);
+        assert!(result.is_err(), "nonexistent PID should fail signal check");
+    }
 }

--- a/crates/zremote-agent/src/local/mod.rs
+++ b/crates/zremote-agent/src/local/mod.rs
@@ -86,12 +86,18 @@ pub async fn run_local(
         shutdown_for_signal.cancel();
     });
 
-    // Detect tmux for persistent sessions
-    let use_tmux = crate::config::detect_tmux();
-    if use_tmux {
-        tracing::info!("tmux detected, persistent sessions enabled");
-    } else {
-        tracing::info!("tmux not found, using standard PTY sessions");
+    // Detect persistence backend for sessions
+    let backend = crate::config::detect_persistence_backend();
+    match backend {
+        crate::config::PersistenceBackend::Daemon => {
+            tracing::info!("using PTY daemon backend for persistent sessions");
+        }
+        crate::config::PersistenceBackend::Tmux => {
+            tracing::info!("using tmux backend for persistent sessions");
+        }
+        crate::config::PersistenceBackend::None => {
+            tracing::info!("no persistence backend, using standard PTY sessions");
+        }
     }
 
     // Create application state
@@ -100,15 +106,16 @@ pub async fn run_local(
         hostname.clone(),
         host_id,
         shutdown.clone(),
-        use_tmux,
+        backend,
     );
 
     // === Session recovery ===
-    // Discover surviving tmux sessions from a previous agent lifecycle
+    // Discover surviving sessions from a previous agent lifecycle
     // and reconcile DB state before starting the PTY output loop.
     let recovery_now = chrono::Utc::now().to_rfc3339();
 
-    if use_tmux {
+    let supports_persistence = backend != crate::config::PersistenceBackend::None;
+    if supports_persistence {
         // Mark stale active/creating sessions as suspended first
         // (they were active when the previous agent died)
         sqlx::query(
@@ -131,10 +138,10 @@ pub async fn run_local(
         .await?;
     }
 
-    // Discover existing tmux sessions and reattach
+    // Discover existing sessions and reattach
     let recovered = {
         let mut mgr = state.session_manager.lock().await;
-        mgr.discover_existing()
+        mgr.discover_existing().await
     };
 
     let recovered_ids: Vec<String> = recovered
@@ -186,7 +193,7 @@ pub async fn run_local(
     if !recovered.is_empty() {
         tracing::info!(
             count = recovered.len(),
-            "recovered tmux sessions from previous run"
+            "recovered sessions from previous run"
         );
     }
 
@@ -874,7 +881,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "test".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "test".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let router = build_router(state).unwrap();
 
@@ -897,7 +910,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "test".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "test".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let router = build_router(state).unwrap();
 
@@ -924,7 +943,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let router = build_router(state).unwrap();
 
@@ -953,7 +978,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let router = build_router(state).unwrap();
 

--- a/crates/zremote-agent/src/local/routes/agentic.rs
+++ b/crates/zremote-agent/src/local/routes/agentic.rs
@@ -69,7 +69,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/routes/claude_sessions.rs
+++ b/crates/zremote-agent/src/local/routes/claude_sessions.rs
@@ -129,6 +129,7 @@ pub async fn create_claude_task(
     let pid = {
         let mut mgr = state.session_manager.lock().await;
         mgr.create(session_id, shell, 120, 40, Some(&body.project_path), None)
+            .await
             .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -323,6 +324,7 @@ pub async fn resume_claude_task(
             Some(&original.project_path),
             None,
         )
+        .await
         .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -398,7 +400,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/routes/config.rs
+++ b/crates/zremote-agent/src/local/routes/config.rs
@@ -120,7 +120,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/routes/events.rs
+++ b/crates/zremote-agent/src/local/routes/events.rs
@@ -68,7 +68,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let mut rx = state.events.subscribe();
 

--- a/crates/zremote-agent/src/local/routes/health.rs
+++ b/crates/zremote-agent/src/local/routes/health.rs
@@ -37,7 +37,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v5(&Uuid::NAMESPACE_DNS, b"test-host");
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     #[tokio::test]

--- a/crates/zremote-agent/src/local/routes/hosts.rs
+++ b/crates/zremote-agent/src/local/routes/hosts.rs
@@ -52,7 +52,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     #[tokio::test]

--- a/crates/zremote-agent/src/local/routes/knowledge.rs
+++ b/crates/zremote-agent/src/local/routes/knowledge.rs
@@ -349,7 +349,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/routes/projects.rs
+++ b/crates/zremote-agent/src/local/routes/projects.rs
@@ -854,6 +854,7 @@ async fn spawn_command_session(
     let pid = {
         let mut mgr = state.session_manager.lock().await;
         mgr.create(session_id, shell, 80, 24, Some(working_dir), None)
+            .await
             .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -1074,6 +1075,7 @@ pub async fn run_action(
     let pid = {
         let mut mgr = state.session_manager.lock().await;
         mgr.create(session_id, shell, cols, rows, Some(&working_dir), env_ref)
+            .await
             .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -1237,6 +1239,7 @@ pub async fn configure_with_claude(
     let pid = {
         let mut mgr = state.session_manager.lock().await;
         mgr.create(session_id, shell, 120, 40, Some(&project_path), None)
+            .await
             .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -1427,7 +1430,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/routes/sessions.rs
+++ b/crates/zremote-agent/src/local/routes/sessions.rs
@@ -126,7 +126,7 @@ pub async fn create_session(
         sessions.insert(session_id, SessionState::new(session_id, parsed_host_id));
     }
 
-    // Spawn PTY/tmux session directly
+    // Spawn PTY/tmux/daemon session directly
     let pid = {
         let mut mgr = state.session_manager.lock().await;
         mgr.create(
@@ -137,6 +137,7 @@ pub async fn create_session(
             effective_working_dir,
             env_vars,
         )
+        .await
         .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
     };
 
@@ -432,7 +433,13 @@ mod tests {
         upsert_local_host(&pool, &host_id, "test-host")
             .await
             .unwrap();
-        LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false)
+        LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        )
     }
 
     fn build_test_router(state: Arc<LocalAppState>) -> Router {

--- a/crates/zremote-agent/src/local/state.rs
+++ b/crates/zremote-agent/src/local/state.rs
@@ -40,14 +40,14 @@ impl LocalAppState {
         hostname: String,
         host_id: Uuid,
         shutdown: CancellationToken,
-        use_tmux: bool,
+        backend: crate::config::PersistenceBackend,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(1024);
         let sessions = SessionStore::default();
         let agentic_loops = AgenticLoopStore::default();
 
         let (pty_output_tx, pty_output_rx) = mpsc::channel(256);
-        let session_manager = SessionManager::new(pty_output_tx, use_tmux);
+        let session_manager = SessionManager::new(pty_output_tx, backend);
 
         let agentic_manager = AgenticLoopManager::new();
         let session_mapper = SessionMapper::new();
@@ -87,7 +87,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v5(&Uuid::NAMESPACE_DNS, b"test-host");
-        let state = LocalAppState::new(pool, "test-host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "test-host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         assert_eq!(state.hostname, "test-host");
         assert_eq!(state.host_id, host_id);
@@ -98,7 +104,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         // Session store should be empty
         let sessions = state.sessions.read().await;
@@ -113,7 +125,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         let mut rx = state.events.subscribe();
         let event = ServerEvent::HostStatusChanged {
@@ -131,7 +149,13 @@ mod tests {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
         let shutdown = CancellationToken::new();
         let host_id = Uuid::new_v4();
-        let state = LocalAppState::new(pool, "host".to_string(), host_id, shutdown, false);
+        let state = LocalAppState::new(
+            pool,
+            "host".to_string(),
+            host_id,
+            shutdown,
+            crate::config::PersistenceBackend::None,
+        );
 
         // Agentic manager should be accessible
         let _mgr = state.agentic_manager.lock().await;

--- a/crates/zremote-agent/src/main.rs
+++ b/crates/zremote-agent/src/main.rs
@@ -24,6 +24,7 @@ mod agentic;
 mod claude;
 mod config;
 mod connection;
+mod daemon;
 mod hooks;
 mod knowledge;
 mod linear;
@@ -93,17 +94,111 @@ enum Commands {
         #[arg(long)]
         skip_permissions: bool,
     },
+    /// Internal: run as a PTY daemon process (not for direct use)
+    #[command(hide = true)]
+    PtyDaemon {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        socket: PathBuf,
+        #[arg(long)]
+        state_file: PathBuf,
+        #[arg(long)]
+        shell: String,
+        #[arg(long)]
+        cols: u16,
+        #[arg(long)]
+        rows: u16,
+        #[arg(long)]
+        working_dir: Option<PathBuf>,
+        /// Extra environment variables as KEY=VALUE pairs
+        #[arg(long = "env")]
+        env_vars: Vec<String>,
+    },
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Parse CLI first (before tokio) so PtyDaemon can call setsid() before runtime
+    let cli = Cli::try_parse().unwrap_or_default();
+
+    // PtyDaemon: setsid() FIRST, then single-thread tokio runtime
+    if let Some(Commands::PtyDaemon {
+        session_id,
+        socket,
+        state_file,
+        shell,
+        cols,
+        rows,
+        working_dir,
+        env_vars,
+    }) = cli.command
+    {
+        // Validate session_id as UUID to prevent path traversal (e.g. "../")
+        if uuid::Uuid::parse_str(&session_id).is_err() {
+            eprintln!("invalid session_id: must be a valid UUID");
+            std::process::exit(1);
+        }
+
+        // setsid() must be called before tokio runtime starts
+        if let Err(e) = nix::unistd::setsid() {
+            eprintln!("setsid failed: {e}");
+            std::process::exit(1);
+        }
+
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+            .json()
+            .init();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build tokio runtime");
+
+        // Parse --env KEY=VALUE pairs into a HashMap
+        let extra_env: std::collections::HashMap<String, String> = env_vars
+            .into_iter()
+            .filter_map(|kv| {
+                let (k, v) = kv.split_once('=')?;
+                // Validate env key: must be non-empty, start with letter/underscore,
+                // contain only alphanumeric/underscore
+                if k.is_empty()
+                    || !k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    || k.starts_with(|c: char| c.is_ascii_digit())
+                {
+                    tracing::warn!(key = k, "ignoring invalid environment variable key");
+                    return None;
+                }
+                Some((k.to_string(), v.to_string()))
+            })
+            .collect();
+
+        rt.block_on(daemon::run_pty_daemon(
+            session_id,
+            socket,
+            state_file,
+            shell,
+            cols,
+            rows,
+            working_dir,
+            extra_env,
+        ));
+        return;
+    }
+
+    // All other commands use the multi-thread runtime
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(async_main(cli));
+}
+
+async fn async_main(cli: Cli) {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .json()
         .init();
-
-    // Parse CLI args; default to Run if no subcommand given
-    let cli = Cli::try_parse().unwrap_or_default();
 
     match cli.command.unwrap_or_default() {
         Commands::Run => run_agent().await,
@@ -124,6 +219,7 @@ async fn main() {
         } => {
             run_configure(&project, &model, skip_permissions);
         }
+        Commands::PtyDaemon { .. } => unreachable!("handled above"),
     }
 }
 
@@ -183,11 +279,17 @@ async fn run_agent() {
         }
     };
 
-    let use_tmux = config::detect_tmux();
-    if use_tmux {
-        tracing::info!("tmux detected, persistent sessions enabled");
-    } else {
-        tracing::info!("tmux not found, using standard PTY sessions");
+    let backend = config::detect_persistence_backend();
+    match backend {
+        config::PersistenceBackend::Daemon => {
+            tracing::info!("using PTY daemon backend for persistent sessions");
+        }
+        config::PersistenceBackend::Tmux => {
+            tracing::info!("using tmux backend for persistent sessions");
+        }
+        config::PersistenceBackend::None => {
+            tracing::info!("no persistence backend, using standard PTY sessions");
+        }
     }
 
     // Shutdown signal channel: sender sets to `true` on SIGINT/SIGTERM
@@ -214,7 +316,7 @@ async fn run_agent() {
 
         attempt_num += 1;
 
-        match connection::run_connection(&config, shutdown_rx.clone(), use_tmux).await {
+        match connection::run_connection(&config, shutdown_rx.clone(), backend).await {
             Ok(()) => {
                 // Clean disconnect (e.g. server closed, or we received shutdown)
                 tracing::info!("connection closed cleanly");

--- a/crates/zremote-agent/src/session.rs
+++ b/crates/zremote-agent/src/session.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 use zremote_protocol::SessionId;
 
+use crate::config::PersistenceBackend;
+use crate::daemon::session::DaemonSession;
 use crate::pty::PtySession;
 use crate::tmux::TmuxSession;
 
@@ -21,6 +23,7 @@ pub struct PtyOutput {
 pub enum SessionBackend {
     Pty(PtySession),
     Tmux(TmuxSession),
+    Daemon(DaemonSession),
 }
 
 /// Connection info returned to the GUI for direct tmux attachment.
@@ -32,22 +35,25 @@ pub struct DirectAttachInfo {
 pub struct SessionManager {
     sessions: HashMap<SessionId, SessionBackend>,
     output_tx: mpsc::Sender<PtyOutput>,
-    use_tmux: bool,
+    backend: PersistenceBackend,
     direct_attached: HashSet<SessionId>,
 }
 
 impl SessionManager {
-    pub fn new(output_tx: mpsc::Sender<PtyOutput>, use_tmux: bool) -> Self {
+    pub fn new(output_tx: mpsc::Sender<PtyOutput>, backend: PersistenceBackend) -> Self {
         Self {
             sessions: HashMap::new(),
             output_tx,
-            use_tmux,
+            backend,
             direct_attached: HashSet::new(),
         }
     }
 
-    /// Spawn a new session (PTY or tmux). Returns the child PID.
-    pub fn create(
+    /// Spawn a new session (PTY, tmux, or daemon). Returns the child PID.
+    ///
+    /// Daemon sessions are async (need to spawn a process and wait for socket),
+    /// so this method is now async.
+    pub async fn create(
         &mut self,
         session_id: SessionId,
         shell: &str,
@@ -56,32 +62,50 @@ impl SessionManager {
         working_dir: Option<&str>,
         env: Option<&std::collections::HashMap<String, String>>,
     ) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
-        if self.use_tmux {
-            let (session, pid) = TmuxSession::spawn(
-                session_id,
-                shell,
-                cols,
-                rows,
-                working_dir,
-                env,
-                self.output_tx.clone(),
-            )?;
-            self.sessions
-                .insert(session_id, SessionBackend::Tmux(session));
-            Ok(pid)
-        } else {
-            let (session, pid) = PtySession::spawn(
-                session_id,
-                shell,
-                cols,
-                rows,
-                working_dir,
-                env,
-                self.output_tx.clone(),
-            )?;
-            self.sessions
-                .insert(session_id, SessionBackend::Pty(session));
-            Ok(pid)
+        match self.backend {
+            PersistenceBackend::Tmux => {
+                let (session, pid) = TmuxSession::spawn(
+                    session_id,
+                    shell,
+                    cols,
+                    rows,
+                    working_dir,
+                    env,
+                    self.output_tx.clone(),
+                )?;
+                self.sessions
+                    .insert(session_id, SessionBackend::Tmux(session));
+                Ok(pid)
+            }
+            PersistenceBackend::Daemon => {
+                let (session, pid) = DaemonSession::spawn(
+                    session_id,
+                    shell,
+                    cols,
+                    rows,
+                    working_dir,
+                    env,
+                    self.output_tx.clone(),
+                )
+                .await?;
+                self.sessions
+                    .insert(session_id, SessionBackend::Daemon(session));
+                Ok(pid)
+            }
+            PersistenceBackend::None => {
+                let (session, pid) = PtySession::spawn(
+                    session_id,
+                    shell,
+                    cols,
+                    rows,
+                    working_dir,
+                    env,
+                    self.output_tx.clone(),
+                )?;
+                self.sessions
+                    .insert(session_id, SessionBackend::Pty(session));
+                Ok(pid)
+            }
         }
     }
 
@@ -98,6 +122,7 @@ impl SessionManager {
         match backend {
             SessionBackend::Pty(session) => session.write(data)?,
             SessionBackend::Tmux(session) => session.write(data)?,
+            SessionBackend::Daemon(session) => session.write(data)?,
         }
         Ok(())
     }
@@ -116,20 +141,26 @@ impl SessionManager {
         match backend {
             SessionBackend::Pty(session) => session.resize(cols, rows),
             SessionBackend::Tmux(session) => session.resize(cols, rows),
+            SessionBackend::Daemon(session) => session.resize(cols, rows),
         }
     }
 
     /// Close a session, killing the child process. Returns the exit code if available.
     pub fn close(&mut self, session_id: &SessionId) -> Option<i32> {
-        let mut backend = self.sessions.remove(session_id)?;
-        match &mut backend {
-            SessionBackend::Pty(session) => {
+        let backend = self.sessions.remove(session_id)?;
+        match backend {
+            SessionBackend::Pty(mut session) => {
                 session.kill();
                 session.try_wait()
             }
-            SessionBackend::Tmux(session) => {
+            SessionBackend::Tmux(mut session) => {
                 session.kill();
                 session.try_wait()
+            }
+            SessionBackend::Daemon(session) => {
+                let exit = session.try_wait();
+                session.kill();
+                exit
             }
         }
     }
@@ -142,8 +173,8 @@ impl SessionManager {
         }
     }
 
-    /// Detach tmux sessions (they survive) and kill PTY sessions.
-    /// Used during graceful agent shutdown when tmux is enabled.
+    /// Detach persistent sessions (they survive) and kill plain PTY sessions.
+    /// Used during graceful agent shutdown.
     pub fn detach_all(&mut self) {
         let ids: Vec<SessionId> = self.sessions.keys().copied().collect();
         for id in ids {
@@ -151,39 +182,64 @@ impl SessionManager {
                 match backend {
                     SessionBackend::Tmux(mut session) => session.detach(),
                     SessionBackend::Pty(mut session) => session.kill(),
+                    SessionBackend::Daemon(session) => session.detach(),
                 }
             }
         }
     }
 
-    /// Discover existing tmux sessions from a previous agent lifecycle.
+    /// Discover existing sessions from a previous agent lifecycle.
+    ///
+    /// For Tmux backend: discovers tmux sessions.
+    /// For Daemon backend: discovers running daemon processes via state files.
+    /// For None (plain PTY): no persistence, returns empty.
+    ///
     /// Returns a list of `(session_id, shell_name, pid, captured_content)` for
-    /// recovered sessions. The captured content is the visible pane state at
+    /// recovered sessions. The captured content is scrollback data at
     /// reattach time; the caller should put it into the scrollback synchronously.
-    pub fn discover_existing(&mut self) -> Vec<(SessionId, String, u32, Option<Vec<u8>>)> {
-        if !self.use_tmux {
-            return Vec::new();
+    pub async fn discover_existing(&mut self) -> Vec<(SessionId, String, u32, Option<Vec<u8>>)> {
+        match self.backend {
+            PersistenceBackend::None => Vec::new(),
+            PersistenceBackend::Tmux => {
+                // Clean up stale sessions first
+                crate::tmux::cleanup_stale();
+
+                let recovered = crate::tmux::discover_sessions(self.output_tx.clone());
+                let mut result = Vec::new();
+
+                for (session, captured) in recovered {
+                    let session_id = session.session_id();
+                    let pid = session.pid();
+                    // Get shell name from sysinfo or default to "shell"
+                    let shell = get_process_name(pid);
+                    result.push((session_id, shell, pid, captured));
+                    self.sessions
+                        .insert(session_id, SessionBackend::Tmux(session));
+                }
+
+                result
+            }
+            PersistenceBackend::Daemon => {
+                // Clean up stale daemon files first
+                crate::daemon::discovery::cleanup_stale_daemons();
+
+                let recovered =
+                    crate::daemon::discovery::discover_daemon_sessions(self.output_tx.clone())
+                        .await;
+                let mut result = Vec::new();
+
+                for (session, scrollback) in recovered {
+                    let session_id = session.session_id();
+                    let pid = session.pid();
+                    let shell = get_process_name(pid);
+                    result.push((session_id, shell, pid, scrollback));
+                    self.sessions
+                        .insert(session_id, SessionBackend::Daemon(session));
+                }
+
+                result
+            }
         }
-
-        // Clean up stale sessions first
-        crate::tmux::cleanup_stale();
-
-        let recovered = crate::tmux::discover_sessions(self.output_tx.clone());
-        let mut result = Vec::new();
-
-        for (session, captured) in recovered {
-            let session_id = session.session_id();
-            let pid = session.pid();
-            // Get shell from /proc/{pid}/comm or default to "shell"
-            let shell = std::fs::read_to_string(format!("/proc/{pid}/comm"))
-                .map(|s| s.trim().to_string())
-                .unwrap_or_else(|_| "shell".to_string());
-            result.push((session_id, shell, pid, captured));
-            self.sessions
-                .insert(session_id, SessionBackend::Tmux(session));
-        }
-
-        result
     }
 
     /// Return an iterator of `(session_id, shell_pid)` for all active sessions.
@@ -192,6 +248,7 @@ impl SessionManager {
             let pid = match backend {
                 SessionBackend::Pty(s) => s.pid(),
                 SessionBackend::Tmux(s) => s.pid(),
+                SessionBackend::Daemon(s) => s.pid(),
             };
             (*id, pid)
         })
@@ -213,7 +270,9 @@ impl SessionManager {
                 session.write_to_pane(pane_id, data)?;
                 Ok(())
             }
-            SessionBackend::Pty(_) => Err("PTY sessions do not support pane targeting".into()),
+            SessionBackend::Pty(_) | SessionBackend::Daemon(_) => {
+                Err("pane targeting not supported for this session type".into())
+            }
         }
     }
 
@@ -231,7 +290,9 @@ impl SessionManager {
             .ok_or_else(|| format!("session {session_id} not found"))?;
         match backend {
             SessionBackend::Tmux(session) => session.resize_pane(pane_id, cols, rows),
-            SessionBackend::Pty(_) => Err("PTY sessions do not support pane targeting".into()),
+            SessionBackend::Pty(_) | SessionBackend::Daemon(_) => {
+                Err("pane targeting not supported for this session type".into())
+            }
         }
     }
 
@@ -251,7 +312,17 @@ impl SessionManager {
 
     /// Whether tmux-backed sessions are enabled.
     pub fn use_tmux(&self) -> bool {
-        self.use_tmux
+        self.backend == PersistenceBackend::Tmux
+    }
+
+    /// Whether any persistent backend (tmux or daemon) is active.
+    pub fn supports_persistence(&self) -> bool {
+        self.backend != PersistenceBackend::None
+    }
+
+    /// Return the active persistence backend.
+    pub fn backend(&self) -> PersistenceBackend {
+        self.backend
     }
 
     /// Detach agent's FIFO reader, allowing GUI to connect directly to tmux.
@@ -267,7 +338,7 @@ impl SessionManager {
 
         let tmux_session = match backend {
             SessionBackend::Tmux(session) => session,
-            SessionBackend::Pty(_) => {
+            SessionBackend::Pty(_) | SessionBackend::Daemon(_) => {
                 return Err("direct attach only supported for tmux sessions".into());
             }
         };
@@ -307,7 +378,7 @@ impl SessionManager {
 
         let tmux_session = match backend {
             SessionBackend::Tmux(session) => session,
-            SessionBackend::Pty(_) => {
+            SessionBackend::Pty(_) | SessionBackend::Daemon(_) => {
                 return Err("direct detach only supported for tmux sessions".into());
             }
         };
@@ -348,6 +419,20 @@ impl SessionManager {
     }
 }
 
+/// Get the process name for a given PID using sysinfo.
+/// Falls back to "shell" if the process cannot be found.
+fn get_process_name(pid: u32) -> String {
+    use sysinfo::{Pid, System};
+    let mut sys = System::new();
+    sys.refresh_processes(
+        sysinfo::ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+        true,
+    );
+    sys.process(Pid::from_u32(pid))
+        .map(|p| p.name().to_string_lossy().to_string())
+        .unwrap_or_else(|| "shell".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,7 +440,7 @@ mod tests {
 
     fn make_manager() -> SessionManager {
         let (tx, _rx) = mpsc::channel(64);
-        SessionManager::new(tx, false)
+        SessionManager::new(tx, PersistenceBackend::None)
     }
 
     #[test]
@@ -408,17 +493,21 @@ mod tests {
     #[test]
     fn use_tmux_returns_configured_value() {
         let (tx, _rx) = mpsc::channel(64);
-        let mgr_false = SessionManager::new(tx.clone(), false);
-        assert!(!mgr_false.use_tmux());
+        let mgr_none = SessionManager::new(tx.clone(), PersistenceBackend::None);
+        assert!(!mgr_none.use_tmux());
 
-        let mgr_true = SessionManager::new(tx, true);
-        assert!(mgr_true.use_tmux());
+        let mgr_tmux = SessionManager::new(tx.clone(), PersistenceBackend::Tmux);
+        assert!(mgr_tmux.use_tmux());
+
+        let mgr_daemon = SessionManager::new(tx, PersistenceBackend::Daemon);
+        assert!(!mgr_daemon.use_tmux());
+        assert!(mgr_daemon.supports_persistence());
     }
 
-    #[test]
-    fn discover_existing_returns_empty_when_tmux_disabled() {
+    #[tokio::test]
+    async fn discover_existing_returns_empty_when_no_persistence() {
         let mut mgr = make_manager();
-        let result = mgr.discover_existing();
+        let result = mgr.discover_existing().await;
         assert!(result.is_empty());
     }
 
@@ -474,21 +563,31 @@ mod tests {
         assert_eq!(mgr.count(), 0);
     }
 
-    #[test]
-    fn discover_existing_with_tmux_false_always_empty() {
+    #[tokio::test]
+    async fn discover_existing_with_no_persistence_always_empty() {
         let mut mgr = make_manager();
         assert!(!mgr.use_tmux());
-        let result1 = mgr.discover_existing();
+        let result1 = mgr.discover_existing().await;
         assert!(result1.is_empty());
-        let result2 = mgr.discover_existing();
+        let result2 = mgr.discover_existing().await;
         assert!(result2.is_empty());
     }
 
     #[test]
-    fn new_manager_with_tmux_true() {
+    fn new_manager_with_tmux_backend() {
         let (tx, _rx) = mpsc::channel(64);
-        let mgr = SessionManager::new(tx, true);
+        let mgr = SessionManager::new(tx, PersistenceBackend::Tmux);
         assert!(mgr.use_tmux());
+        assert_eq!(mgr.count(), 0);
+    }
+
+    #[test]
+    fn new_manager_with_daemon_backend() {
+        let (tx, _rx) = mpsc::channel(64);
+        let mgr = SessionManager::new(tx, PersistenceBackend::Daemon);
+        assert!(!mgr.use_tmux());
+        assert!(mgr.supports_persistence());
+        assert_eq!(mgr.backend(), PersistenceBackend::Daemon);
         assert_eq!(mgr.count(), 0);
     }
 

--- a/docs/rfc/rfc-pty-daemon.md
+++ b/docs/rfc/rfc-pty-daemon.md
@@ -266,7 +266,7 @@ Path: `/tmp/zremote-pty-{uid}/{session_id}.json`
 
 | Operation | Solution |
 |-----------|----------|
-| PID liveness check | `nix::sys::signal::kill(Pid, None)` + verify `started_at` (PID reuse) |
+| PID liveness check | Linux: `kill(pid, 0)` + `/proc/{pid}/stat` starttime verification (precise). macOS: `kill(pid, 0)` + wall-clock `started_at` check + `GetState` verification on reconnect |
 | Shell name from PID | Stored in state file (not from `/proc`) |
 | UID | `nix::unistd::getuid()` |
 | Socket path | Always `/tmp/...` (not `$TMPDIR`), assert < 104 bytes |
@@ -274,7 +274,7 @@ Path: `/tmp/zremote-pty-{uid}/{session_id}.json`
 | `setsid()` | via `nix` - same API on both platforms |
 | `portable-pty` | Cross-platform (abstracted by crate) |
 
-**Rule**: Never use `/proc/` anywhere. Use `nix` crate for everything.
+**Rule**: Use `/proc/` only behind `#[cfg(target_os = "linux")]` with fallback for other platforms.
 
 ## Risks
 
@@ -284,7 +284,7 @@ Path: `/tmp/zremote-pty-{uid}/{session_id}.json`
 | systemd KillUserProcesses | `systemd-run --scope --user` with fallback to direct spawn |
 | Memory per daemon (~2-4MB) | OK for 1-20 sessions, monitor |
 | Daemon startup race | State file written AFTER socket bind; agent retry 100ms, max 3s |
-| PID reuse during discovery | `started_at` timestamp in state file, verify on reconnect |
+| PID reuse during discovery | Linux: `/proc/{pid}/stat` starttime verification (precise, pre-connect). All platforms: `started_at` timestamp in state file, verified on reconnect via `GetState` |
 | Socket write backpressure | Write with timeout, never block PTY read loop |
 | macOS socket path length | Assert < 104 bytes, always `/tmp/` not `$TMPDIR` |
 


### PR DESCRIPTION
## Summary

- Replace single-point-of-failure tmux server with per-session PTY daemon processes
- Each daemon holds one PTY master fd, communicates via Unix domain socket, survives agent crashes independently
- Crash isolation: one daemon crash kills only one session, not all sessions
- No external dependency (tmux binary no longer required)
- Cross-platform: Linux (with /proc-based PID reuse detection) + macOS (wall-clock fallback)

## Changes

**New daemon module** (`crates/zremote-agent/src/daemon/`):
- `mod.rs` - Daemon process: setsid(), SIGHUP ignore, PTY management, 100KB ring buffer, backpressure
- `protocol.rs` - Length-prefixed JSON IPC with 1MB frame limit
- `session.rs` - Agent-side client with systemd-run (Linux) / direct spawn (macOS), async I/O relay
- `discovery.rs` - Session recovery on restart, PID reuse protection

**Integration**:
- `SessionManager` now uses `PersistenceBackend` enum (Daemon/Tmux/None)
- `create()` and `discover_existing()` are now async
- All route handlers updated

**Security**:
- Socket dir 0700, socket file 0600, state file 0600 (atomic write)
- session_id UUID validation, env key validation, socket path length check

## Test plan

- [x] 642 unit tests pass (cargo test -p zremote-agent)
- [x] cargo clippy clean
- [x] Pre-commit hooks pass (fmt + clippy + test)
- [ ] Manual: start local mode, create session, kill -9 agent, restart, session recovers
- [ ] Manual: start 2 sessions, kill -9 one daemon, other session unaffected
- [ ] Manual: SSH → start session → logout → SSH again → session survived (systemd)