### PR TITLE
Display Claude Code session metrics in GUI

### DIFF
--- a/crates/zremote-agent/src/ccline/input.rs
+++ b/crates/zremote-agent/src/ccline/input.rs
@@ -19,7 +19,6 @@ pub struct StatusInput {
     pub output_style: Option<OutputStyle>,
     pub cost: Option<CostInfo>,
     pub context_window: Option<ContextWindow>,
-    pub exceeds_200k_tokens: Option<bool>,
     pub rate_limits: Option<RateLimits>,
 }
 

--- a/crates/zremote-agent/src/ccline/types.rs
+++ b/crates/zremote-agent/src/ccline/types.rs
@@ -14,7 +14,6 @@ pub struct CclineMessage {
     pub cost: Option<CclineCost>,
     pub context_window: Option<CclineContext>,
     pub rate_limits: Option<CclineRateLimits>,
-    pub exceeds_200k_tokens: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/zremote-agent/src/ccline/types.rs
+++ b/crates/zremote-agent/src/ccline/types.rs
@@ -14,6 +14,7 @@ pub struct CclineMessage {
     pub cost: Option<CclineCost>,
     pub context_window: Option<CclineContext>,
     pub rate_limits: Option<CclineRateLimits>,
+    pub exceeds_200k_tokens: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/zremote-gui/assets/icons/bot.svg
+++ b/crates/zremote-gui/assets/icons/bot.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>

--- a/crates/zremote-gui/src/icons.rs
+++ b/crates/zremote-gui/src/icons.rs
@@ -23,6 +23,7 @@ pub enum Icon {
     Zap,
     MessageCircle,
     CircleHelp,
+    Bot,
 }
 
 impl Icon {
@@ -49,6 +50,7 @@ impl Icon {
             Self::Zap => "icons/zap.svg",
             Self::MessageCircle => "icons/message-circle.svg",
             Self::CircleHelp => "icons/circle-help.svg",
+            Self::Bot => "icons/bot.svg",
         }
     }
 }

--- a/crates/zremote-gui/src/views/cc_widgets.rs
+++ b/crates/zremote-gui/src/views/cc_widgets.rs
@@ -23,7 +23,7 @@ pub fn render_context_bar(metrics: &CcMetrics, width: f32, height: f32) -> impl 
     let window_size = metrics.context_window_size.unwrap_or(200_000);
 
     // Calculate tokens used, then normalize to 200k baseline
-    let tokens_used = (pct / 100.0) * window_size as f64;
+    let (tokens_used, _) = context_usage_200k(pct, window_size);
     let fill_ratio_200k = (tokens_used / 200_000.0).min(1.0) as f32;
 
     let fill_color = if pct > 90.0 {
@@ -99,16 +99,38 @@ pub fn short_model_name(model: &str) -> String {
     model.chars().take(8).collect()
 }
 
-/// Extract version number from start of string (e.g. "4.6 (1M context)" -> "4.6")
+/// Extract version number (major.minor) from start of string.
+///
+/// Accepts dots or dashes as separators and normalizes to dots.
+/// Only keeps the first two numeric segments (major.minor):
+/// - `"4.6 (1M context)"` -> `"4.6"`
+/// - `"-4-6-20250514"` -> `"4.6"` (leading dashes stripped, trailing ignored)
 fn extract_version(s: &str) -> String {
     let s = s.trim_start_matches([' ', '-']);
-    s.chars()
-        .take_while(|c| c.is_ascii_digit() || *c == '.')
-        .collect::<String>()
+    let raw: String = s
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
+        .collect();
+    // Normalize dashes to dots and keep only major.minor
+    let normalized = raw.replace('-', ".");
+    let mut parts = normalized.split('.');
+    match (parts.next(), parts.next()) {
+        (Some(major), Some(minor)) => format!("{major}.{minor}"),
+        (Some(major), None) => major.to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Calculate context usage normalized to a 200k token baseline.
+/// Returns (tokens_used, percentage_of_200k).
+pub fn context_usage_200k(pct: f64, window_size: u64) -> (f64, f64) {
+    let tokens_used = (pct / 100.0) * window_size as f64;
+    let pct_200k = tokens_used / 200_000.0 * 100.0;
+    (tokens_used, pct_200k)
 }
 
 /// Format cost as "$X.XX".
-pub fn format_cost(cost_usd: f64) -> String {
+fn format_cost(cost_usd: f64) -> String {
     format!("${cost_usd:.2}")
 }
 
@@ -163,11 +185,15 @@ pub fn render_cc_tooltip(
     // Context
     if let Some(pct) = metrics.context_used_pct {
         let window = metrics.context_window_size.unwrap_or(200_000);
-        let tokens_used = (pct / 100.0) * window as f64;
+        let (tokens_used, _) = context_usage_200k(pct, window);
+        let window_label = if window >= 1_000_000 {
+            format!("{}M", window / 1_000_000)
+        } else {
+            format!("{}k", window / 1000)
+        };
         content = content.child(div().child(format!(
-            "Context: {:.0}k / 200k tokens ({:.1}%)",
+            "Context: {:.0}k tokens ({pct:.0}% of {window_label})",
             tokens_used / 1000.0,
-            tokens_used / 200_000.0 * 100.0
         )));
     }
 
@@ -195,4 +221,59 @@ pub fn render_cc_tooltip(
     }
 
     content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{context_usage_200k, extract_version, format_cost, short_model_name};
+
+    #[test]
+    fn short_model_name_display_names() {
+        assert_eq!(short_model_name("Opus 4.6 (1M context)"), "Opus4.6");
+        assert_eq!(short_model_name("Sonnet 4.6"), "Son4.6");
+        assert_eq!(short_model_name("Haiku 4.5"), "Hai4.5");
+    }
+
+    #[test]
+    fn short_model_name_raw_ids() {
+        assert_eq!(short_model_name("claude-opus-4-6"), "Opus4.6");
+        assert_eq!(short_model_name("claude-sonnet-4-6"), "Son4.6");
+        assert_eq!(short_model_name("claude-haiku-4-5"), "Hai4.5");
+    }
+
+    #[test]
+    fn short_model_name_fallback() {
+        assert_eq!(short_model_name("gpt-4o"), "gpt-4o");
+        assert_eq!(short_model_name("some-long-model-name"), "some-lon");
+    }
+
+    #[test]
+    fn extract_version_patterns() {
+        assert_eq!(extract_version("4.6 (1M context)"), "4.6");
+        assert_eq!(extract_version("4-6"), "4.6");
+        assert_eq!(extract_version("-4-6-20250514"), "4.6");
+        assert_eq!(extract_version(""), "");
+    }
+
+    #[test]
+    fn context_usage_200k_basic() {
+        let (tokens, pct) = context_usage_200k(50.0, 200_000);
+        assert!((tokens - 100_000.0).abs() < 1.0);
+        assert!((pct - 50.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn context_usage_200k_large_window() {
+        // 10% of 1M = 100k tokens = 50% of 200k
+        let (tokens, pct) = context_usage_200k(10.0, 1_000_000);
+        assert!((tokens - 100_000.0).abs() < 1.0);
+        assert!((pct - 50.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn format_cost_basic() {
+        assert_eq!(format_cost(1.5), "$1.50");
+        assert_eq!(format_cost(0.0), "$0.00");
+        assert_eq!(format_cost(99.999), "$100.00");
+    }
 }

--- a/crates/zremote-gui/src/views/cc_widgets.rs
+++ b/crates/zremote-gui/src/views/cc_widgets.rs
@@ -1,0 +1,198 @@
+//! Shared UI widgets for Claude Code session metrics display.
+
+use std::fmt::Write as _;
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+
+use crate::icons::{Icon, icon};
+use crate::theme;
+use crate::views::sidebar::CcMetrics;
+use zremote_client::AgenticStatus;
+
+/// Render a context usage progress bar.
+///
+/// The bar shows usage relative to a 200k token baseline:
+/// - 200,000 tokens = 100% fill
+/// - Larger context windows can exceed 100% fill visually (capped at bar width)
+/// - Color: green (<70%), yellow (70-90%), red (>90%)
+/// - Overflow indicator when context_window_size > 200k and usage is high
+#[allow(clippy::cast_possible_truncation)]
+pub fn render_context_bar(metrics: &CcMetrics, width: f32, height: f32) -> impl IntoElement {
+    let pct = metrics.context_used_pct.unwrap_or(0.0);
+    let window_size = metrics.context_window_size.unwrap_or(200_000);
+
+    // Calculate tokens used, then normalize to 200k baseline
+    let tokens_used = (pct / 100.0) * window_size as f64;
+    let fill_ratio_200k = (tokens_used / 200_000.0).min(1.0) as f32;
+
+    let fill_color = if pct > 90.0 {
+        theme::error()
+    } else if pct > 70.0 {
+        theme::warning()
+    } else {
+        theme::success()
+    };
+
+    let exceeds_200k = window_size > 200_000 && tokens_used > 160_000.0;
+
+    div().flex().items_center().gap(px(4.0)).child(
+        div()
+            .w(px(width))
+            .h(px(height))
+            .rounded(px(height / 2.0))
+            .bg(theme::bg_primary())
+            .overflow_hidden()
+            .child(
+                div()
+                    .h_full()
+                    .w(relative(fill_ratio_200k))
+                    .rounded(px(height / 2.0))
+                    .bg(fill_color),
+            )
+            .when(exceeds_200k, |d: Div| {
+                d.border_1().border_color(theme::warning())
+            }),
+    )
+}
+
+/// Shorten a model display name for compact UI display.
+///
+/// Examples:
+/// - "Opus 4.6 (1M context)" -> "Opus4.6"
+/// - "Sonnet 4.6" -> "Son4.6"
+/// - "Haiku 4.5" -> "Hai4.5"
+/// - "claude-opus-4-6" -> "Opus4.6"
+pub fn short_model_name(model: &str) -> String {
+    // Try to extract family + version from display name patterns
+    let lower = model.to_lowercase();
+
+    if let Some(rest) = lower.strip_prefix("opus ").or_else(|| {
+        lower
+            .find("opus")
+            .map(|i| &lower[i + 4..])
+            .map(|s| s.trim_start_matches([' ', '-']))
+    }) {
+        let version = extract_version(rest);
+        return format!("Opus{version}");
+    }
+    if let Some(rest) = lower.strip_prefix("sonnet ").or_else(|| {
+        lower
+            .find("sonnet")
+            .map(|i| &lower[i + 6..])
+            .map(|s| s.trim_start_matches([' ', '-']))
+    }) {
+        let version = extract_version(rest);
+        return format!("Son{version}");
+    }
+    if let Some(rest) = lower.strip_prefix("haiku ").or_else(|| {
+        lower
+            .find("haiku")
+            .map(|i| &lower[i + 5..])
+            .map(|s| s.trim_start_matches([' ', '-']))
+    }) {
+        let version = extract_version(rest);
+        return format!("Hai{version}");
+    }
+
+    // Fallback: first 8 chars
+    model.chars().take(8).collect()
+}
+
+/// Extract version number from start of string (e.g. "4.6 (1M context)" -> "4.6")
+fn extract_version(s: &str) -> String {
+    let s = s.trim_start_matches([' ', '-']);
+    s.chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect::<String>()
+}
+
+/// Format cost as "$X.XX".
+pub fn format_cost(cost_usd: f64) -> String {
+    format!("${cost_usd:.2}")
+}
+
+/// Bot icon colored by agentic status.
+pub fn cc_bot_icon(status: AgenticStatus, size: f32) -> gpui::Svg {
+    let color = match status {
+        AgenticStatus::Working => theme::accent(),
+        AgenticStatus::WaitingForInput => theme::warning(),
+        AgenticStatus::Error => theme::error(),
+        AgenticStatus::Completed => theme::success(),
+        _ => theme::text_tertiary(),
+    };
+    icon(Icon::Bot).size(px(size)).text_color(color)
+}
+
+/// Render detailed tooltip content for CC session metrics.
+pub fn render_cc_tooltip(
+    metrics: &CcMetrics,
+    status: Option<AgenticStatus>,
+    task_name: Option<&str>,
+) -> impl IntoElement {
+    let mut content = div()
+        .flex()
+        .flex_col()
+        .gap(px(4.0))
+        .p(px(8.0))
+        .max_w(px(280.0))
+        .text_size(px(12.0))
+        .text_color(theme::text_primary());
+
+    // Status + task
+    if let Some(status) = status {
+        let status_text = match status {
+            AgenticStatus::Working => "Working",
+            AgenticStatus::WaitingForInput => "Waiting for input",
+            AgenticStatus::Error => "Error",
+            AgenticStatus::Completed => "Completed",
+            _ => "Unknown",
+        };
+        let mut line = format!("Status: {status_text}");
+        if let Some(task) = task_name {
+            let _ = write!(line, " - {task}");
+        }
+        content = content.child(div().child(line));
+    }
+
+    // Model
+    if let Some(ref model) = metrics.model {
+        content = content.child(div().child(format!("Model: {model}")));
+    }
+
+    // Context
+    if let Some(pct) = metrics.context_used_pct {
+        let window = metrics.context_window_size.unwrap_or(200_000);
+        let tokens_used = (pct / 100.0) * window as f64;
+        content = content.child(div().child(format!(
+            "Context: {:.0}k / 200k tokens ({:.1}%)",
+            tokens_used / 1000.0,
+            tokens_used / 200_000.0 * 100.0
+        )));
+    }
+
+    // Cost
+    if let Some(cost) = metrics.cost_usd {
+        content = content.child(div().child(format!("Cost: {}", format_cost(cost))));
+    }
+
+    // Lines
+    if metrics.lines_added.is_some() || metrics.lines_removed.is_some() {
+        let added = metrics.lines_added.unwrap_or(0);
+        let removed = metrics.lines_removed.unwrap_or(0);
+        content = content.child(div().child(format!("Lines: +{added} / -{removed}")));
+    }
+
+    // Rate limits
+    if metrics.rate_limit_5h_pct.is_some() || metrics.rate_limit_7d_pct.is_some() {
+        let r5 = metrics
+            .rate_limit_5h_pct
+            .map_or("-".to_string(), |v| format!("{v}%"));
+        let r7 = metrics
+            .rate_limit_7d_pct
+            .map_or("-".to_string(), |v| format!("{v}%"));
+        content = content.child(div().child(format!("Rate limits: 5h: {r5} | 7d: {r7}")));
+    }
+
+    content
+}

--- a/crates/zremote-gui/src/views/command_palette.rs
+++ b/crates/zremote-gui/src/views/command_palette.rs
@@ -21,7 +21,8 @@ use gpui::*;
 use crate::icons::{Icon, icon};
 use crate::persistence::RecentSession;
 use crate::theme;
-use crate::views::sidebar::CcState;
+use crate::views::cc_widgets;
+use crate::views::sidebar::{CcMetrics, CcState};
 use zremote_client::{AgenticStatus, Host, Project, Session};
 
 use super::fuzzy::{FuzzyMatch, fuzzy_match_item};
@@ -223,9 +224,11 @@ pub struct PaletteSnapshot {
     project_names: HashMap<String, String>,
     recent_set: HashSet<String>,
     cc_states: HashMap<String, CcState>,
+    cc_metrics: HashMap<String, CcMetrics>,
 }
 
 impl PaletteSnapshot {
+    #[allow(clippy::too_many_arguments)]
     pub fn capture(
         hosts: Rc<Vec<Host>>,
         sessions: Rc<Vec<Session>>,
@@ -234,6 +237,7 @@ impl PaletteSnapshot {
         active_session_id: Option<String>,
         recent_sessions: &[RecentSession],
         cc_states: HashMap<String, CcState>,
+        cc_metrics: HashMap<String, CcMetrics>,
     ) -> Self {
         let host_names: HashMap<String, String> = hosts
             .iter()
@@ -257,6 +261,7 @@ impl PaletteSnapshot {
             project_names,
             recent_set,
             cc_states,
+            cc_metrics,
         }
     }
 
@@ -1522,17 +1527,7 @@ impl CommandPalette {
 
         // Agentic state indicator
         if let Some(cc) = cc_state {
-            let (cc_icon, cc_color) = if cc.status == AgenticStatus::WaitingForInput {
-                (Icon::MessageCircle, theme::warning())
-            } else {
-                (Icon::Loader, theme::accent())
-            };
-            row = row.child(
-                icon(cc_icon)
-                    .size(px(12.0))
-                    .flex_shrink_0()
-                    .text_color(cc_color),
-            );
+            row = row.child(cc_widgets::cc_bot_icon(cc.status, 12.0).flex_shrink_0());
             if let Some(ref task) = cc.task_name {
                 row = row.child(
                     div()
@@ -1543,6 +1538,18 @@ impl CommandPalette {
                         .whitespace_nowrap()
                         .child(task.clone()),
                 );
+            }
+            // Context bar + model from metrics
+            if let Some(metrics) = self.snapshot.cc_metrics.get(&session.id) {
+                row = row.child(cc_widgets::render_context_bar(metrics, 40.0, 3.0));
+                if let Some(ref model) = metrics.model {
+                    row = row.child(
+                        div()
+                            .text_size(px(10.0))
+                            .text_color(theme::text_tertiary())
+                            .child(cc_widgets::short_model_name(model)),
+                    );
+                }
             }
         }
 
@@ -3003,6 +3010,7 @@ mod tests {
             Some("sess-1".to_string()),
             &[],
             std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
         )
     }
 
@@ -3251,6 +3259,7 @@ mod tests {
             "local".to_string(),
             None,
             &[],
+            std::collections::HashMap::new(),
             std::collections::HashMap::new(),
         );
         let session_items = build_session_items(&snapshot);

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -7,6 +7,8 @@ use gpui::*;
 
 use zremote_client::{ClientEvent, ServerEvent};
 
+use crate::views::sidebar::CcMetrics;
+
 use crate::app_state::AppState;
 use crate::icons::{Icon, icon};
 use crate::theme;
@@ -204,6 +206,66 @@ impl MainView {
                 }
             }
         }
+
+        // Forward CC metrics to terminal panel
+        if let ServerEvent::ClaudeSessionMetrics {
+            session_id,
+            model,
+            context_used_pct,
+            context_window_size,
+            cost_usd,
+            tokens_in,
+            tokens_out,
+            lines_added,
+            lines_removed,
+            rate_limit_5h_pct,
+            rate_limit_7d_pct,
+        } = event
+            && let Some(terminal) = &self.terminal
+            && terminal.read(cx).session_id() == session_id.as_str()
+        {
+            terminal.update(cx, |panel, cx| {
+                panel.update_cc_metrics(CcMetrics {
+                    model: model.clone(),
+                    context_used_pct: *context_used_pct,
+                    context_window_size: *context_window_size,
+                    cost_usd: *cost_usd,
+                    tokens_in: *tokens_in,
+                    tokens_out: *tokens_out,
+                    lines_added: *lines_added,
+                    lines_removed: *lines_removed,
+                    rate_limit_5h_pct: *rate_limit_5h_pct,
+                    rate_limit_7d_pct: *rate_limit_7d_pct,
+                });
+                cx.notify();
+            });
+        }
+
+        // Forward agentic loop status to terminal panel
+        match event {
+            ServerEvent::LoopDetected { loop_info, .. }
+            | ServerEvent::LoopStatusChanged { loop_info, .. } => {
+                if let Some(terminal) = &self.terminal
+                    && terminal.read(cx).session_id() == loop_info.session_id.as_str()
+                {
+                    terminal.update(cx, |panel, cx| {
+                        panel.update_cc_status(Some(loop_info.status));
+                        cx.notify();
+                    });
+                }
+            }
+            ServerEvent::LoopEnded { loop_info, .. } => {
+                if let Some(terminal) = &self.terminal
+                    && terminal.read(cx).session_id() == loop_info.session_id.as_str()
+                {
+                    terminal.update(cx, |panel, cx| {
+                        panel.clear_cc_state();
+                        cx.notify();
+                    });
+                }
+            }
+            _ => {}
+        }
     }
 
     // -- Command palette ---------------------------------------------------------
@@ -235,6 +297,7 @@ impl MainView {
             .map(|p| p.state().recent_sessions.clone())
             .unwrap_or_default();
         let cc_states = snapshot.cc_states().clone();
+        let cc_metrics = snapshot.cc_metrics().clone();
         let palette_snapshot = PaletteSnapshot::capture(
             Rc::clone(snapshot.hosts_rc()),
             Rc::clone(snapshot.sessions_rc()),
@@ -243,6 +306,7 @@ impl MainView {
             snapshot.selected_session_id().map(String::from),
             &recent_sessions,
             cc_states,
+            cc_metrics,
         );
         let palette = cx.new(|cx| CommandPalette::new(palette_snapshot, tab, cx));
         cx.subscribe(&palette, Self::on_palette_event).detach();
@@ -354,6 +418,7 @@ impl MainView {
         let sessions = Rc::clone(snapshot.sessions_rc());
         let projects = Rc::clone(snapshot.projects_rc());
         let cc_states = snapshot.cc_states().clone();
+        let cc_metrics = snapshot.cc_metrics().clone();
         let mode = self.app_state.mode.clone();
 
         let switcher = cx.new(|cx| {
@@ -365,6 +430,7 @@ impl MainView {
                 current_session_id.as_deref(),
                 &mode,
                 &cc_states,
+                &cc_metrics,
                 cx,
             )
         });

--- a/crates/zremote-gui/src/views/mod.rs
+++ b/crates/zremote-gui/src/views/mod.rs
@@ -1,3 +1,4 @@
+pub mod cc_widgets;
 pub mod command_palette;
 pub mod double_shift;
 pub mod fuzzy;

--- a/crates/zremote-gui/src/views/session_switcher.rs
+++ b/crates/zremote-gui/src/views/session_switcher.rs
@@ -23,7 +23,8 @@ use gpui::*;
 use crate::icons::{Icon, icon};
 use crate::persistence::RecentSession;
 use crate::theme;
-use crate::views::sidebar::CcState;
+use crate::views::cc_widgets;
+use crate::views::sidebar::{CcMetrics, CcState};
 use zremote_client::{AgenticStatus, Host, Project, Session};
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,8 @@ struct SwitcherEntry {
     is_current: bool,
     /// Agentic state: (status, task_name)
     cc_state: Option<(AgenticStatus, Option<String>)>,
+    /// Claude Code session metrics (context, cost, model).
+    cc_metrics: Option<CcMetrics>,
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +87,7 @@ impl SessionSwitcher {
         current_session_id: Option<&str>,
         mode: &str,
         cc_states: &HashMap<String, CcState>,
+        cc_metrics: &HashMap<String, CcMetrics>,
         cx: &mut Context<Self>,
     ) -> Self {
         let entries = build_entries(
@@ -94,6 +98,7 @@ impl SessionSwitcher {
             current_session_id,
             mode,
             cc_states,
+            cc_metrics,
         );
         let focus_handle = cx.focus_handle();
         let scroll_handle = ScrollHandle::new();
@@ -272,18 +277,29 @@ impl Render for SessionSwitcher {
                             .when_some(
                                 entry.cc_state.as_ref(),
                                 |d: Stateful<Div>, (status, task_name)| {
-                                    let (cc_icon, cc_color) =
-                                        if *status == AgenticStatus::WaitingForInput {
-                                            (Icon::MessageCircle, theme::warning())
-                                        } else {
-                                            (Icon::Loader, theme::accent())
-                                        };
-                                    let mut indicator = div()
-                                        .flex()
-                                        .items_center()
-                                        .gap(px(4.0))
-                                        .flex_shrink_0()
-                                        .child(icon(cc_icon).size(px(12.0)).text_color(cc_color));
+                                    let mut indicator =
+                                        div().flex().items_center().gap(px(4.0)).flex_shrink_0();
+
+                                    // Context bar + model (if metrics available)
+                                    if let Some(ref metrics) = entry.cc_metrics {
+                                        indicator = indicator.child(
+                                            cc_widgets::render_context_bar(metrics, 40.0, 3.0),
+                                        );
+                                        if let Some(ref model) = metrics.model {
+                                            indicator = indicator.child(
+                                                div()
+                                                    .text_size(px(10.0))
+                                                    .text_color(theme::text_tertiary())
+                                                    .child(cc_widgets::short_model_name(model)),
+                                            );
+                                        }
+                                    }
+
+                                    // Bot icon
+                                    indicator =
+                                        indicator.child(cc_widgets::cc_bot_icon(*status, 12.0));
+
+                                    // Task name
                                     if let Some(task) = task_name {
                                         indicator = indicator.child(
                                             div()
@@ -317,6 +333,7 @@ impl Render for SessionSwitcher {
 // Entry builder
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn build_entries(
     sessions: &Rc<Vec<Session>>,
     hosts: &Rc<Vec<Host>>,
@@ -325,6 +342,7 @@ fn build_entries(
     current_session_id: Option<&str>,
     mode: &str,
     cc_states: &HashMap<String, CcState>,
+    cc_metrics: &HashMap<String, CcMetrics>,
 ) -> Vec<SwitcherEntry> {
     let host_names: HashMap<&str, &str> = hosts
         .iter()
@@ -394,6 +412,7 @@ fn build_entries(
                 subtitle,
                 is_current: current_session_id == Some(s.id.as_str()),
                 cc_state,
+                cc_metrics: cc_metrics.get(&s.id).cloned(),
             }
         })
         .collect()

--- a/crates/zremote-gui/src/views/sidebar.rs
+++ b/crates/zremote-gui/src/views/sidebar.rs
@@ -264,6 +264,7 @@ impl SidebarView {
                     && state.loop_id == loop_info.id
                 {
                     self.cc_states.remove(&loop_info.session_id);
+                    self.cc_metrics.remove(&loop_info.session_id);
                 }
                 cx.notify();
             }

--- a/crates/zremote-gui/src/views/sidebar.rs
+++ b/crates/zremote-gui/src/views/sidebar.rs
@@ -7,6 +7,7 @@ use gpui::*;
 use crate::app_state::AppState;
 use crate::icons::{Icon, icon};
 use crate::theme;
+use crate::views::cc_widgets;
 use std::time::Duration;
 
 use crate::views::main_view::SidebarEvent;
@@ -20,6 +21,21 @@ pub struct CcState {
     pub loop_id: String,
     pub status: AgenticStatus,
     pub task_name: Option<String>,
+}
+
+/// Claude Code session metrics (context, cost, model, rate limits).
+#[derive(Clone, Default)]
+pub struct CcMetrics {
+    pub model: Option<String>,
+    pub context_used_pct: Option<f64>,
+    pub context_window_size: Option<u64>,
+    pub cost_usd: Option<f64>,
+    pub tokens_in: Option<u64>,
+    pub tokens_out: Option<u64>,
+    pub lines_added: Option<i64>,
+    pub lines_removed: Option<i64>,
+    pub rate_limit_5h_pct: Option<u64>,
+    pub rate_limit_7d_pct: Option<u64>,
 }
 
 /// A project with its associated sessions.
@@ -45,6 +61,8 @@ pub struct SidebarView {
     load_generation: u64,
     /// Claude Code agentic loop state per session_id.
     cc_states: HashMap<String, CcState>,
+    /// Claude Code session metrics per session_id.
+    cc_metrics: HashMap<String, CcMetrics>,
 }
 
 impl SidebarView {
@@ -68,6 +86,10 @@ impl SidebarView {
         &self.cc_states
     }
 
+    pub fn cc_metrics(&self) -> &HashMap<String, CcMetrics> {
+        &self.cc_metrics
+    }
+
     pub fn new(app_state: Arc<AppState>, cx: &mut Context<Self>) -> Self {
         // Restore previously selected session from persistence.
         let restored_session_id = app_state
@@ -85,6 +107,7 @@ impl SidebarView {
             loading: true,
             load_generation: 0,
             cc_states: HashMap::new(),
+            cc_metrics: HashMap::new(),
         };
         view.load_data(cx);
         view
@@ -191,14 +214,16 @@ impl SidebarView {
             }
             ServerEvent::SessionClosed { session_id, .. } => {
                 self.cc_states.remove(session_id);
+                self.cc_metrics.remove(session_id);
                 self.load_data(cx);
             }
             ServerEvent::SessionSuspended { session_id } => {
                 self.cc_states.remove(session_id);
+                self.cc_metrics.remove(session_id);
                 self.load_data(cx);
             }
             ServerEvent::HostDisconnected { host_id } => {
-                // Remove cc_states for all sessions belonging to this host.
+                // Remove cc_states and cc_metrics for all sessions belonging to this host.
                 let session_ids: Vec<String> = self
                     .sessions
                     .iter()
@@ -207,6 +232,7 @@ impl SidebarView {
                     .collect();
                 for sid in &session_ids {
                     self.cc_states.remove(sid);
+                    self.cc_metrics.remove(sid);
                 }
                 self.load_data(cx);
             }
@@ -239,6 +265,36 @@ impl SidebarView {
                 {
                     self.cc_states.remove(&loop_info.session_id);
                 }
+                cx.notify();
+            }
+            ServerEvent::ClaudeSessionMetrics {
+                session_id,
+                model,
+                context_used_pct,
+                context_window_size,
+                cost_usd,
+                tokens_in,
+                tokens_out,
+                lines_added,
+                lines_removed,
+                rate_limit_5h_pct,
+                rate_limit_7d_pct,
+            } => {
+                self.cc_metrics.insert(
+                    session_id.clone(),
+                    CcMetrics {
+                        model: model.clone(),
+                        context_used_pct: *context_used_pct,
+                        context_window_size: *context_window_size,
+                        cost_usd: *cost_usd,
+                        tokens_in: *tokens_in,
+                        tokens_out: *tokens_out,
+                        lines_added: *lines_added,
+                        lines_removed: *lines_removed,
+                        rate_limit_5h_pct: *rate_limit_5h_pct,
+                        rate_limit_7d_pct: *rate_limit_7d_pct,
+                    },
+                );
                 cx.notify();
             }
             _ => {}
@@ -821,6 +877,8 @@ impl SidebarView {
 
         // Claude Code agentic state for this session
         let cc_state = self.cc_states.get(&session.id);
+        let cc_metrics = self.cc_metrics.get(&session.id);
+        let has_second_row = cc_metrics.is_some();
 
         let bg_color = if is_selected {
             theme::bg_tertiary()
@@ -861,6 +919,9 @@ impl SidebarView {
             div().into_any_element()
         };
 
+        // Row height: taller when we have a second row with metrics
+        let row_height = if has_second_row { px(38.0) } else { px(22.0) };
+
         div()
             .id(SharedString::from(format!("session-{session_id}")))
             .flex()
@@ -868,7 +929,7 @@ impl SidebarView {
             .justify_between()
             .pl(indent)
             .pr(px(12.0))
-            .h(px(22.0))
+            .h(row_height)
             .cursor_pointer()
             .rounded(px(4.0))
             .mx(px(4.0))
@@ -889,62 +950,108 @@ impl SidebarView {
                 })
             })
             .child({
-                let mut left = div()
+                // Two-row layout container
+                let mut col = div().flex().flex_col().flex_1().min_w(px(0.0));
+
+                // Row 1: icon + name + task
+                let mut row1 = div()
                     .flex()
                     .items_center()
                     .gap(px(6.0))
                     .min_w(px(0.0))
-                    .overflow_hidden()
-                    .child(
+                    .overflow_hidden();
+
+                // Status indicator: Bot icon when CC is active, dot otherwise
+                if let Some(cc) = cc_state {
+                    let bot_icon_id = SharedString::from(format!("cc-bot-{}", session.id));
+                    let tooltip_metrics = cc_metrics.cloned().unwrap_or_default();
+                    let tooltip_status = Some(cc.status);
+                    let tooltip_task = cc.task_name.clone();
+
+                    row1 = row1.child(
+                        div()
+                            .id(bot_icon_id)
+                            .flex_shrink_0()
+                            .child(cc_widgets::cc_bot_icon(cc.status, 12.0))
+                            .tooltip(move |_window, cx| {
+                                cx.new(|_| CcTooltipView {
+                                    metrics: tooltip_metrics.clone(),
+                                    status: tooltip_status,
+                                    task_name: tooltip_task.clone(),
+                                })
+                                .into()
+                            }),
+                    );
+                } else {
+                    row1 = row1.child(
                         div()
                             .w(px(6.0))
                             .h(px(6.0))
                             .flex_shrink_0()
                             .rounded(px(3.0))
                             .bg(status_color),
-                    )
-                    .child(
-                        div()
-                            .text_color(text_color)
-                            .text_size(px(12.0))
-                            .flex_shrink_0()
-                            .whitespace_nowrap()
-                            .child(display_name),
                     );
-
-                if let Some(cc) = cc_state {
-                    let cc_icon = if cc.status == AgenticStatus::WaitingForInput {
-                        Icon::MessageCircle
-                    } else {
-                        Icon::Loader
-                    };
-                    let cc_color = if cc.status == AgenticStatus::WaitingForInput {
-                        theme::warning()
-                    } else {
-                        theme::accent()
-                    };
-
-                    left = left.child(
-                        icon(cc_icon)
-                            .size(px(12.0))
-                            .flex_shrink_0()
-                            .text_color(cc_color),
-                    );
-
-                    if let Some(ref task) = cc.task_name {
-                        left = left.child(
-                            div()
-                                .text_color(theme::text_tertiary())
-                                .text_size(px(11.0))
-                                .truncate()
-                                .child(format!("— {task}")),
-                        );
-                    }
                 }
 
-                left
+                // Session name
+                row1 = row1.child(
+                    div()
+                        .text_color(text_color)
+                        .text_size(px(12.0))
+                        .flex_shrink_0()
+                        .whitespace_nowrap()
+                        .child(display_name),
+                );
+
+                // Task name (without secondary icon)
+                if let Some(cc) = cc_state
+                    && let Some(ref task) = cc.task_name
+                {
+                    row1 = row1.child(
+                        div()
+                            .text_color(theme::text_tertiary())
+                            .text_size(px(11.0))
+                            .truncate()
+                            .child(format!("— {task}")),
+                    );
+                }
+
+                col = col.child(row1);
+
+                // Row 2: context bar + model (only when metrics available)
+                if let Some(metrics) = cc_metrics {
+                    let mut row2 = div().flex().items_center().gap(px(4.0)).ml(px(18.0));
+
+                    row2 = row2.child(cc_widgets::render_context_bar(metrics, 60.0, 4.0));
+
+                    if let Some(ref model) = metrics.model {
+                        row2 = row2.child(
+                            div()
+                                .text_color(theme::text_tertiary())
+                                .text_size(px(10.0))
+                                .child(cc_widgets::short_model_name(model)),
+                        );
+                    }
+
+                    col = col.child(row2);
+                }
+
+                col
             })
             .child(close_button)
+    }
+}
+
+/// Tooltip view for Claude Code session metrics.
+struct CcTooltipView {
+    metrics: CcMetrics,
+    status: Option<AgenticStatus>,
+    task_name: Option<String>,
+}
+
+impl Render for CcTooltipView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        cc_widgets::render_cc_tooltip(&self.metrics, self.status, self.task_name.as_deref())
     }
 }
 

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -1491,9 +1491,10 @@ impl Render for TerminalPanel {
 
             // Context percentage text
             if let Some(pct) = metrics.context_used_pct {
-                let window = metrics.context_window_size.unwrap_or(200_000);
-                let tokens_used = (pct / 100.0) * window as f64;
-                let pct_200k = tokens_used / 200_000.0 * 100.0;
+                let (_, pct_200k) = cc_widgets::context_usage_200k(
+                    pct,
+                    metrics.context_window_size.unwrap_or(200_000),
+                );
                 cc_badge = cc_badge.child(
                     div()
                         .text_size(px(10.0))

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -63,7 +63,10 @@ use crate::views::command_palette::PaletteTab;
 use crate::views::double_shift::DoubleShiftDetector;
 use crate::views::terminal_element::{CellRunCache, GlyphCache, TerminalElement};
 use crate::views::url_detector::UrlDetector;
-use zremote_client::TerminalEvent;
+use zremote_client::{AgenticStatus, TerminalEvent};
+
+use crate::views::cc_widgets;
+use crate::views::sidebar::CcMetrics;
 
 /// Cursor blink interval (standard terminal blink rate).
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
@@ -200,6 +203,10 @@ pub struct TerminalPanel {
     /// Whether the terminal WebSocket connection has been lost
     /// (session may still be alive on server, waiting for reconnect).
     disconnected: bool,
+    /// Claude Code session metrics for the current session.
+    cc_metrics: Option<CcMetrics>,
+    /// Claude Code agentic status for the current session.
+    cc_status: Option<AgenticStatus>,
 }
 
 impl TerminalPanel {
@@ -297,6 +304,8 @@ impl TerminalPanel {
             tmux_name,
             mode,
             disconnected: false,
+            cc_metrics: None,
+            cc_status: None,
         }
     }
 
@@ -307,6 +316,22 @@ impl TerminalPanel {
     /// Whether the terminal WebSocket connection has been lost.
     pub fn is_disconnected(&self) -> bool {
         self.disconnected
+    }
+
+    /// Update Claude Code metrics for this terminal's session.
+    pub fn update_cc_metrics(&mut self, metrics: CcMetrics) {
+        self.cc_metrics = Some(metrics);
+    }
+
+    /// Update Claude Code agentic status.
+    pub fn update_cc_status(&mut self, status: Option<AgenticStatus>) {
+        self.cc_status = status;
+    }
+
+    /// Clear Claude Code state (e.g., on session close).
+    pub fn clear_cc_state(&mut self) {
+        self.cc_metrics = None;
+        self.cc_status = None;
     }
 
     /// Reconnect with a new terminal handle after session resume.
@@ -1431,6 +1456,55 @@ impl Render for TerminalPanel {
                 },
             );
         }
+        // CC metrics badge (above connection badge)
+        if let Some(ref metrics) = self.cc_metrics
+            && let Some(status) = self.cc_status
+        {
+            let mut cc_badge = div()
+                .id("cc-metrics-badge")
+                .absolute()
+                .bottom(px(28.0))
+                .right(px(8.0))
+                .flex()
+                .items_center()
+                .gap(px(6.0))
+                .px(px(6.0))
+                .py(px(2.0))
+                .rounded(px(8.0))
+                .bg(gpui::rgba(0x1111_1399));
+
+            // Bot icon
+            cc_badge = cc_badge.child(cc_widgets::cc_bot_icon(status, 10.0));
+
+            // Model name
+            if let Some(ref model) = metrics.model {
+                cc_badge = cc_badge.child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme::text_tertiary())
+                        .child(cc_widgets::short_model_name(model)),
+                );
+            }
+
+            // Context bar
+            cc_badge = cc_badge.child(cc_widgets::render_context_bar(metrics, 50.0, 4.0));
+
+            // Context percentage text
+            if let Some(pct) = metrics.context_used_pct {
+                let window = metrics.context_window_size.unwrap_or(200_000);
+                let tokens_used = (pct / 100.0) * window as f64;
+                let pct_200k = tokens_used / 200_000.0 * 100.0;
+                cc_badge = cc_badge.child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme::text_tertiary())
+                        .child(format!("{pct_200k:.0}%")),
+                );
+            }
+
+            content = content.child(cc_badge);
+        }
+
         content = content.child(badge);
 
         // Wrap in a vertical container with optional search overlay on top.


### PR DESCRIPTION
## Summary

- Surface `ClaudeSessionMetrics` events (previously broadcast but ignored by GUI) in sidebar, session switcher, command palette, and terminal panel
- Bot icon (Lucide) colored by agentic status replaces Loader/MessageCircle icons
- Context usage progress bar normalized to 200k token baseline with overflow indicator for larger windows
- Short model name display (e.g., "Opus4.6", "Son4.6")
- Detailed tooltip on hover: model, tokens, cost, rate limits, lines changed

## Changes

- **New:** `cc_widgets.rs` -- shared rendering helpers (context bar, bot icon, model name, tooltip)
- **New:** `bot.svg` -- Lucide bot icon
- **Sidebar:** Two-row layout when CC active (bot icon + task name / context bar + model)
- **Session switcher:** Inline context bar + model + bot icon per entry
- **Command palette:** Same metrics in session accessory area
- **Terminal panel:** CC badge above connection badge with model + context bar + percentage
- **Data flow:** `ClaudeSessionMetrics` -> sidebar `cc_metrics` HashMap -> forwarded to terminal panel and snapshots

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace` passes (0 warnings)
- [x] `cargo test --workspace` passes (1372 tests)
- [x] Unit tests for `short_model_name`, `extract_version`, `context_usage_200k`, `format_cost`
- [x] Code review: rust-reviewer + code-reviewer (all issues fixed)
- [ ] Manual: verify sidebar with active CC session shows bot icon + context bar
- [ ] Manual: verify session switcher (Ctrl+Tab) shows metrics
- [ ] Manual: verify terminal panel CC badge appears