### PR TITLE
Add ZRemote mobile app: UniFFI bindings + Android MVP

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,74 @@
+name: Android Build
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NDK_VERSION: "27.2.12479018"
+
+jobs:
+  build-android:
+    name: Build Android Native Library
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+
+      - name: Setup Android NDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Set ANDROID_NDK_HOME
+        run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> "$GITHUB_ENV"
+
+      - name: Run FFI tests
+        run: cargo test -p zremote-ffi
+
+      - name: Build for arm64-v8a
+        run: |
+          cargo ndk -t arm64-v8a \
+            -o ./android-output/jniLibs \
+            build --profile release-android -p zremote-ffi
+
+      - name: Generate Kotlin bindings
+        run: |
+          mkdir -p ./android-output/kotlin
+          cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+            --library target/aarch64-linux-android/release-android/libzremote_ffi.so \
+            --language kotlin \
+            --out-dir ./android-output/kotlin
+
+      - name: Report binary size
+        run: |
+          echo "=== Binary sizes ==="
+          find ./android-output/jniLibs -name "*.so" -exec ls -lh {} \;
+          echo ""
+          echo "=== Kotlin bindings ==="
+          find ./android-output/kotlin -name "*.kt" -exec wc -l {} \;
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zremote-android-${{ github.ref_name || github.sha }}
+          path: |
+            android-output/jniLibs/
+            android-output/kotlin/
+          retention-days: 90

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +980,38 @@ dependencies = [
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2241,6 +2324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2586,17 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -5505,6 +5608,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5544,6 +5667,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -5831,6 +5958,12 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
@@ -5868,6 +6001,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smol"
@@ -6330,7 +6469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
- "siphasher",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -6589,6 +6728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6830,6 +6978,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7218,6 +7375,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniffi"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+dependencies = [
+ "anyhow",
+ "siphasher 0.3.11",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7253,7 +7531,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz 0.20.1",
  "simplecss",
- "siphasher",
+ "siphasher 1.0.2",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -7678,6 +7956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8884,6 +9171,20 @@ dependencies = [
  "tracing",
  "uuid",
  "zremote-protocol",
+]
+
+[[package]]
+name = "zremote-ffi"
+version = "0.1.0"
+dependencies = [
+ "flume",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uniffi",
+ "zremote-client",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,7 +3130,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5247,7 +5247,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6965,6 +6965,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7947,6 +7948,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,9 @@ opt-level = 3
 [profile.release]
 strip = true
 lto = "thin"
+
+[profile.release-android]
+inherits = "release"
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ dashmap = "6"
 teloxide = { version = "0.17", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }
 
 # Agent-only
-tokio-tungstenite = { version = "0.28", features = ["connect", "rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.28", features = ["connect", "rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 portable-pty = "0.9"
 hostname = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/zremote-agent",
     "crates/zremote-gui",
     "crates/zremote-client",
+    "crates/zremote-ffi",
 ]
 
 [workspace.package]

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,13 @@
+*.iml
+.gradle
+/local.properties
+/.idea
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx
+local.properties
+/app/build
+/app/src/main/jniLibs
+/app/src/main/java/com/zremote/sdk

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,215 @@
+# ZRemote Android App
+
+Android client for monitoring ZRemote hosts, terminal sessions, agentic loops, and Claude tasks.
+
+## Features
+
+- **Host monitoring** -- view all connected hosts with online/offline status
+- **Session management** -- browse terminal sessions per host
+- **Agentic loop tracking** -- real-time loop status with color-coded indicators
+- **Claude task monitoring** -- view active tasks, cost, and token usage
+- **Terminal viewer** -- read-only terminal output with ANSI color support + quick-command input
+- **Push notifications** -- background alerts for loop completions, errors, and permission requests
+- **Dark theme** -- matches the desktop GPUI client
+
+## Prerequisites
+
+- Android Studio Ladybug (2024.2) or newer
+- JDK 17+
+- Android SDK 35
+- Android NDK 27.x (for building native library)
+- Rust toolchain with `aarch64-linux-android` target
+- `cargo-ndk` (`cargo install cargo-ndk`)
+
+## Building the Native Library
+
+The app requires the Rust FFI library (`libzremote_ffi.so`) and generated Kotlin bindings.
+
+### 1. Set up Rust for Android
+
+```bash
+# Add Android target
+rustup target add aarch64-linux-android
+
+# Install cargo-ndk
+cargo install cargo-ndk
+
+# Set NDK path (adjust to your installation)
+export ANDROID_NDK_HOME=$HOME/Android/Sdk/ndk/27.2.12479018
+```
+
+### 2. Build native library + generate bindings
+
+From the repository root:
+
+```bash
+./scripts/build-android.sh
+```
+
+This produces:
+- `android/app/src/main/jniLibs/arm64-v8a/libzremote_ffi.so` -- native library
+- `android/app/src/main/java/com/zremote/sdk/` -- generated Kotlin bindings
+
+For all ABIs (arm64, armv7, x86_64, x86):
+
+```bash
+./scripts/build-android.sh --all-abis
+```
+
+### 3. Build the Android app
+
+```bash
+cd android
+./gradlew assembleDebug
+```
+
+The APK will be at `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+## Installing Without Google Play
+
+### Option A: Direct APK install (sideload)
+
+1. Build the debug APK:
+   ```bash
+   cd android && ./gradlew assembleDebug
+   ```
+
+2. Transfer the APK to your phone:
+   ```bash
+   adb install app/build/outputs/apk/debug/app-debug.apk
+   ```
+
+   Or copy the APK file to your phone and open it in a file manager.
+
+3. Enable "Install from unknown sources" when prompted on the device.
+
+### Option B: Direct install via ADB
+
+Connect your phone via USB with developer mode enabled:
+
+```bash
+cd android
+./gradlew installDebug
+```
+
+### Option C: Release APK (smaller, optimized)
+
+1. Create a signing key (one-time):
+   ```bash
+   keytool -genkey -v -keystore zremote-release.keystore \
+     -alias zremote -keyalg RSA -keysize 2048 -validity 10000
+   ```
+
+2. Create `android/local.properties`:
+   ```properties
+   sdk.dir=/path/to/Android/Sdk
+   ```
+
+3. Create `android/keystore.properties`:
+   ```properties
+   storeFile=../zremote-release.keystore
+   storePassword=your_password
+   keyAlias=zremote
+   keyPassword=your_password
+   ```
+
+4. Build release APK:
+   ```bash
+   cd android && ./gradlew assembleRelease
+   ```
+
+5. Install:
+   ```bash
+   adb install app/build/outputs/apk/release/app-release.apk
+   ```
+
+## Usage
+
+### First Launch
+
+1. Open the app -- you'll see the **Hosts** tab (empty, not connected)
+2. Go to **Settings** tab (bottom right)
+3. Enter your ZRemote server URL (e.g., `http://192.168.1.100:3000`)
+4. Tap **Connect**
+5. Navigate back to **Hosts** -- your hosts should appear
+
+### Navigation
+
+| Tab | What it shows |
+|-----|---------------|
+| **Hosts** | All registered hosts with online/offline status. Tap a host to see its sessions. |
+| **Loops** | Active and recent agentic loops across all hosts. Tap for details. |
+| **Tasks** | Claude tasks with status, cost, and token usage. |
+| **Settings** | Server URL configuration and connection status. |
+
+### Terminal Viewer
+
+1. Go to **Hosts** > tap a host > tap a session
+2. Terminal output is displayed with ANSI color support
+3. Use the **quick-command bar** at the bottom:
+   - `Ctrl+C` -- send interrupt
+   - `Tab` -- send tab
+   - `Esc` -- send escape
+   - `Up`/`Down` -- arrow keys
+   - Text field -- type commands, press Send
+
+### Background Notifications
+
+When the app is in the background, you'll receive notifications for:
+
+| Event | Priority | Description |
+|-------|----------|-------------|
+| Loop completed | Normal | Agentic loop finished successfully |
+| Loop error | High | Agentic loop encountered an error |
+| Permission request | High | A tool call needs your approval |
+| Task completed | Normal | Claude task finished |
+| Task error | High | Claude task failed |
+| Host disconnected | Low | A host lost connection |
+
+To enable background notifications, grant the "Notifications" permission when prompted.
+
+## Architecture
+
+```
+ZRemoteClient (Rust via UniFFI)
+       |
+       v
+ConnectionManager (singleton)
+  |-- ZRemoteEventRepository (real-time events via WebSocket)
+  |-- SettingsRepository (DataStore persistence)
+       |
+       v
+ViewModel (Hilt, per-screen)
+       |
+       v
+Compose Screen (Material 3 dark theme)
+```
+
+The native Rust SDK (`zremote-ffi`) handles all networking:
+- REST API calls via `reqwest`
+- WebSocket event stream with auto-reconnect
+- WebSocket terminal I/O with binary frame support
+
+Kotlin receives data through UniFFI-generated callback interfaces (`EventListener`, `TerminalListener`).
+
+## Troubleshooting
+
+### "Not connected" on Hosts screen
+- Go to Settings, verify the server URL is correct
+- Make sure the ZRemote server is running and reachable from your phone
+- Check that your phone is on the same network as the server
+
+### No notifications
+- Check Android Settings > Apps > ZRemote > Notifications
+- Ensure notification channels are enabled
+- Grant POST_NOTIFICATIONS permission (Android 13+)
+
+### Terminal not showing output
+- Verify the session is in "active" status
+- Check that the host is online
+- The terminal uses a read-only ANSI viewer -- some escape sequences may not render
+
+### Build fails with "libzremote_ffi.so not found"
+- Run `./scripts/build-android.sh` from the repo root first
+- Check that `ANDROID_NDK_HOME` is set correctly
+- Verify `android/app/src/main/jniLibs/arm64-v8a/libzremote_ffi.so` exists

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,73 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
+}
+
+android {
+    namespace = "com.zremote.app"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.zremote.app"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    // Compose BOM
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // AndroidX
+    implementation(libs.core.ktx)
+    implementation(libs.activity.compose)
+
+    // Navigation
+    implementation(libs.navigation.compose)
+
+    // Lifecycle
+    implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.runtime.compose)
+
+    // Hilt DI
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    // DataStore (for settings persistence)
+    implementation(libs.datastore.preferences)
+}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -67,6 +68,9 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
+
+    // Serialization (for type-safe navigation routes)
+    implementation(libs.kotlinx.serialization.json)
 
     // DataStore (for settings persistence)
     implementation(libs.datastore.preferences)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -74,4 +74,7 @@ dependencies {
 
     // DataStore (for settings persistence)
     implementation(libs.datastore.preferences)
+
+    // JNA (for UniFFI generated native bindings)
+    implementation(libs.jna) { artifact { type = "aar" } }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+# UniFFI generated bindings - keep all SDK types
+-keep class com.zremote.sdk.** { *; }
+
+# Keep native method names
+-keepclasseswithmembernames class * {
+    native <methods>;
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -5,3 +5,23 @@
 -keepclasseswithmembernames class * {
     native <methods>;
 }
+
+# Kotlin serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.zremote.**$$serializer { *; }
+-keepclassmembers class com.zremote.** {
+    *** Companion;
+}
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class * extends dagger.hilt.android.internal.managers.ViewComponentManager$FragmentContextWrapper { *; }
+
+# Compose - keep runtime metadata
+-keep class androidx.compose.runtime.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
-        android:name=".app.ZRemoteApp"
+        android:name="com.zremote.app.ZRemoteApp"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="ZRemote"
@@ -15,7 +15,7 @@
         android:theme="@style/Theme.ZRemote">
 
         <activity
-            android:name=".app.MainActivity"
+            android:name="com.zremote.app.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.ZRemote">
             <intent-filter>
@@ -24,7 +24,7 @@
             </intent-filter>
         </activity>
         <service
-            android:name=".services.ZRemoteEventService"
+            android:name="com.zremote.services.ZRemoteEventService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:name=".app.ZRemoteApp"
+        android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
+        android:label="ZRemote"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ZRemote">
+
+        <activity
+            android:name=".app.MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.ZRemote">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".services.ZRemoteEventService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/zremote/app/MainActivity.kt
+++ b/android/app/src/main/java/com/zremote/app/MainActivity.kt
@@ -1,0 +1,22 @@
+package com.zremote.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import com.zremote.ui.navigation.ZRemoteNavHost
+import com.zremote.ui.theme.ZRemoteTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            ZRemoteTheme {
+                ZRemoteNavHost()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/app/ZRemoteApp.kt
+++ b/android/app/src/main/java/com/zremote/app/ZRemoteApp.kt
@@ -1,0 +1,7 @@
+package com.zremote.app
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class ZRemoteApp : Application()

--- a/android/app/src/main/java/com/zremote/app/ZRemoteApp.kt
+++ b/android/app/src/main/java/com/zremote/app/ZRemoteApp.kt
@@ -1,7 +1,13 @@
 package com.zremote.app
 
 import android.app.Application
+import com.zremote.notifications.NotificationHelper
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class ZRemoteApp : Application()
+class ZRemoteApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        NotificationHelper.createChannels(this)
+    }
+}

--- a/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
+++ b/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
@@ -1,7 +1,8 @@
 package com.zremote.data
 
 import android.content.Context
-import com.zremote.sdk.FfiError
+import android.util.Log
+import com.zremote.sdk.FfiException
 import com.zremote.sdk.ZRemoteClient
 import com.zremote.services.ZRemoteEventService
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,15 +26,26 @@ class ConnectionManager @Inject constructor(
 
     @Synchronized
     fun connect(serverUrl: String) {
+        Log.i("ZRemote", "connect() called with url=$serverUrl")
         disconnect()
         try {
+            Log.i("ZRemote", "Creating ZRemoteClient...")
             val newClient = ZRemoteClient(serverUrl)
+            Log.i("ZRemote", "ZRemoteClient created, connecting events...")
             client = newClient
             eventRepository.connect(newClient)
+            // Mark as connected immediately so UI can start loading data.
+            // The WS event stream will update this via onConnected/onDisconnected.
+            eventRepository.setConnected(true)
             _connectionError.value = null
             ZRemoteEventService.start(appContext, serverUrl)
-        } catch (e: FfiError) {
-            _connectionError.value = e.message
+            Log.i("ZRemote", "Connected successfully")
+        } catch (e: Exception) {
+            Log.e("ZRemote", "connect() Exception", e)
+            _connectionError.value = e.message ?: e.toString()
+        } catch (e: Error) {
+            Log.e("ZRemote", "connect() Error", e)
+            _connectionError.value = e.message ?: e.toString()
         }
     }
 

--- a/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
+++ b/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
@@ -1,7 +1,10 @@
 package com.zremote.data
 
+import android.content.Context
 import com.zremote.sdk.FfiError
 import com.zremote.sdk.ZRemoteClient
+import com.zremote.services.ZRemoteEventService
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,13 +14,16 @@ import javax.inject.Singleton
 @Singleton
 class ConnectionManager @Inject constructor(
     val eventRepository: ZRemoteEventRepository,
+    @ApplicationContext private val appContext: Context,
 ) {
+    @Volatile
     var client: ZRemoteClient? = null
         private set
 
     private val _connectionError = MutableStateFlow<String?>(null)
     val connectionError: StateFlow<String?> = _connectionError.asStateFlow()
 
+    @Synchronized
     fun connect(serverUrl: String) {
         disconnect()
         try {
@@ -25,12 +31,15 @@ class ConnectionManager @Inject constructor(
             client = newClient
             eventRepository.connect(newClient)
             _connectionError.value = null
+            ZRemoteEventService.start(appContext, serverUrl)
         } catch (e: FfiError) {
             _connectionError.value = e.message
         }
     }
 
+    @Synchronized
     fun disconnect() {
+        ZRemoteEventService.stop(appContext)
         eventRepository.disconnect()
         client = null
     }

--- a/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
+++ b/android/app/src/main/java/com/zremote/data/ConnectionManager.kt
@@ -1,0 +1,37 @@
+package com.zremote.data
+
+import com.zremote.sdk.FfiError
+import com.zremote.sdk.ZRemoteClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectionManager @Inject constructor(
+    val eventRepository: ZRemoteEventRepository,
+) {
+    var client: ZRemoteClient? = null
+        private set
+
+    private val _connectionError = MutableStateFlow<String?>(null)
+    val connectionError: StateFlow<String?> = _connectionError.asStateFlow()
+
+    fun connect(serverUrl: String) {
+        disconnect()
+        try {
+            val newClient = ZRemoteClient(serverUrl)
+            client = newClient
+            eventRepository.connect(newClient)
+            _connectionError.value = null
+        } catch (e: FfiError) {
+            _connectionError.value = e.message
+        }
+    }
+
+    fun disconnect() {
+        eventRepository.disconnect()
+        client = null
+    }
+}

--- a/android/app/src/main/java/com/zremote/data/DataStoreExt.kt
+++ b/android/app/src/main/java/com/zremote/data/DataStoreExt.kt
@@ -1,0 +1,8 @@
+package com.zremote.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")

--- a/android/app/src/main/java/com/zremote/data/SettingsRepository.kt
+++ b/android/app/src/main/java/com/zremote/data/SettingsRepository.kt
@@ -2,6 +2,7 @@ package com.zremote.data
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -13,15 +14,52 @@ import javax.inject.Singleton
 class SettingsRepository @Inject constructor(
     private val dataStore: DataStore<Preferences>,
 ) {
-    private val serverUrlKey = stringPreferencesKey("server_url")
-
     val serverUrl: Flow<String> = dataStore.data.map { prefs ->
-        prefs[serverUrlKey] ?: ""
+        prefs[KEY_SERVER_URL] ?: ""
     }
 
+    val notifyLoopCompletions: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_LOOP_COMPLETIONS] ?: true }
+    val notifyLoopErrors: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_LOOP_ERRORS] ?: true }
+    val notifyPermissionRequests: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_PERMISSION_REQUESTS] ?: true }
+    val notifyTaskCompletions: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_TASK_COMPLETIONS] ?: true }
+    val notifyTaskErrors: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_TASK_ERRORS] ?: true }
+    val notifyHostDisconnections: Flow<Boolean> = dataStore.data.map { it[KEY_NOTIFY_HOST_DISCONNECTIONS] ?: true }
+
     suspend fun setServerUrl(url: String) {
-        dataStore.edit { prefs ->
-            prefs[serverUrlKey] = url
-        }
+        dataStore.edit { prefs -> prefs[KEY_SERVER_URL] = url }
+    }
+
+    suspend fun setNotifyLoopCompletions(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_LOOP_COMPLETIONS] = enabled }
+    }
+
+    suspend fun setNotifyLoopErrors(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_LOOP_ERRORS] = enabled }
+    }
+
+    suspend fun setNotifyPermissionRequests(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_PERMISSION_REQUESTS] = enabled }
+    }
+
+    suspend fun setNotifyTaskCompletions(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_TASK_COMPLETIONS] = enabled }
+    }
+
+    suspend fun setNotifyTaskErrors(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_TASK_ERRORS] = enabled }
+    }
+
+    suspend fun setNotifyHostDisconnections(enabled: Boolean) {
+        dataStore.edit { it[KEY_NOTIFY_HOST_DISCONNECTIONS] = enabled }
+    }
+
+    companion object {
+        private val KEY_SERVER_URL = stringPreferencesKey("server_url")
+        val KEY_NOTIFY_LOOP_COMPLETIONS = booleanPreferencesKey("notify_loop_completions")
+        val KEY_NOTIFY_LOOP_ERRORS = booleanPreferencesKey("notify_loop_errors")
+        val KEY_NOTIFY_PERMISSION_REQUESTS = booleanPreferencesKey("notify_permission_requests")
+        val KEY_NOTIFY_TASK_COMPLETIONS = booleanPreferencesKey("notify_task_completions")
+        val KEY_NOTIFY_TASK_ERRORS = booleanPreferencesKey("notify_task_errors")
+        val KEY_NOTIFY_HOST_DISCONNECTIONS = booleanPreferencesKey("notify_host_disconnections")
     }
 }

--- a/android/app/src/main/java/com/zremote/data/SettingsRepository.kt
+++ b/android/app/src/main/java/com/zremote/data/SettingsRepository.kt
@@ -1,0 +1,27 @@
+package com.zremote.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingsRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val serverUrlKey = stringPreferencesKey("server_url")
+
+    val serverUrl: Flow<String> = dataStore.data.map { prefs ->
+        prefs[serverUrlKey] ?: ""
+    }
+
+    suspend fun setServerUrl(url: String) {
+        dataStore.edit { prefs ->
+            prefs[serverUrlKey] = url
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
+++ b/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
@@ -10,6 +10,7 @@ import com.zremote.sdk.ZRemoteEventStream
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,13 +49,7 @@ class ZRemoteEventRepository @Inject constructor() {
         _isConnected.value = false
         _loops.value = emptyList()
         _sessionMetrics.value = emptyMap()
-    }
-
-    private fun refreshAfterEvent() {
-        val c = client ?: return
-        scope.launch {
-            // Subclasses or screens can observe StateFlows and refresh as needed
-        }
+        scope.coroutineContext[Job]?.cancelChildren()
     }
 
     private inner class Listener : EventListener {

--- a/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
+++ b/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
@@ -1,5 +1,6 @@
 package com.zremote.data
 
+import android.util.Log
 import com.zremote.sdk.EventListener
 import com.zremote.sdk.FfiClaudeSessionMetrics
 import com.zremote.sdk.FfiHostInfo
@@ -10,7 +11,7 @@ import com.zremote.sdk.ZRemoteEventStream
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,6 +43,10 @@ class ZRemoteEventRepository @Inject constructor() {
         eventStream = newClient.connectEvents(Listener())
     }
 
+    fun setConnected(connected: Boolean) {
+        _isConnected.value = connected
+    }
+
     fun disconnect() {
         eventStream?.disconnect()
         eventStream = null
@@ -49,24 +54,26 @@ class ZRemoteEventRepository @Inject constructor() {
         _isConnected.value = false
         _loops.value = emptyList()
         _sessionMetrics.value = emptyMap()
-        scope.coroutineContext[Job]?.cancelChildren()
+        scope.coroutineContext.cancel()
     }
 
     private inner class Listener : EventListener {
         override fun onConnected() {
+            Log.i("ZRemote", "EventListener.onConnected()")
             _isConnected.value = true
         }
 
         override fun onDisconnected() {
+            Log.i("ZRemote", "EventListener.onDisconnected()")
             _isConnected.value = false
         }
 
         override fun onHostConnected(host: FfiHostInfo) {
-            refreshAfterEvent()
+            // Host state changed; UI refreshes via pull-to-refresh
         }
 
         override fun onHostDisconnected(hostId: String) {
-            refreshAfterEvent()
+            // Host state changed; UI refreshes via pull-to-refresh
         }
 
         override fun onHostStatusChanged(hostId: String, status: String) {}

--- a/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
+++ b/android/app/src/main/java/com/zremote/data/ZRemoteEventRepository.kt
@@ -1,0 +1,123 @@
+package com.zremote.data
+
+import com.zremote.sdk.EventListener
+import com.zremote.sdk.FfiClaudeSessionMetrics
+import com.zremote.sdk.FfiHostInfo
+import com.zremote.sdk.FfiLoopInfo
+import com.zremote.sdk.FfiSessionInfo
+import com.zremote.sdk.ZRemoteClient
+import com.zremote.sdk.ZRemoteEventStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ZRemoteEventRepository @Inject constructor() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _loops = MutableStateFlow<List<FfiLoopInfo>>(emptyList())
+    val loops: StateFlow<List<FfiLoopInfo>> = _loops.asStateFlow()
+
+    private val _sessionMetrics = MutableStateFlow<Map<String, FfiClaudeSessionMetrics>>(emptyMap())
+    val sessionMetrics: StateFlow<Map<String, FfiClaudeSessionMetrics>> = _sessionMetrics.asStateFlow()
+
+    private var eventStream: ZRemoteEventStream? = null
+    private var client: ZRemoteClient? = null
+
+    fun connect(newClient: ZRemoteClient) {
+        disconnect()
+        client = newClient
+        eventStream = newClient.connectEvents(Listener())
+    }
+
+    fun disconnect() {
+        eventStream?.disconnect()
+        eventStream = null
+        client = null
+        _isConnected.value = false
+        _loops.value = emptyList()
+        _sessionMetrics.value = emptyMap()
+    }
+
+    private fun refreshAfterEvent() {
+        val c = client ?: return
+        scope.launch {
+            // Subclasses or screens can observe StateFlows and refresh as needed
+        }
+    }
+
+    private inner class Listener : EventListener {
+        override fun onConnected() {
+            _isConnected.value = true
+        }
+
+        override fun onDisconnected() {
+            _isConnected.value = false
+        }
+
+        override fun onHostConnected(host: FfiHostInfo) {
+            refreshAfterEvent()
+        }
+
+        override fun onHostDisconnected(hostId: String) {
+            refreshAfterEvent()
+        }
+
+        override fun onHostStatusChanged(hostId: String, status: String) {}
+
+        override fun onSessionCreated(session: FfiSessionInfo) {}
+        override fun onSessionClosed(sessionId: String, exitCode: Int?) {}
+        override fun onSessionUpdated(sessionId: String) {}
+        override fun onSessionSuspended(sessionId: String) {}
+        override fun onSessionResumed(sessionId: String) {}
+
+        override fun onProjectsUpdated(hostId: String) {}
+
+        override fun onLoopDetected(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+            _loops.update { current -> current + loopInfo }
+        }
+
+        override fun onLoopStatusChanged(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+            _loops.update { current ->
+                current.map { if (it.id == loopInfo.id) loopInfo else it }
+            }
+        }
+
+        override fun onLoopEnded(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+            _loops.update { current ->
+                current.map { if (it.id == loopInfo.id) loopInfo else it }
+            }
+        }
+
+        override fun onKnowledgeStatusChanged(hostId: String, status: String, error: String?) {}
+        override fun onIndexingProgress(
+            projectId: String, projectPath: String, status: String,
+            filesProcessed: ULong, filesTotal: ULong,
+        ) {}
+        override fun onMemoryExtracted(projectId: String, loopId: String, memoryCount: UInt) {}
+        override fun onWorktreeError(hostId: String, projectPath: String, message: String) {}
+
+        override fun onClaudeTaskStarted(
+            taskId: String, sessionId: String, hostId: String, projectPath: String,
+        ) {}
+        override fun onClaudeTaskUpdated(taskId: String, status: String, loopId: String?) {}
+        override fun onClaudeTaskEnded(taskId: String, status: String, summary: String?) {}
+
+        override fun onClaudeSessionMetrics(metrics: FfiClaudeSessionMetrics) {
+            _sessionMetrics.update { current ->
+                current + (metrics.sessionId to metrics)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/di/AppModule.kt
+++ b/android/app/src/main/java/com/zremote/di/AppModule.kt
@@ -3,15 +3,13 @@ package com.zremote.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import com.zremote.data.dataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
-
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/android/app/src/main/java/com/zremote/di/AppModule.kt
+++ b/android/app/src/main/java/com/zremote/di/AppModule.kt
@@ -1,0 +1,25 @@
+package com.zremote.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return context.dataStore
+    }
+}

--- a/android/app/src/main/java/com/zremote/notifications/NotificationEventListener.kt
+++ b/android/app/src/main/java/com/zremote/notifications/NotificationEventListener.kt
@@ -12,6 +12,7 @@ import com.zremote.sdk.FfiSessionInfo
 class NotificationEventListener(
     private val context: Context,
     private val isAppBackgrounded: () -> Boolean,
+    private val preferences: NotificationPreferences = NotificationPreferences(),
 ) : EventListener {
 
     private val notificationManager = NotificationManagerCompat.from(context)
@@ -36,6 +37,7 @@ class NotificationEventListener(
     override fun onHostConnected(host: FfiHostInfo) {}
 
     override fun onHostDisconnected(hostId: String) {
+        if (!preferences.hostDisconnections) return
         notifyIfBackgrounded(
             hostId.hashCode(),
             NotificationHelper.CHANNEL_HOST_STATUS,
@@ -60,7 +62,7 @@ class NotificationEventListener(
     override fun onLoopDetected(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {}
 
     override fun onLoopStatusChanged(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
-        if (loopInfo.status == FfiAgenticStatus.WAITING_FOR_INPUT) {
+        if (loopInfo.status == FfiAgenticStatus.WAITING_FOR_INPUT && preferences.permissionRequests) {
             notifyIfBackgrounded(
                 loopInfo.id.hashCode(),
                 NotificationHelper.CHANNEL_PERMISSIONS,
@@ -71,16 +73,20 @@ class NotificationEventListener(
     }
 
     override fun onLoopEnded(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
-        val (channel, title) = when (loopInfo.status) {
-            FfiAgenticStatus.ERROR -> Pair(
+        val (channel, title, enabled) = when (loopInfo.status) {
+            FfiAgenticStatus.ERROR -> Triple(
                 NotificationHelper.CHANNEL_LOOP_ERRORS,
                 "Loop error on $hostname",
+                preferences.loopErrors,
             )
-            else -> Pair(
+            else -> Triple(
                 NotificationHelper.CHANNEL_LOOP_STATUS,
                 "Loop completed on $hostname",
+                preferences.loopCompletions,
             )
         }
+
+        if (!enabled) return
 
         notifyIfBackgrounded(
             loopInfo.id.hashCode(),
@@ -107,10 +113,11 @@ class NotificationEventListener(
     override fun onClaudeTaskUpdated(taskId: String, status: String, loopId: String?) {}
 
     override fun onClaudeTaskEnded(taskId: String, status: String, summary: String?) {
-        val (channel, title) = when (status) {
-            "error" -> Pair(NotificationHelper.CHANNEL_TASK_ERRORS, "Task failed")
-            else -> Pair(NotificationHelper.CHANNEL_TASK_STATUS, "Task completed")
+        val (channel, title, enabled) = when (status) {
+            "error" -> Triple(NotificationHelper.CHANNEL_TASK_ERRORS, "Task failed", preferences.taskErrors)
+            else -> Triple(NotificationHelper.CHANNEL_TASK_STATUS, "Task completed", preferences.taskCompletions)
         }
+        if (!enabled) return
         notifyIfBackgrounded(
             taskId.hashCode(),
             channel,
@@ -121,3 +128,12 @@ class NotificationEventListener(
 
     override fun onClaudeSessionMetrics(metrics: FfiClaudeSessionMetrics) {}
 }
+
+data class NotificationPreferences(
+    val loopCompletions: Boolean = true,
+    val loopErrors: Boolean = true,
+    val permissionRequests: Boolean = true,
+    val taskCompletions: Boolean = true,
+    val taskErrors: Boolean = true,
+    val hostDisconnections: Boolean = true,
+)

--- a/android/app/src/main/java/com/zremote/notifications/NotificationEventListener.kt
+++ b/android/app/src/main/java/com/zremote/notifications/NotificationEventListener.kt
@@ -1,0 +1,123 @@
+package com.zremote.notifications
+
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import com.zremote.sdk.EventListener
+import com.zremote.sdk.FfiAgenticStatus
+import com.zremote.sdk.FfiClaudeSessionMetrics
+import com.zremote.sdk.FfiHostInfo
+import com.zremote.sdk.FfiLoopInfo
+import com.zremote.sdk.FfiSessionInfo
+
+class NotificationEventListener(
+    private val context: Context,
+    private val isAppBackgrounded: () -> Boolean,
+) : EventListener {
+
+    private val notificationManager = NotificationManagerCompat.from(context)
+
+    private fun notifyIfBackgrounded(id: Int, channel: String, title: String, body: String) {
+        if (!isAppBackgrounded()) return
+        try {
+            val notification = NotificationHelper
+                .buildNotification(context, channel, title, body)
+                .build()
+            notificationManager.notify(id, notification)
+        } catch (_: SecurityException) {
+            // POST_NOTIFICATIONS permission not granted
+        }
+    }
+
+    // Connection lifecycle
+    override fun onConnected() {}
+    override fun onDisconnected() {}
+
+    // Hosts
+    override fun onHostConnected(host: FfiHostInfo) {}
+
+    override fun onHostDisconnected(hostId: String) {
+        notifyIfBackgrounded(
+            hostId.hashCode(),
+            NotificationHelper.CHANNEL_HOST_STATUS,
+            "Host disconnected",
+            hostId.take(8),
+        )
+    }
+
+    override fun onHostStatusChanged(hostId: String, status: String) {}
+
+    // Sessions
+    override fun onSessionCreated(session: FfiSessionInfo) {}
+    override fun onSessionClosed(sessionId: String, exitCode: Int?) {}
+    override fun onSessionUpdated(sessionId: String) {}
+    override fun onSessionSuspended(sessionId: String) {}
+    override fun onSessionResumed(sessionId: String) {}
+
+    // Projects
+    override fun onProjectsUpdated(hostId: String) {}
+
+    // Loops
+    override fun onLoopDetected(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {}
+
+    override fun onLoopStatusChanged(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+        if (loopInfo.status == FfiAgenticStatus.WAITING_FOR_INPUT) {
+            notifyIfBackgrounded(
+                loopInfo.id.hashCode(),
+                NotificationHelper.CHANNEL_PERMISSIONS,
+                "Permission request on $hostname",
+                "${loopInfo.toolName}: waiting for input",
+            )
+        }
+    }
+
+    override fun onLoopEnded(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+        val (channel, title) = when (loopInfo.status) {
+            FfiAgenticStatus.ERROR -> Pair(
+                NotificationHelper.CHANNEL_LOOP_ERRORS,
+                "Loop error on $hostname",
+            )
+            else -> Pair(
+                NotificationHelper.CHANNEL_LOOP_STATUS,
+                "Loop completed on $hostname",
+            )
+        }
+
+        notifyIfBackgrounded(
+            loopInfo.id.hashCode(),
+            channel,
+            title,
+            "${loopInfo.taskName ?: loopInfo.toolName}: ${loopInfo.status.name.lowercase()}",
+        )
+    }
+
+    // Knowledge
+    override fun onKnowledgeStatusChanged(hostId: String, status: String, error: String?) {}
+    override fun onIndexingProgress(
+        projectId: String, projectPath: String, status: String,
+        filesProcessed: ULong, filesTotal: ULong,
+    ) {}
+    override fun onMemoryExtracted(projectId: String, loopId: String, memoryCount: UInt) {}
+    override fun onWorktreeError(hostId: String, projectPath: String, message: String) {}
+
+    // Claude tasks
+    override fun onClaudeTaskStarted(
+        taskId: String, sessionId: String, hostId: String, projectPath: String,
+    ) {}
+
+    override fun onClaudeTaskUpdated(taskId: String, status: String, loopId: String?) {}
+
+    override fun onClaudeTaskEnded(taskId: String, status: String, summary: String?) {
+        val (channel, title) = when (status) {
+            "error" -> Pair(NotificationHelper.CHANNEL_TASK_ERRORS, "Task failed")
+            else -> Pair(NotificationHelper.CHANNEL_TASK_STATUS, "Task completed")
+        }
+        notifyIfBackgrounded(
+            taskId.hashCode(),
+            channel,
+            title,
+            summary ?: "Task $status",
+        )
+    }
+
+    override fun onClaudeSessionMetrics(metrics: FfiClaudeSessionMetrics) {}
+}

--- a/android/app/src/main/java/com/zremote/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zremote/notifications/NotificationHelper.kt
@@ -1,0 +1,81 @@
+package com.zremote.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
+
+object NotificationHelper {
+
+    const val CHANNEL_LOOP_STATUS = "loop_status"
+    const val CHANNEL_LOOP_ERRORS = "loop_errors"
+    const val CHANNEL_PERMISSIONS = "permissions"
+    const val CHANNEL_TASK_STATUS = "task_status"
+    const val CHANNEL_TASK_ERRORS = "task_errors"
+    const val CHANNEL_HOST_STATUS = "host_status"
+    const val CHANNEL_SERVICE = "service"
+
+    fun createChannels(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java)
+
+        val channels = listOf(
+            NotificationChannel(
+                CHANNEL_LOOP_STATUS, "Loop Status",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = "Agentic loop completion notifications" },
+
+            NotificationChannel(
+                CHANNEL_LOOP_ERRORS, "Loop Errors",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply { description = "Agentic loop error notifications" },
+
+            NotificationChannel(
+                CHANNEL_PERMISSIONS, "Permission Requests",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply { description = "Tool call permission requests requiring approval" },
+
+            NotificationChannel(
+                CHANNEL_TASK_STATUS, "Task Status",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = "Claude task completion notifications" },
+
+            NotificationChannel(
+                CHANNEL_TASK_ERRORS, "Task Errors",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply { description = "Claude task error notifications" },
+
+            NotificationChannel(
+                CHANNEL_HOST_STATUS, "Host Status",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply { description = "Host connection/disconnection notifications" },
+
+            NotificationChannel(
+                CHANNEL_SERVICE, "Background Service",
+                NotificationManager.IMPORTANCE_MIN,
+            ).apply { description = "Keeps connection alive in background" },
+        )
+
+        manager.createNotificationChannels(channels)
+    }
+
+    fun buildNotification(
+        context: Context,
+        channel: String,
+        title: String,
+        body: String,
+    ): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, channel)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+    }
+
+    fun buildServiceNotification(context: Context): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, CHANNEL_SERVICE)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle("ZRemote")
+            .setContentText("Connected to server")
+            .setOngoing(true)
+    }
+}

--- a/android/app/src/main/java/com/zremote/services/ZRemoteEventService.kt
+++ b/android/app/src/main/java/com/zremote/services/ZRemoteEventService.kt
@@ -1,0 +1,75 @@
+package com.zremote.services
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.ServiceCompat
+import com.zremote.notifications.NotificationEventListener
+import com.zremote.notifications.NotificationHelper
+import com.zremote.sdk.ZRemoteClient
+import com.zremote.sdk.ZRemoteEventStream
+
+class ZRemoteEventService : Service() {
+
+    private var eventStream: ZRemoteEventStream? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        NotificationHelper.createChannels(this)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val serverUrl = intent?.getStringExtra(EXTRA_SERVER_URL)
+        if (serverUrl.isNullOrBlank()) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        val notification = NotificationHelper
+            .buildServiceNotification(this)
+            .build()
+        ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, 0)
+
+        connectToServer(serverUrl)
+        return START_STICKY
+    }
+
+    private fun connectToServer(serverUrl: String) {
+        eventStream?.disconnect()
+        try {
+            val client = ZRemoteClient(serverUrl)
+            val listener = NotificationEventListener(
+                context = this,
+                isAppBackgrounded = { true },
+            )
+            eventStream = client.connectEvents(listener)
+        } catch (_: Exception) {
+            stopSelf()
+        }
+    }
+
+    override fun onDestroy() {
+        eventStream?.disconnect()
+        eventStream = null
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        private const val NOTIFICATION_ID = 1
+        private const val EXTRA_SERVER_URL = "server_url"
+
+        fun start(context: Context, serverUrl: String) {
+            val intent = Intent(context, ZRemoteEventService::class.java).apply {
+                putExtra(EXTRA_SERVER_URL, serverUrl)
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, ZRemoteEventService::class.java))
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/services/ZRemoteEventService.kt
+++ b/android/app/src/main/java/com/zremote/services/ZRemoteEventService.kt
@@ -5,14 +5,24 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import androidx.core.app.ServiceCompat
+import com.zremote.data.SettingsRepository
+import com.zremote.data.dataStore
 import com.zremote.notifications.NotificationEventListener
 import com.zremote.notifications.NotificationHelper
+import com.zremote.notifications.NotificationPreferences
 import com.zremote.sdk.ZRemoteClient
 import com.zremote.sdk.ZRemoteEventStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 class ZRemoteEventService : Service() {
 
     private var eventStream: ZRemoteEventStream? = null
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
@@ -31,17 +41,21 @@ class ZRemoteEventService : Service() {
             .build()
         ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, 0)
 
-        connectToServer(serverUrl)
+        serviceScope.launch {
+            connectToServer(serverUrl)
+        }
         return START_STICKY
     }
 
-    private fun connectToServer(serverUrl: String) {
+    private suspend fun connectToServer(serverUrl: String) {
         eventStream?.disconnect()
         try {
             val client = ZRemoteClient(serverUrl)
+            val preferences = loadPreferences()
             val listener = NotificationEventListener(
                 context = this,
                 isAppBackgrounded = { true },
+                preferences = preferences,
             )
             eventStream = client.connectEvents(listener)
         } catch (_: Exception) {
@@ -49,9 +63,26 @@ class ZRemoteEventService : Service() {
         }
     }
 
+    private suspend fun loadPreferences(): NotificationPreferences {
+        return try {
+            val prefs = applicationContext.dataStore.data.first()
+            NotificationPreferences(
+                loopCompletions = prefs[SettingsRepository.KEY_NOTIFY_LOOP_COMPLETIONS] ?: true,
+                loopErrors = prefs[SettingsRepository.KEY_NOTIFY_LOOP_ERRORS] ?: true,
+                permissionRequests = prefs[SettingsRepository.KEY_NOTIFY_PERMISSION_REQUESTS] ?: true,
+                taskCompletions = prefs[SettingsRepository.KEY_NOTIFY_TASK_COMPLETIONS] ?: true,
+                taskErrors = prefs[SettingsRepository.KEY_NOTIFY_TASK_ERRORS] ?: true,
+                hostDisconnections = prefs[SettingsRepository.KEY_NOTIFY_HOST_DISCONNECTIONS] ?: true,
+            )
+        } catch (_: Exception) {
+            NotificationPreferences()
+        }
+    }
+
     override fun onDestroy() {
         eventStream?.disconnect()
         eventStream = null
+        serviceScope.cancel()
         super.onDestroy()
     }
 

--- a/android/app/src/main/java/com/zremote/ui/components/DetailRow.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/DetailRow.kt
@@ -1,0 +1,28 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DetailRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/components/EmptyState.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/EmptyState.kt
@@ -1,0 +1,47 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyState(
+    icon: ImageVector,
+    message: String,
+    modifier: Modifier = Modifier,
+    hint: String? = null,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                icon,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            hint?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/components/ErrorState.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/ErrorState.kt
@@ -1,0 +1,47 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorState(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            Button(
+                onClick = onRetry,
+                modifier = Modifier.padding(top = 16.dp),
+            ) {
+                Text("Retry")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/components/LoadingState.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/LoadingState.kt
@@ -1,0 +1,15 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingState(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/components/RefreshableList.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/RefreshableList.kt
@@ -1,0 +1,26 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RefreshableList(
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: LazyListScope.() -> Unit,
+) {
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        LazyColumn(modifier = Modifier.fillMaxSize(), content = content)
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/components/StatusDot.kt
+++ b/android/app/src/main/java/com/zremote/ui/components/StatusDot.kt
@@ -1,0 +1,23 @@
+package com.zremote.ui.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun StatusDot(
+    color: Color,
+    modifier: Modifier = Modifier,
+    size: Dp = 10.dp,
+) {
+    Surface(
+        shape = CircleShape,
+        color = color,
+        modifier = modifier.size(size),
+    ) {}
+}

--- a/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
@@ -25,8 +25,10 @@ import androidx.navigation.toRoute
 import com.zremote.ui.screens.hosts.HostListScreen
 import com.zremote.ui.screens.loops.LoopDetailScreen
 import com.zremote.ui.screens.loops.LoopListScreen
+import com.zremote.ui.screens.projects.ProjectListScreen
 import com.zremote.ui.screens.sessions.SessionListScreen
 import com.zremote.ui.screens.settings.SettingsScreen
+import com.zremote.ui.screens.tasks.TaskDetailScreen
 import com.zremote.ui.screens.tasks.TaskListScreen
 import com.zremote.ui.screens.terminal.TerminalScreen
 import kotlinx.serialization.Serializable
@@ -37,7 +39,9 @@ import kotlinx.serialization.Serializable
 @Serializable object TasksRoute
 @Serializable object SettingsRoute
 @Serializable data class SessionsRoute(val hostId: String)
+@Serializable data class ProjectsRoute(val hostId: String)
 @Serializable data class LoopDetailRoute(val loopId: String)
+@Serializable data class TaskDetailRoute(val taskId: String)
 @Serializable data class TerminalRoute(val sessionId: String)
 
 data class BottomNavItem(
@@ -88,6 +92,9 @@ fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
                     onHostClick = { hostId ->
                         navController.navigate(SessionsRoute(hostId))
                     },
+                    onProjectsClick = { hostId ->
+                        navController.navigate(ProjectsRoute(hostId))
+                    },
                 )
             }
             composable<SessionsRoute> { backStackEntry ->
@@ -98,6 +105,10 @@ fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
                         navController.navigate(TerminalRoute(sessionId))
                     },
                 )
+            }
+            composable<ProjectsRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<ProjectsRoute>()
+                ProjectListScreen(hostId = route.hostId)
             }
             composable<LoopsRoute> {
                 LoopListScreen(
@@ -111,7 +122,20 @@ fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
                 LoopDetailScreen(loopId = route.loopId)
             }
             composable<TasksRoute> {
-                TaskListScreen()
+                TaskListScreen(
+                    onTaskClick = { taskId ->
+                        navController.navigate(TaskDetailRoute(taskId))
+                    },
+                )
+            }
+            composable<TaskDetailRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<TaskDetailRoute>()
+                TaskDetailScreen(
+                    taskId = route.taskId,
+                    onLoopClick = { loopId ->
+                        navController.navigate(LoopDetailRoute(loopId))
+                    },
+                )
             }
             composable<TerminalRoute> { backStackEntry ->
                 val route = backStackEntry.toRoute<TerminalRoute>()

--- a/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
@@ -92,7 +92,12 @@ fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
             }
             composable<SessionsRoute> { backStackEntry ->
                 val route = backStackEntry.toRoute<SessionsRoute>()
-                SessionListScreen(hostId = route.hostId)
+                SessionListScreen(
+                    hostId = route.hostId,
+                    onSessionClick = { sessionId ->
+                        navController.navigate(TerminalRoute(sessionId))
+                    },
+                )
             }
             composable<LoopsRoute> {
                 LoopListScreen(

--- a/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
@@ -1,0 +1,114 @@
+package com.zremote.ui.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Loop
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import com.zremote.ui.screens.hosts.HostListScreen
+import com.zremote.ui.screens.loops.LoopDetailScreen
+import com.zremote.ui.screens.loops.LoopListScreen
+import com.zremote.ui.screens.sessions.SessionListScreen
+import com.zremote.ui.screens.settings.SettingsScreen
+import com.zremote.ui.screens.tasks.TaskListScreen
+import kotlinx.serialization.Serializable
+
+// Route definitions
+@Serializable object HostsRoute
+@Serializable object LoopsRoute
+@Serializable object TasksRoute
+@Serializable object SettingsRoute
+@Serializable data class SessionsRoute(val hostId: String)
+@Serializable data class LoopDetailRoute(val loopId: String)
+
+data class BottomNavItem(
+    val label: String,
+    val icon: ImageVector,
+    val route: Any,
+)
+
+val bottomNavItems = listOf(
+    BottomNavItem("Hosts", Icons.Default.Computer, HostsRoute),
+    BottomNavItem("Loops", Icons.Default.Loop, LoopsRoute),
+    BottomNavItem("Tasks", Icons.Default.SmartToy, TasksRoute),
+    BottomNavItem("Settings", Icons.Default.Settings, SettingsRoute),
+)
+
+@Composable
+fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                bottomNavItems.forEach { item ->
+                    NavigationBarItem(
+                        icon = { Icon(item.icon, contentDescription = item.label) },
+                        label = { Text(item.label) },
+                        selected = currentDestination?.hasRoute(item.route::class) == true,
+                        onClick = {
+                            navController.navigate(item.route) {
+                                popUpTo(HostsRoute) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                    )
+                }
+            }
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = HostsRoute,
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            composable<HostsRoute> {
+                HostListScreen(
+                    onHostClick = { hostId ->
+                        navController.navigate(SessionsRoute(hostId))
+                    },
+                )
+            }
+            composable<SessionsRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<SessionsRoute>()
+                SessionListScreen(hostId = route.hostId)
+            }
+            composable<LoopsRoute> {
+                LoopListScreen(
+                    onLoopClick = { loopId ->
+                        navController.navigate(LoopDetailRoute(loopId))
+                    },
+                )
+            }
+            composable<LoopDetailRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<LoopDetailRoute>()
+                LoopDetailScreen(loopId = route.loopId)
+            }
+            composable<TasksRoute> {
+                TaskListScreen()
+            }
+            composable<SettingsRoute> {
+                SettingsScreen()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/zremote/ui/navigation/NavGraph.kt
@@ -28,6 +28,7 @@ import com.zremote.ui.screens.loops.LoopListScreen
 import com.zremote.ui.screens.sessions.SessionListScreen
 import com.zremote.ui.screens.settings.SettingsScreen
 import com.zremote.ui.screens.tasks.TaskListScreen
+import com.zremote.ui.screens.terminal.TerminalScreen
 import kotlinx.serialization.Serializable
 
 // Route definitions
@@ -37,6 +38,7 @@ import kotlinx.serialization.Serializable
 @Serializable object SettingsRoute
 @Serializable data class SessionsRoute(val hostId: String)
 @Serializable data class LoopDetailRoute(val loopId: String)
+@Serializable data class TerminalRoute(val sessionId: String)
 
 data class BottomNavItem(
     val label: String,
@@ -105,6 +107,10 @@ fun ZRemoteNavHost(navController: NavHostController = rememberNavController()) {
             }
             composable<TasksRoute> {
                 TaskListScreen()
+            }
+            composable<TerminalRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<TerminalRoute>()
+                TerminalScreen(sessionId = route.sessionId)
             }
             composable<SettingsRoute> {
                 SettingsScreen()

--- a/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
@@ -1,0 +1,142 @@
+package com.zremote.ui.screens.hosts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiHost
+import com.zremote.ui.theme.StatusOffline
+import com.zremote.ui.theme.StatusOnline
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostListScreen(
+    onHostClick: (String) -> Unit,
+    viewModel: HostListViewModel = hiltViewModel(),
+) {
+    val hosts by viewModel.hosts.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
+
+    if (!isConnected) {
+        NotConnectedState()
+        return
+    }
+
+    PullToRefreshBox(
+        isRefreshing = isLoading,
+        onRefresh = { viewModel.refresh() },
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        if (hosts.isEmpty() && !isLoading) {
+            EmptyState(error = error)
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(hosts, key = { it.id }) { host ->
+                    HostCard(host = host, onClick = { onHostClick(host.id) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HostCard(host: FfiHost, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = if (host.status == "online") StatusOnline else StatusOffline,
+                modifier = Modifier.size(10.dp),
+            ) {}
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = host.hostname,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    host.os?.let { os ->
+                        Text(text = os, style = MaterialTheme.typography.bodySmall)
+                    }
+                    host.agentVersion?.let { version ->
+                        Text(text = "v$version", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotConnectedState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.CloudOff,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "Not connected",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            Text(
+                text = "Configure server URL in Settings",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(error: String?) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (error != null) {
+            Text(text = error, color = MaterialTheme.colorScheme.error)
+        } else {
+            Text(text = "No hosts found", style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
@@ -2,28 +2,23 @@ package com.zremote.ui.screens.hosts
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -32,13 +27,18 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zremote.sdk.FfiHost
+import com.zremote.ui.components.EmptyState
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.components.RefreshableList
+import com.zremote.ui.components.StatusDot
 import com.zremote.ui.theme.StatusOffline
 import com.zremote.ui.theme.StatusOnline
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HostListScreen(
     onHostClick: (String) -> Unit,
+    onProjectsClick: (String) -> Unit = {},
     viewModel: HostListViewModel = hiltViewModel(),
 ) {
     val hosts by viewModel.hosts.collectAsStateWithLifecycle()
@@ -47,29 +47,43 @@ fun HostListScreen(
     val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
 
     if (!isConnected) {
-        NotConnectedState()
+        EmptyState(
+            icon = Icons.Default.CloudOff,
+            message = "Not connected",
+            hint = "Configure server URL in Settings",
+        )
         return
     }
 
-    PullToRefreshBox(
-        isRefreshing = isLoading,
-        onRefresh = { viewModel.refresh() },
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        if (hosts.isEmpty() && !isLoading) {
-            EmptyState(error = error)
-        } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(hosts, key = { it.id }) { host ->
-                    HostCard(host = host, onClick = { onHostClick(host.id) })
-                }
+    val currentError = error
+    when {
+        isLoading && hosts.isEmpty() -> LoadingState()
+        currentError != null && hosts.isEmpty() -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
+        )
+        hosts.isEmpty() && !isLoading -> EmptyState(
+            icon = Icons.Default.Dns,
+            message = "No hosts found",
+            hint = "Hosts will appear when agents connect",
+        )
+        else -> RefreshableList(
+            isRefreshing = isLoading,
+            onRefresh = { viewModel.refresh() },
+        ) {
+            items(hosts, key = { it.id }) { host ->
+                HostCard(
+                    host = host,
+                    onClick = { onHostClick(host.id) },
+                    onProjectsClick = { onProjectsClick(host.id) },
+                )
             }
         }
     }
 }
 
 @Composable
-private fun HostCard(host: FfiHost, onClick: () -> Unit) {
+private fun HostCard(host: FfiHost, onClick: () -> Unit, onProjectsClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -80,11 +94,7 @@ private fun HostCard(host: FfiHost, onClick: () -> Unit) {
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Surface(
-                shape = CircleShape,
-                color = if (host.status == "online") StatusOnline else StatusOffline,
-                modifier = Modifier.size(10.dp),
-            ) {}
+            StatusDot(color = if (host.status == "online") StatusOnline else StatusOffline)
 
             Spacer(Modifier.width(12.dp))
 
@@ -102,41 +112,15 @@ private fun HostCard(host: FfiHost, onClick: () -> Unit) {
                     }
                 }
             }
-        }
-    }
-}
 
-@Composable
-private fun NotConnectedState() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                Icons.Default.CloudOff,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = "Not connected",
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(top = 8.dp),
-            )
-            Text(
-                text = "Configure server URL in Settings",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@Composable
-private fun EmptyState(error: String?) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (error != null) {
-            Text(text = error, color = MaterialTheme.colorScheme.error)
-        } else {
-            Text(text = "No hosts found", style = MaterialTheme.typography.bodyLarge)
+            IconButton(onClick = onProjectsClick, modifier = Modifier.size(32.dp)) {
+                Icon(
+                    Icons.Default.Folder,
+                    contentDescription = "Projects",
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,6 +46,12 @@ fun HostListScreen(
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
     val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
+
+    LaunchedEffect(isConnected) {
+        if (isConnected) {
+            viewModel.refresh()
+        }
+    }
 
     if (!isConnected) {
         EmptyState(

--- a/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListViewModel.kt
@@ -1,5 +1,6 @@
 package com.zremote.ui.screens.hosts
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zremote.data.ConnectionManager
@@ -8,7 +9,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -32,14 +35,22 @@ class HostListViewModel @Inject constructor(
     }
 
     fun refresh() {
-        val client = connectionManager.client ?: return
+        val client = connectionManager.client
+        Log.i("ZRemote", "HostListVM.refresh() client=${client != null} isConnected=${isConnected.value}")
+        if (client == null) return
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
             try {
-                _hosts.value = client.listHosts()
+                val result = withContext(Dispatchers.IO) { client.listHosts() }
+                Log.i("ZRemote", "HostListVM.refresh() got ${result.size} hosts")
+                _hosts.value = result
             } catch (e: Exception) {
-                _error.value = e.message
+                Log.e("ZRemote", "HostListVM.refresh() error", e)
+                _error.value = e.message ?: e.toString()
+            } catch (e: Error) {
+                Log.e("ZRemote", "HostListVM.refresh() Error", e)
+                _error.value = e.message ?: e.toString()
             } finally {
                 _isLoading.value = false
             }

--- a/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/hosts/HostListViewModel.kt
@@ -1,0 +1,48 @@
+package com.zremote.ui.screens.hosts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.sdk.FfiHost
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HostListViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val _hosts = MutableStateFlow<List<FfiHost>>(emptyList())
+    val hosts: StateFlow<List<FfiHost>> = _hosts.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    val isConnected = connectionManager.eventRepository.isConnected
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                _hosts.value = client.listHosts()
+            } catch (e: Exception) {
+                _error.value = e.message
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailScreen.kt
@@ -1,22 +1,22 @@
 package com.zremote.ui.screens.loops
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.ui.components.DetailRow
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
 
 @Composable
 fun LoopDetailScreen(
@@ -25,65 +25,52 @@ fun LoopDetailScreen(
 ) {
     val loop by viewModel.loop.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
 
     LaunchedEffect(loopId) {
         viewModel.loadLoop(loopId)
     }
 
-    if (isLoading) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
-        }
-        return
-    }
-
-    val loopData = loop
-    if (loopData == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Loop not found")
-        }
-        return
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-    ) {
-        Text(
-            text = loopData.taskName ?: loopData.toolName,
-            style = MaterialTheme.typography.headlineMedium,
+    val currentError = error
+    when {
+        isLoading -> LoadingState()
+        currentError != null && loop == null -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
         )
+        else -> {
+            val loopData = loop
+            if (loopData == null) {
+                LoadingState()
+                return
+            }
 
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 16.dp),
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                DetailRow("Status", loopData.status.name.lowercase().replace('_', ' '))
-                DetailRow("Tool", loopData.toolName)
-                DetailRow("Session", loopData.sessionId.take(8))
-                DetailRow("Started", loopData.startedAt)
-                loopData.endedAt?.let { DetailRow("Ended", it) }
-                loopData.endReason?.let { DetailRow("End reason", it) }
-                loopData.projectPath?.let { DetailRow("Project", it) }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            ) {
+                Text(
+                    text = loopData.taskName ?: loopData.toolName,
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        DetailRow("Status", loopData.status.name.lowercase().replace('_', ' '))
+                        DetailRow("Tool", loopData.toolName)
+                        DetailRow("Session", loopData.sessionId.take(8))
+                        DetailRow("Started", loopData.startedAt)
+                        loopData.endedAt?.let { DetailRow("Ended", it) }
+                        loopData.endReason?.let { DetailRow("End reason", it) }
+                        loopData.projectPath?.let { DetailRow("Project", it) }
+                    }
+                }
             }
         }
-    }
-}
-
-@Composable
-private fun DetailRow(label: String, value: String) {
-    Column(modifier = Modifier.padding(vertical = 4.dp)) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyLarge,
-        )
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailScreen.kt
@@ -1,0 +1,89 @@
+package com.zremote.ui.screens.loops
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun LoopDetailScreen(
+    loopId: String,
+    viewModel: LoopDetailViewModel = hiltViewModel(),
+) {
+    val loop by viewModel.loop.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+
+    LaunchedEffect(loopId) {
+        viewModel.loadLoop(loopId)
+    }
+
+    if (isLoading) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    val loopData = loop
+    if (loopData == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Loop not found")
+        }
+        return
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            text = loopData.taskName ?: loopData.toolName,
+            style = MaterialTheme.typography.headlineMedium,
+        )
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                DetailRow("Status", loopData.status.name.lowercase().replace('_', ' '))
+                DetailRow("Tool", loopData.toolName)
+                DetailRow("Session", loopData.sessionId.take(8))
+                DetailRow("Started", loopData.startedAt)
+                loopData.endedAt?.let { DetailRow("Ended", it) }
+                loopData.endReason?.let { DetailRow("End reason", it) }
+                loopData.projectPath?.let { DetailRow("Project", it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailViewModel.kt
@@ -1,0 +1,38 @@
+package com.zremote.ui.screens.loops
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.sdk.FfiAgenticLoop
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoopDetailViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val _loop = MutableStateFlow<FfiAgenticLoop?>(null)
+    val loop: StateFlow<FfiAgenticLoop?> = _loop.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    fun loadLoop(loopId: String) {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _loop.value = client.getLoop(loopId)
+            } catch (_: Exception) {
+                _loop.value = null
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt
@@ -4,11 +4,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Loop
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,6 +20,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zremote.sdk.FfiAgenticLoop
 import com.zremote.sdk.FfiAgenticStatus
+import com.zremote.ui.components.EmptyState
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.components.RefreshableList
 import com.zremote.ui.theme.StatusCompleted
 import com.zremote.ui.theme.StatusError
 import com.zremote.ui.theme.StatusOffline
@@ -32,10 +36,28 @@ fun LoopListScreen(
     viewModel: LoopListViewModel = hiltViewModel(),
 ) {
     val loops by viewModel.loops.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(loops, key = { it.id }) { loop ->
-            LoopCard(loop = loop, onClick = { onLoopClick(loop.id) })
+    val currentError = error
+    when {
+        isLoading && loops.isEmpty() -> LoadingState()
+        currentError != null && loops.isEmpty() -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
+        )
+        loops.isEmpty() && !isLoading -> EmptyState(
+            icon = Icons.Default.Loop,
+            message = "No agentic loops",
+            hint = "Loops will appear when agents are running",
+        )
+        else -> RefreshableList(
+            isRefreshing = isLoading,
+            onRefresh = { viewModel.refresh() },
+        ) {
+            items(loops, key = { it.id }) { loop ->
+                LoopCard(loop = loop, onClick = { onLoopClick(loop.id) })
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt
@@ -1,0 +1,92 @@
+package com.zremote.ui.screens.loops
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiAgenticLoop
+import com.zremote.sdk.FfiAgenticStatus
+import com.zremote.ui.theme.StatusCompleted
+import com.zremote.ui.theme.StatusError
+import com.zremote.ui.theme.StatusOffline
+import com.zremote.ui.theme.StatusWaitingForInput
+import com.zremote.ui.theme.StatusWorking
+
+@Composable
+fun LoopListScreen(
+    onLoopClick: (String) -> Unit,
+    viewModel: LoopListViewModel = hiltViewModel(),
+) {
+    val loops by viewModel.loops.collectAsStateWithLifecycle()
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(loops, key = { it.id }) { loop ->
+            LoopCard(loop = loop, onClick = { onLoopClick(loop.id) })
+        }
+    }
+}
+
+@Composable
+private fun LoopCard(loop: FfiAgenticLoop, onClick: () -> Unit) {
+    val statusColor = when (loop.status) {
+        FfiAgenticStatus.WORKING -> StatusWorking
+        FfiAgenticStatus.WAITING_FOR_INPUT -> StatusWaitingForInput
+        FfiAgenticStatus.ERROR -> StatusError
+        FfiAgenticStatus.COMPLETED -> StatusCompleted
+        FfiAgenticStatus.UNKNOWN -> StatusOffline
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = loop.taskName ?: loop.toolName,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = loop.status.name.lowercase().replace('_', ' '),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = statusColor,
+                )
+            }
+
+            loop.projectPath?.let { path ->
+                Text(
+                    text = path,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+
+            Text(
+                text = "Started: ${loop.startedAt}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListViewModel.kt
@@ -30,6 +30,9 @@ class LoopListViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         refresh()
     }
@@ -38,12 +41,13 @@ class LoopListViewModel @Inject constructor(
         val client = connectionManager.client ?: return
         viewModelScope.launch {
             _isLoading.value = true
+            _error.value = null
             try {
                 _loops.value = client.listLoops(FfiListLoopsFilter(
                     status = null, hostId = null, sessionId = null, projectId = null,
                 ))
-            } catch (_: Exception) {
-                _loops.value = emptyList()
+            } catch (e: Exception) {
+                _error.value = e.message
             } finally {
                 _isLoading.value = false
             }

--- a/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/loops/LoopListViewModel.kt
@@ -1,0 +1,52 @@
+package com.zremote.ui.screens.loops
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.data.ZRemoteEventRepository
+import com.zremote.sdk.FfiAgenticLoop
+import com.zremote.sdk.FfiClaudeSessionMetrics
+import com.zremote.sdk.FfiListLoopsFilter
+import com.zremote.sdk.FfiLoopInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoopListViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+    private val eventRepository: ZRemoteEventRepository,
+) : ViewModel() {
+
+    private val _loops = MutableStateFlow<List<FfiAgenticLoop>>(emptyList())
+    val loops: StateFlow<List<FfiAgenticLoop>> = _loops.asStateFlow()
+
+    val realtimeLoops: StateFlow<List<FfiLoopInfo>> = eventRepository.loops
+    val sessionMetrics: StateFlow<Map<String, FfiClaudeSessionMetrics>> = eventRepository.sessionMetrics
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _loops.value = client.listLoops(FfiListLoopsFilter(
+                    status = null, hostId = null, sessionId = null, projectId = null,
+                ))
+            } catch (_: Exception) {
+                _loops.value = emptyList()
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListScreen.kt
@@ -119,16 +119,16 @@ private fun ProjectCard(project: FfiProject, onGitRefresh: () -> Unit) {
                         style = MaterialTheme.typography.bodyMedium,
                         color = StatusWorking,
                     )
-                    if (project.gitDirty) {
+                    if (project.gitIsDirty) {
                         Text(
                             text = "dirty",
                             style = MaterialTheme.typography.labelSmall,
                             color = StatusError,
                         )
                     }
-                    project.gitAheadBehind?.let { ab ->
+                    if (project.gitAhead > 0 || project.gitBehind > 0) {
                         Text(
-                            text = ab,
+                            text = "+${project.gitAhead} -${project.gitBehind}",
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListScreen.kt
@@ -1,0 +1,158 @@
+package com.zremote.ui.screens.projects
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiProject
+import com.zremote.ui.components.EmptyState
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.components.RefreshableList
+import com.zremote.ui.theme.StatusError
+import com.zremote.ui.theme.StatusOnline
+import com.zremote.ui.theme.StatusWorking
+
+@Composable
+fun ProjectListScreen(
+    hostId: String,
+    viewModel: ProjectListViewModel = hiltViewModel(),
+) {
+    val projects by viewModel.projects.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+
+    LaunchedEffect(hostId) {
+        viewModel.loadProjects(hostId)
+    }
+
+    val currentError = error
+    when {
+        isLoading && projects.isEmpty() -> LoadingState()
+        currentError != null && projects.isEmpty() -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
+        )
+        projects.isEmpty() && !isLoading -> EmptyState(
+            icon = Icons.Default.Folder,
+            message = "No projects",
+            hint = "Tap refresh to scan for projects on this host",
+        )
+        else -> RefreshableList(
+            isRefreshing = isLoading,
+            onRefresh = { viewModel.refresh() },
+        ) {
+            items(projects, key = { it.id }) { project ->
+                ProjectCard(
+                    project = project,
+                    onGitRefresh = { viewModel.triggerGitRefresh(project.id) },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ProjectCard(project: FfiProject, onGitRefresh: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = project.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onGitRefresh, modifier = Modifier.size(32.dp)) {
+                    Icon(
+                        Icons.Default.Refresh,
+                        contentDescription = "Refresh git status",
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+
+            Text(
+                text = project.path,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            project.gitBranch?.let { branch ->
+                Row(
+                    modifier = Modifier.padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = branch,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = StatusWorking,
+                    )
+                    if (project.gitDirty) {
+                        Text(
+                            text = "dirty",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = StatusError,
+                        )
+                    }
+                    project.gitAheadBehind?.let { ab ->
+                        Text(
+                            text = ab,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            FlowRow(
+                modifier = Modifier.padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (project.hasClaudeConfig) {
+                    AssistChip(
+                        onClick = {},
+                        label = { Text("Claude", style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+                if (project.hasZremoteConfig) {
+                    AssistChip(
+                        onClick = {},
+                        label = { Text("ZRemote", style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListViewModel.kt
@@ -1,10 +1,9 @@
-package com.zremote.ui.screens.sessions
+package com.zremote.ui.screens.projects
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zremote.data.ConnectionManager
-import com.zremote.sdk.FfiCreateSessionRequest
-import com.zremote.sdk.FfiSession
+import com.zremote.sdk.FfiProject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,12 +12,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SessionListViewModel @Inject constructor(
+class ProjectListViewModel @Inject constructor(
     private val connectionManager: ConnectionManager,
 ) : ViewModel() {
 
-    private val _sessions = MutableStateFlow<List<FfiSession>>(emptyList())
-    val sessions: StateFlow<List<FfiSession>> = _sessions.asStateFlow()
+    private val _projects = MutableStateFlow<List<FfiProject>>(emptyList())
+    val projects: StateFlow<List<FfiProject>> = _projects.asStateFlow()
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -26,12 +25,9 @@ class SessionListViewModel @Inject constructor(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
-    private val _createdSessionId = MutableStateFlow<String?>(null)
-    val createdSessionId: StateFlow<String?> = _createdSessionId.asStateFlow()
-
     private var currentHostId: String? = null
 
-    fun loadSessions(hostId: String) {
+    fun loadProjects(hostId: String) {
         currentHostId = hostId
         refresh()
     }
@@ -43,7 +39,7 @@ class SessionListViewModel @Inject constructor(
             _isLoading.value = true
             _error.value = null
             try {
-                _sessions.value = client.listSessions(hostId)
+                _projects.value = client.listProjects(hostId)
             } catch (e: Exception) {
                 _error.value = e.message
             } finally {
@@ -52,23 +48,12 @@ class SessionListViewModel @Inject constructor(
         }
     }
 
-    fun createSession(hostId: String, shell: String?, workingDir: String?) {
+    fun triggerScan() {
+        val hostId = currentHostId ?: return
         val client = connectionManager.client ?: return
         viewModelScope.launch {
-            _error.value = null
             try {
-                // Initial dimensions; TerminalScreen sends a resize once layout is measured
-                val response = client.createSession(
-                    hostId,
-                    FfiCreateSessionRequest(
-                        name = null,
-                        shell = shell,
-                        cols = DEFAULT_COLS,
-                        rows = DEFAULT_ROWS,
-                        workingDir = workingDir,
-                    ),
-                )
-                _createdSessionId.value = response.id
+                client.triggerScan(hostId)
                 refresh()
             } catch (e: Exception) {
                 _error.value = e.message
@@ -76,12 +61,15 @@ class SessionListViewModel @Inject constructor(
         }
     }
 
-    fun clearCreatedSession() {
-        _createdSessionId.value = null
-    }
-
-    companion object {
-        private const val DEFAULT_COLS: UShort = 80u
-        private const val DEFAULT_ROWS: UShort = 24u
+    fun triggerGitRefresh(projectId: String) {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            try {
+                client.triggerGitRefresh(projectId)
+                refresh()
+            } catch (e: Exception) {
+                _error.value = e.message
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
@@ -32,9 +32,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiClaudeSessionMetrics
+import com.zremote.sdk.FfiClaudeTask
+import com.zremote.sdk.FfiClaudeTaskStatus
 import com.zremote.sdk.FfiSession
 import com.zremote.ui.components.EmptyState
 import com.zremote.ui.components.ErrorState
@@ -44,6 +48,8 @@ import com.zremote.ui.components.StatusDot
 import com.zremote.ui.theme.StatusCompleted
 import com.zremote.ui.theme.StatusOffline
 import com.zremote.ui.theme.StatusOnline
+import com.zremote.ui.theme.StatusWaitingForInput
+import com.zremote.ui.theme.StatusWorking
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +59,8 @@ fun SessionListScreen(
     viewModel: SessionListViewModel = hiltViewModel(),
 ) {
     val sessions by viewModel.sessions.collectAsStateWithLifecycle()
+    val claudeTasks by viewModel.claudeTasks.collectAsStateWithLifecycle()
+    val sessionMetrics by viewModel.sessionMetrics.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
     val createdSessionId by viewModel.createdSessionId.collectAsStateWithLifecycle()
@@ -80,7 +88,7 @@ fun SessionListScreen(
             )
             sessions.isEmpty() && !isLoading -> EmptyState(
                 icon = Icons.Default.Terminal,
-                message = "No sessions",
+                message = "No active sessions",
                 hint = "Tap + to create a new terminal session",
             )
             else -> RefreshableList(
@@ -90,6 +98,8 @@ fun SessionListScreen(
                 items(sessions, key = { it.id }) { session ->
                     SessionCard(
                         session = session,
+                        claudeTask = claudeTasks[session.id],
+                        metrics = sessionMetrics[session.id],
                         onClick = { onSessionClick(session.id) },
                     )
                 }
@@ -179,11 +189,15 @@ private fun CreateSessionSheet(
 }
 
 @Composable
-private fun SessionCard(session: FfiSession, onClick: () -> Unit) {
+private fun SessionCard(
+    session: FfiSession,
+    claudeTask: FfiClaudeTask?,
+    metrics: FfiClaudeSessionMetrics?,
+    onClick: () -> Unit,
+) {
     val statusColor = when (session.status) {
         "active" -> StatusOnline
-        "closed" -> StatusOffline
-        "suspended" -> StatusCompleted
+        "suspended" -> StatusWaitingForInput
         else -> StatusOffline
     }
 
@@ -194,24 +208,103 @@ private fun SessionCard(session: FfiSession, onClick: () -> Unit) {
             .clickable(onClick = onClick),
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top,
         ) {
             StatusDot(color = statusColor)
 
             Spacer(Modifier.width(12.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = session.name ?: "Session ${session.id.take(8)}",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = "${session.status} | ${session.shell ?: "unknown shell"}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                // Line 1: shell + status
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = session.shell ?: session.name ?: "Session ${session.id.take(8)}",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = session.status,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                // Line 2: working directory
+                session.workingDir?.let { dir ->
+                    Text(
+                        text = shortenPath(dir),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                // Line 3+: Claude Code info
+                if (claudeTask != null) {
+                    Spacer(Modifier.height(4.dp))
+                    ClaudeTaskInfo(task = claudeTask, metrics = metrics)
+                }
             }
         }
     }
+}
+
+@Composable
+private fun ClaudeTaskInfo(
+    task: FfiClaudeTask,
+    metrics: FfiClaudeSessionMetrics?,
+) {
+    val statusColor = when (task.status) {
+        FfiClaudeTaskStatus.STARTING, FfiClaudeTaskStatus.ACTIVE -> StatusWorking
+        FfiClaudeTaskStatus.COMPLETED -> StatusCompleted
+        FfiClaudeTaskStatus.ERROR -> StatusOffline
+    }
+
+    val parts = buildList {
+        add(task.status.name.lowercase())
+        task.model?.let { add(shortenModelName(it)) }
+        val cost = task.totalCostUsd ?: metrics?.costUsd
+        if (cost != null) add("$${String.format("%.2f", cost)}")
+        metrics?.contextUsedPct?.let { add("ctx ${it.toInt()}%") }
+    }
+
+    Text(
+        text = "CC: ${parts.joinToString(" | ")}",
+        style = MaterialTheme.typography.labelSmall,
+        color = statusColor,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+
+    task.initialPrompt?.let { prompt ->
+        if (prompt.isNotBlank()) {
+            Text(
+                text = "\"${prompt.take(50)}${if (prompt.length > 50) "..." else ""}\"",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+private fun shortenPath(path: String): String {
+    val normalized = path.replace(Regex("^/home/[^/]+"), "~")
+    val parts = normalized.split("/")
+    return if (parts.size > 2) {
+        parts.takeLast(2).joinToString("/")
+    } else {
+        normalized
+    }
+}
+
+private fun shortenModelName(model: String): String {
+    // "claude-sonnet-4-5-20250514" -> "sonnet-4.5"
+    val withoutPrefix = model.removePrefix("claude-")
+    val withoutDate = withoutPrefix.replace(Regex("-\\d{8}$"), "")
+    // Convert "sonnet-4-5" -> "sonnet-4.5"
+    return withoutDate.replace(Regex("(\\d+)-(\\d+)$"), "$1.$2")
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
@@ -1,5 +1,6 @@
 package com.zremote.ui.screens.sessions
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -31,6 +32,7 @@ import com.zremote.ui.theme.StatusOnline
 @Composable
 fun SessionListScreen(
     hostId: String,
+    onSessionClick: (String) -> Unit = {},
     viewModel: SessionListViewModel = hiltViewModel(),
 ) {
     val sessions by viewModel.sessions.collectAsStateWithLifecycle()
@@ -41,13 +43,16 @@ fun SessionListScreen(
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         items(sessions, key = { it.id }) { session ->
-            SessionCard(session)
+            SessionCard(
+                session = session,
+                onClick = { onSessionClick(session.id) },
+            )
         }
     }
 }
 
 @Composable
-private fun SessionCard(session: FfiSession) {
+private fun SessionCard(session: FfiSession, onClick: () -> Unit) {
     val statusColor = when (session.status) {
         "active" -> StatusOnline
         "closed" -> StatusOffline
@@ -58,7 +63,8 @@ private fun SessionCard(session: FfiSession) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
@@ -1,0 +1,88 @@
+package com.zremote.ui.screens.sessions
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiSession
+import com.zremote.ui.theme.StatusCompleted
+import com.zremote.ui.theme.StatusOffline
+import com.zremote.ui.theme.StatusOnline
+
+@Composable
+fun SessionListScreen(
+    hostId: String,
+    viewModel: SessionListViewModel = hiltViewModel(),
+) {
+    val sessions by viewModel.sessions.collectAsStateWithLifecycle()
+
+    LaunchedEffect(hostId) {
+        viewModel.loadSessions(hostId)
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(sessions, key = { it.id }) { session ->
+            SessionCard(session)
+        }
+    }
+}
+
+@Composable
+private fun SessionCard(session: FfiSession) {
+    val statusColor = when (session.status) {
+        "active" -> StatusOnline
+        "closed" -> StatusOffline
+        "suspended" -> StatusCompleted
+        else -> StatusOffline
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = statusColor,
+                modifier = Modifier.size(10.dp),
+            ) {}
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = session.name ?: "Session ${session.id.take(8)}",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "${session.status} | ${session.shell ?: "unknown shell"}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt
@@ -1,34 +1,51 @@
 package com.zremote.ui.screens.sessions
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zremote.sdk.FfiSession
+import com.zremote.ui.components.EmptyState
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.components.RefreshableList
+import com.zremote.ui.components.StatusDot
 import com.zremote.ui.theme.StatusCompleted
 import com.zremote.ui.theme.StatusOffline
 import com.zremote.ui.theme.StatusOnline
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionListScreen(
     hostId: String,
@@ -36,17 +53,127 @@ fun SessionListScreen(
     viewModel: SessionListViewModel = hiltViewModel(),
 ) {
     val sessions by viewModel.sessions.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val createdSessionId by viewModel.createdSessionId.collectAsStateWithLifecycle()
+
+    var showCreateSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(hostId) {
         viewModel.loadSessions(hostId)
     }
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(sessions, key = { it.id }) { session ->
-            SessionCard(
-                session = session,
-                onClick = { onSessionClick(session.id) },
+    LaunchedEffect(createdSessionId) {
+        createdSessionId?.let { sessionId ->
+            viewModel.clearCreatedSession()
+            onSessionClick(sessionId)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        val currentError = error
+        when {
+            isLoading && sessions.isEmpty() -> LoadingState()
+            currentError != null && sessions.isEmpty() -> ErrorState(
+                message = currentError,
+                onRetry = { viewModel.refresh() },
             )
+            sessions.isEmpty() && !isLoading -> EmptyState(
+                icon = Icons.Default.Terminal,
+                message = "No sessions",
+                hint = "Tap + to create a new terminal session",
+            )
+            else -> RefreshableList(
+                isRefreshing = isLoading,
+                onRefresh = { viewModel.refresh() },
+            ) {
+                items(sessions, key = { it.id }) { session ->
+                    SessionCard(
+                        session = session,
+                        onClick = { onSessionClick(session.id) },
+                    )
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = { showCreateSheet = true },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        ) {
+            Icon(Icons.Default.Add, contentDescription = "New session")
+        }
+    }
+
+    if (showCreateSheet) {
+        CreateSessionSheet(
+            onDismiss = { showCreateSheet = false },
+            onCreate = { shell, workingDir ->
+                showCreateSheet = false
+                viewModel.createSession(hostId, shell, workingDir)
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateSessionSheet(
+    onDismiss: () -> Unit,
+    onCreate: (shell: String?, workingDir: String?) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    var shell by remember { mutableStateOf("") }
+    var workingDir by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Text(
+                text = "New terminal session",
+                style = MaterialTheme.typography.headlineMedium,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = shell,
+                onValueChange = { shell = it },
+                label = { Text("Shell") },
+                placeholder = { Text("Default shell") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = workingDir,
+                onValueChange = { workingDir = it },
+                label = { Text("Working directory") },
+                placeholder = { Text("Home directory") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    onCreate(
+                        shell.ifBlank { null },
+                        workingDir.ifBlank { null },
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Create session")
+            }
+
+            Spacer(Modifier.height(24.dp))
         }
     }
 }
@@ -70,11 +197,7 @@ private fun SessionCard(session: FfiSession, onClick: () -> Unit) {
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Surface(
-                shape = CircleShape,
-                color = statusColor,
-                modifier = Modifier.size(10.dp),
-            ) {}
+            StatusDot(color = statusColor)
 
             Spacer(Modifier.width(12.dp))
 

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListViewModel.kt
@@ -3,13 +3,18 @@ package com.zremote.ui.screens.sessions
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zremote.data.ConnectionManager
+import com.zremote.sdk.FfiClaudeSessionMetrics
+import com.zremote.sdk.FfiClaudeTask
 import com.zremote.sdk.FfiCreateSessionRequest
+import com.zremote.sdk.FfiListClaudeTasksFilter
 import com.zremote.sdk.FfiSession
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,6 +24,12 @@ class SessionListViewModel @Inject constructor(
 
     private val _sessions = MutableStateFlow<List<FfiSession>>(emptyList())
     val sessions: StateFlow<List<FfiSession>> = _sessions.asStateFlow()
+
+    private val _claudeTasks = MutableStateFlow<Map<String, FfiClaudeTask>>(emptyMap())
+    val claudeTasks: StateFlow<Map<String, FfiClaudeTask>> = _claudeTasks.asStateFlow()
+
+    val sessionMetrics: StateFlow<Map<String, FfiClaudeSessionMetrics>> =
+        connectionManager.eventRepository.sessionMetrics
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -43,7 +54,21 @@ class SessionListViewModel @Inject constructor(
             _isLoading.value = true
             _error.value = null
             try {
-                _sessions.value = client.listSessions(hostId)
+                val allSessions = withContext(Dispatchers.IO) {
+                    client.listSessions(hostId)
+                }
+                _sessions.value = allSessions.filter { it.status != "closed" }
+
+                val tasks = withContext(Dispatchers.IO) {
+                    client.listClaudeTasks(
+                        FfiListClaudeTasksFilter(
+                            hostId = hostId,
+                            status = null,
+                            projectId = null,
+                        ),
+                    )
+                }
+                _claudeTasks.value = tasks.associateBy { it.sessionId }
             } catch (e: Exception) {
                 _error.value = e.message
             } finally {

--- a/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListViewModel.kt
@@ -1,0 +1,38 @@
+package com.zremote.ui.screens.sessions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.sdk.FfiSession
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SessionListViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val _sessions = MutableStateFlow<List<FfiSession>>(emptyList())
+    val sessions: StateFlow<List<FfiSession>> = _sessions.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    fun loadSessions(hostId: String) {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _sessions.value = client.listSessions(hostId)
+            } catch (_: Exception) {
+                _sessions.value = emptyList()
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsScreen.kt
@@ -1,18 +1,24 @@
 package com.zremote.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -26,10 +32,18 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
     val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
     val connectionError by viewModel.connectionError.collectAsStateWithLifecycle()
 
+    val notifyLoopCompletions by viewModel.notifyLoopCompletions.collectAsStateWithLifecycle()
+    val notifyLoopErrors by viewModel.notifyLoopErrors.collectAsStateWithLifecycle()
+    val notifyPermissionRequests by viewModel.notifyPermissionRequests.collectAsStateWithLifecycle()
+    val notifyTaskCompletions by viewModel.notifyTaskCompletions.collectAsStateWithLifecycle()
+    val notifyTaskErrors by viewModel.notifyTaskErrors.collectAsStateWithLifecycle()
+    val notifyHostDisconnections by viewModel.notifyHostDisconnections.collectAsStateWithLifecycle()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
     ) {
         Text(
             text = "Server Connection",
@@ -84,5 +98,81 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
                 Text("Connect")
             }
         }
+
+        Spacer(Modifier.height(32.dp))
+        HorizontalDivider()
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = "Notifications",
+            style = MaterialTheme.typography.headlineMedium,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = "Choose which events trigger notifications when the app is in the background.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        NotificationToggle(
+            label = "Loop completions",
+            checked = notifyLoopCompletions,
+            onCheckedChange = { viewModel.setNotifyLoopCompletions(it) },
+        )
+        NotificationToggle(
+            label = "Loop errors",
+            checked = notifyLoopErrors,
+            onCheckedChange = { viewModel.setNotifyLoopErrors(it) },
+        )
+        NotificationToggle(
+            label = "Permission requests",
+            checked = notifyPermissionRequests,
+            onCheckedChange = { viewModel.setNotifyPermissionRequests(it) },
+        )
+        NotificationToggle(
+            label = "Task completions",
+            checked = notifyTaskCompletions,
+            onCheckedChange = { viewModel.setNotifyTaskCompletions(it) },
+        )
+        NotificationToggle(
+            label = "Task errors",
+            checked = notifyTaskErrors,
+            onCheckedChange = { viewModel.setNotifyTaskErrors(it) },
+        )
+        NotificationToggle(
+            label = "Host disconnections",
+            checked = notifyHostDisconnections,
+            onCheckedChange = { viewModel.setNotifyHostDisconnections(it) },
+        )
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun NotificationToggle(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsScreen.kt
@@ -1,0 +1,88 @@
+package com.zremote.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.ui.theme.StatusError
+import com.zremote.ui.theme.StatusOnline
+
+@Composable
+fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
+    val serverUrl by viewModel.serverUrl.collectAsStateWithLifecycle()
+    val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
+    val connectionError by viewModel.connectionError.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            text = "Server Connection",
+            style = MaterialTheme.typography.headlineMedium,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = serverUrl,
+            onValueChange = { viewModel.updateServerUrl(it) },
+            label = { Text("Server URL") },
+            placeholder = { Text("http://localhost:3000") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        if (isConnected) {
+            Text(
+                text = "Connected",
+                color = StatusOnline,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        connectionError?.let { error ->
+            Text(
+                text = error,
+                color = StatusError,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        if (isConnected) {
+            OutlinedButton(
+                onClick = { viewModel.disconnect() },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Disconnect")
+            }
+        } else {
+            Button(
+                onClick = { viewModel.connect() },
+                enabled = serverUrl.isNotBlank(),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Connect")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsViewModel.kt
@@ -1,0 +1,51 @@
+package com.zremote.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.data.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val _serverUrl = MutableStateFlow("")
+    val serverUrl: StateFlow<String> = _serverUrl.asStateFlow()
+
+    val isConnected = connectionManager.eventRepository.isConnected
+    val connectionError = connectionManager.connectionError
+
+    init {
+        viewModelScope.launch {
+            settingsRepository.serverUrl.collect { url ->
+                _serverUrl.value = url
+            }
+        }
+    }
+
+    fun updateServerUrl(url: String) {
+        _serverUrl.value = url
+        viewModelScope.launch {
+            settingsRepository.setServerUrl(url)
+        }
+    }
+
+    fun connect() {
+        val url = _serverUrl.value
+        if (url.isNotBlank()) {
+            connectionManager.connect(url)
+        }
+    }
+
+    fun disconnect() {
+        connectionManager.disconnect()
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/settings/SettingsViewModel.kt
@@ -23,11 +23,47 @@ class SettingsViewModel @Inject constructor(
     val isConnected = connectionManager.eventRepository.isConnected
     val connectionError = connectionManager.connectionError
 
+    private val _notifyLoopCompletions = MutableStateFlow(true)
+    val notifyLoopCompletions: StateFlow<Boolean> = _notifyLoopCompletions.asStateFlow()
+
+    private val _notifyLoopErrors = MutableStateFlow(true)
+    val notifyLoopErrors: StateFlow<Boolean> = _notifyLoopErrors.asStateFlow()
+
+    private val _notifyPermissionRequests = MutableStateFlow(true)
+    val notifyPermissionRequests: StateFlow<Boolean> = _notifyPermissionRequests.asStateFlow()
+
+    private val _notifyTaskCompletions = MutableStateFlow(true)
+    val notifyTaskCompletions: StateFlow<Boolean> = _notifyTaskCompletions.asStateFlow()
+
+    private val _notifyTaskErrors = MutableStateFlow(true)
+    val notifyTaskErrors: StateFlow<Boolean> = _notifyTaskErrors.asStateFlow()
+
+    private val _notifyHostDisconnections = MutableStateFlow(true)
+    val notifyHostDisconnections: StateFlow<Boolean> = _notifyHostDisconnections.asStateFlow()
+
     init {
         viewModelScope.launch {
             settingsRepository.serverUrl.collect { url ->
                 _serverUrl.value = url
             }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyLoopCompletions.collect { _notifyLoopCompletions.value = it }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyLoopErrors.collect { _notifyLoopErrors.value = it }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyPermissionRequests.collect { _notifyPermissionRequests.value = it }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyTaskCompletions.collect { _notifyTaskCompletions.value = it }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyTaskErrors.collect { _notifyTaskErrors.value = it }
+        }
+        viewModelScope.launch {
+            settingsRepository.notifyHostDisconnections.collect { _notifyHostDisconnections.value = it }
         }
     }
 
@@ -47,5 +83,35 @@ class SettingsViewModel @Inject constructor(
 
     fun disconnect() {
         connectionManager.disconnect()
+    }
+
+    fun setNotifyLoopCompletions(enabled: Boolean) {
+        _notifyLoopCompletions.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyLoopCompletions(enabled) }
+    }
+
+    fun setNotifyLoopErrors(enabled: Boolean) {
+        _notifyLoopErrors.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyLoopErrors(enabled) }
+    }
+
+    fun setNotifyPermissionRequests(enabled: Boolean) {
+        _notifyPermissionRequests.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyPermissionRequests(enabled) }
+    }
+
+    fun setNotifyTaskCompletions(enabled: Boolean) {
+        _notifyTaskCompletions.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyTaskCompletions(enabled) }
+    }
+
+    fun setNotifyTaskErrors(enabled: Boolean) {
+        _notifyTaskErrors.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyTaskErrors(enabled) }
+    }
+
+    fun setNotifyHostDisconnections(enabled: Boolean) {
+        _notifyHostDisconnections.value = enabled
+        viewModelScope.launch { settingsRepository.setNotifyHostDisconnections(enabled) }
     }
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailScreen.kt
@@ -1,0 +1,178 @@
+package com.zremote.ui.screens.tasks
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiClaudeTaskStatus
+import com.zremote.ui.components.DetailRow
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.theme.StatusCompleted
+import com.zremote.ui.theme.StatusError
+import com.zremote.ui.theme.StatusWorking
+
+@Composable
+fun TaskDetailScreen(
+    taskId: String,
+    onLoopClick: ((String) -> Unit)? = null,
+    viewModel: TaskDetailViewModel = hiltViewModel(),
+) {
+    val task by viewModel.task.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+
+    LaunchedEffect(taskId) {
+        viewModel.loadTask(taskId)
+    }
+
+    val currentError = error
+    when {
+        isLoading -> LoadingState()
+        currentError != null && task == null -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
+        )
+        else -> {
+            val taskData = task
+            if (taskData == null) {
+                LoadingState()
+                return
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                Text(
+                    text = taskData.taskName ?: taskData.initialPrompt?.take(80) ?: "Task ${taskData.id.take(8)}",
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+
+                val statusColor = when (taskData.status) {
+                    FfiClaudeTaskStatus.STARTING -> StatusWorking
+                    FfiClaudeTaskStatus.ACTIVE -> StatusWorking
+                    FfiClaudeTaskStatus.COMPLETED -> StatusCompleted
+                    FfiClaudeTaskStatus.ERROR -> StatusError
+                }
+                Text(
+                    text = taskData.status.name.lowercase(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = statusColor,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Details", style = MaterialTheme.typography.titleMedium)
+                        Spacer(Modifier.height(8.dp))
+                        taskData.model?.let { DetailRow("Model", it) }
+                        DetailRow("Project", taskData.projectPath)
+                        DetailRow("Started", taskData.startedAt)
+                        taskData.endedAt?.let { DetailRow("Ended", it) }
+                        DetailRow("Session", taskData.sessionId.take(8))
+                    }
+                }
+
+                taskData.totalCostUsd?.let { cost ->
+                    Spacer(Modifier.height(12.dp))
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("Usage", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.height(8.dp))
+                            DetailRow("Cost", "$${String.format("%.4f", cost)}")
+                            taskData.totalTokensIn?.let { DetailRow("Tokens in", it.toString()) }
+                            taskData.totalTokensOut?.let { DetailRow("Tokens out", it.toString()) }
+                        }
+                    }
+                }
+
+                taskData.initialPrompt?.let { prompt ->
+                    Spacer(Modifier.height(12.dp))
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("Initial prompt", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = prompt,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+
+                taskData.summary?.let { summary ->
+                    Spacer(Modifier.height(12.dp))
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("Summary", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = summary,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+
+                taskData.loopId?.let { loopId ->
+                    Spacer(Modifier.height(12.dp))
+                    Card(
+                        onClick = { onLoopClick?.invoke(loopId) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("Associated loop", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.height(8.dp))
+                            DetailRow("Loop ID", loopId.take(8))
+                            if (onLoopClick != null) {
+                                Text(
+                                    text = "Tap to view loop details",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "Permission approval",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "Approve/deny tool calls requires server v0.8+",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailViewModel.kt
@@ -1,9 +1,9 @@
-package com.zremote.ui.screens.loops
+package com.zremote.ui.screens.tasks
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zremote.data.ConnectionManager
-import com.zremote.sdk.FfiAgenticLoop
+import com.zremote.sdk.FfiClaudeTask
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,12 +12,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LoopDetailViewModel @Inject constructor(
+class TaskDetailViewModel @Inject constructor(
     private val connectionManager: ConnectionManager,
 ) : ViewModel() {
 
-    private val _loop = MutableStateFlow<FfiAgenticLoop?>(null)
-    val loop: StateFlow<FfiAgenticLoop?> = _loop.asStateFlow()
+    private val _task = MutableStateFlow<FfiClaudeTask?>(null)
+    val task: StateFlow<FfiClaudeTask?> = _task.asStateFlow()
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -25,21 +25,21 @@ class LoopDetailViewModel @Inject constructor(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
-    private var currentLoopId: String? = null
+    private var currentTaskId: String? = null
 
-    fun loadLoop(loopId: String) {
-        currentLoopId = loopId
+    fun loadTask(taskId: String) {
+        currentTaskId = taskId
         refresh()
     }
 
     fun refresh() {
-        val loopId = currentLoopId ?: return
+        val taskId = currentTaskId ?: return
         val client = connectionManager.client ?: return
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
             try {
-                _loop.value = client.getLoop(loopId)
+                _task.value = client.getClaudeTask(taskId)
             } catch (e: Exception) {
                 _error.value = e.message
             } finally {

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt
@@ -1,13 +1,14 @@
 package com.zremote.ui.screens.tasks
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Task
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -19,24 +20,48 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zremote.sdk.FfiClaudeTask
 import com.zremote.sdk.FfiClaudeTaskStatus
+import com.zremote.ui.components.EmptyState
+import com.zremote.ui.components.ErrorState
+import com.zremote.ui.components.LoadingState
+import com.zremote.ui.components.RefreshableList
 import com.zremote.ui.theme.StatusCompleted
 import com.zremote.ui.theme.StatusError
-import com.zremote.ui.theme.StatusOffline
 import com.zremote.ui.theme.StatusWorking
 
 @Composable
-fun TaskListScreen(viewModel: TaskListViewModel = hiltViewModel()) {
+fun TaskListScreen(
+    onTaskClick: (String) -> Unit = {},
+    viewModel: TaskListViewModel = hiltViewModel(),
+) {
     val tasks by viewModel.tasks.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(tasks, key = { it.id }) { task ->
-            TaskCard(task)
+    val currentError = error
+    when {
+        isLoading && tasks.isEmpty() -> LoadingState()
+        currentError != null && tasks.isEmpty() -> ErrorState(
+            message = currentError,
+            onRetry = { viewModel.refresh() },
+        )
+        tasks.isEmpty() && !isLoading -> EmptyState(
+            icon = Icons.Default.Task,
+            message = "No tasks",
+            hint = "Tasks will appear when Claude sessions are active",
+        )
+        else -> RefreshableList(
+            isRefreshing = isLoading,
+            onRefresh = { viewModel.refresh() },
+        ) {
+            items(tasks, key = { it.id }) { task ->
+                TaskCard(task = task, onClick = { onTaskClick(task.id) })
+            }
         }
     }
 }
 
 @Composable
-private fun TaskCard(task: FfiClaudeTask) {
+private fun TaskCard(task: FfiClaudeTask, onClick: () -> Unit) {
     val statusColor = when (task.status) {
         FfiClaudeTaskStatus.STARTING -> StatusWorking
         FfiClaudeTaskStatus.ACTIVE -> StatusWorking
@@ -47,7 +72,8 @@ private fun TaskCard(task: FfiClaudeTask) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt
@@ -1,0 +1,92 @@
+package com.zremote.ui.screens.tasks
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.sdk.FfiClaudeTask
+import com.zremote.sdk.FfiClaudeTaskStatus
+import com.zremote.ui.theme.StatusCompleted
+import com.zremote.ui.theme.StatusError
+import com.zremote.ui.theme.StatusOffline
+import com.zremote.ui.theme.StatusWorking
+
+@Composable
+fun TaskListScreen(viewModel: TaskListViewModel = hiltViewModel()) {
+    val tasks by viewModel.tasks.collectAsStateWithLifecycle()
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(tasks, key = { it.id }) { task ->
+            TaskCard(task)
+        }
+    }
+}
+
+@Composable
+private fun TaskCard(task: FfiClaudeTask) {
+    val statusColor = when (task.status) {
+        FfiClaudeTaskStatus.STARTING -> StatusWorking
+        FfiClaudeTaskStatus.ACTIVE -> StatusWorking
+        FfiClaudeTaskStatus.COMPLETED -> StatusCompleted
+        FfiClaudeTaskStatus.ERROR -> StatusError
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = task.taskName ?: task.initialPrompt?.take(50) ?: "Task ${task.id.take(8)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = task.status.name.lowercase(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = statusColor,
+                )
+            }
+
+            Row(
+                modifier = Modifier.padding(top = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                task.model?.let {
+                    Text(text = it, style = MaterialTheme.typography.bodySmall)
+                }
+                task.totalCostUsd?.let { cost ->
+                    Text(
+                        text = "$${String.format("%.4f", cost)}",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+
+            Text(
+                text = task.projectPath,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListViewModel.kt
@@ -23,6 +23,9 @@ class TaskListViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         refresh()
     }
@@ -31,12 +34,13 @@ class TaskListViewModel @Inject constructor(
         val client = connectionManager.client ?: return
         viewModelScope.launch {
             _isLoading.value = true
+            _error.value = null
             try {
                 _tasks.value = client.listClaudeTasks(FfiListClaudeTasksFilter(
                     hostId = null, status = null, projectId = null,
                 ))
-            } catch (_: Exception) {
-                _tasks.value = emptyList()
+            } catch (e: Exception) {
+                _error.value = e.message
             } finally {
                 _isLoading.value = false
             }

--- a/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListViewModel.kt
@@ -1,0 +1,45 @@
+package com.zremote.ui.screens.tasks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zremote.data.ConnectionManager
+import com.zremote.sdk.FfiClaudeTask
+import com.zremote.sdk.FfiListClaudeTasksFilter
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TaskListViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val _tasks = MutableStateFlow<List<FfiClaudeTask>>(emptyList())
+    val tasks: StateFlow<List<FfiClaudeTask>> = _tasks.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        val client = connectionManager.client ?: return
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _tasks.value = client.listClaudeTasks(FfiListClaudeTasksFilter(
+                    hostId = null, status = null, projectId = null,
+                ))
+            } catch (_: Exception) {
+                _tasks.value = emptyList()
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/AnsiParser.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/AnsiParser.kt
@@ -25,15 +25,20 @@ class AnsiParser {
         while (i < text.length) {
             val c = text[i]
             when {
-                c == '\u001B' && i + 1 < text.length && text[i + 1] == '[' -> {
-                    i = parseEscapeSequence(text, i + 2)
+                c == '\u001B' -> {
+                    i = parseEscape(text, i + 1)
                 }
                 c == '\n' -> {
-                    lines.add(TerminalLine(currentLine.toList()))
+                    lines.add(TerminalLine(trimTrailingSpaces(currentLine)))
                     currentLine = mutableListOf()
                     i++
                 }
                 c == '\r' -> {
+                    // Skip carriage return (we don't track cursor position)
+                    i++
+                }
+                c < ' ' && c != '\t' -> {
+                    // Skip other control characters (BEL, BS, etc.)
                     i++
                 }
                 else -> {
@@ -43,16 +48,40 @@ class AnsiParser {
             }
         }
         if (currentLine.isNotEmpty()) {
-            lines.add(TerminalLine(currentLine.toList()))
+            lines.add(TerminalLine(trimTrailingSpaces(currentLine)))
         }
         return lines
     }
 
-    private fun parseEscapeSequence(text: String, start: Int): Int {
+    private fun parseEscape(text: String, start: Int): Int {
+        if (start >= text.length) return start
+        return when (text[start]) {
+            '[' -> parseCsi(text, start + 1)
+            ']' -> parseOsc(text, start + 1)
+            '(' , ')' , '*' , '+' -> {
+                // Charset designation: ESC ( X -- skip next char
+                if (start + 1 < text.length) start + 2 else start + 1
+            }
+            else -> start + 1 // Single-char escape (ESC =, ESC >, etc.)
+        }
+    }
+
+    // Parse CSI sequence: ESC [ (params) (intermediates) (final byte)
+    // Final byte is 0x40..0x7E (@..~)
+    // Intermediate bytes are 0x20..0x2F (space../)
+    // Parameter bytes are 0x30..0x3F (0..? including digits, semicolons, and ?)
+    private fun parseCsi(text: String, start: Int): Int {
         var i = start
         val params = mutableListOf<Int>()
         var current = 0
         var hasParam = false
+        var isPrivate = false
+
+        // Check for private mode marker (?)
+        if (i < text.length && text[i] == '?') {
+            isPrivate = true
+            i++
+        }
 
         while (i < text.length) {
             val c = text[i]
@@ -62,23 +91,44 @@ class AnsiParser {
                     hasParam = true
                     i++
                 }
-                c == ';' -> {
+                c == ';' || c == ':' -> {
                     params.add(if (hasParam) current else 0)
                     current = 0
                     hasParam = false
                     i++
                 }
-                c == 'm' -> {
-                    params.add(if (hasParam) current else 0)
-                    applySgr(params)
-                    return i + 1
+                c in ' '..'/' -> {
+                    // Intermediate bytes - skip
+                    i++
                 }
-                c.isLetter() -> {
+                c in '@'..'~' -> {
+                    // Final byte - process if SGR, otherwise ignore
+                    if (c == 'm' && !isPrivate) {
+                        params.add(if (hasParam) current else 0)
+                        applySgr(params)
+                    }
                     return i + 1
                 }
                 else -> {
+                    // Malformed sequence, bail out
                     return i + 1
                 }
+            }
+        }
+        return i
+    }
+
+    // Parse OSC sequence: ESC ] ... (ST or BEL)
+    // ST is ESC \ or 0x9C; BEL is 0x07
+    private fun parseOsc(text: String, start: Int): Int {
+        var i = start
+        while (i < text.length) {
+            val c = text[i]
+            when {
+                c == '\u0007' -> return i + 1 // BEL terminates
+                c == '\u001B' && i + 1 < text.length && text[i + 1] == '\\' -> return i + 2 // ST
+                c == '\u009C'.code.toChar() -> return i + 1 // 8-bit ST
+                else -> i++
             }
         }
         return i
@@ -97,32 +147,77 @@ class AnsiParser {
             when (val p = params[i]) {
                 0 -> { currentFg = DEFAULT_FG; currentBg = Color.Transparent; bold = false }
                 1 -> bold = true
+                2 -> {} // dim - ignore
+                3 -> {} // italic - ignore
+                4 -> {} // underline - ignore
+                5, 6 -> {} // blink - ignore
+                7 -> { // reverse video
+                    val tmp = currentFg
+                    currentFg = if (currentBg == Color.Transparent) TERMINAL_BG else currentBg
+                    currentBg = tmp
+                }
+                8 -> {} // hidden - ignore
+                9 -> {} // strikethrough - ignore
                 22 -> bold = false
+                23 -> {} // not italic
+                24 -> {} // not underline
+                25 -> {} // not blink
+                27 -> {} // not reverse
+                28 -> {} // not hidden
+                29 -> {} // not strikethrough
                 in 30..37 -> currentFg = ansi8Color(p - 30, bold)
+                38 -> {
+                    i = parseExtendedColor(params, i) { currentFg = it }
+                }
                 39 -> currentFg = DEFAULT_FG
                 in 40..47 -> currentBg = ansi8Color(p - 40, false)
+                48 -> {
+                    i = parseExtendedColor(params, i) { currentBg = it }
+                }
                 49 -> currentBg = Color.Transparent
                 in 90..97 -> currentFg = ansi8Color(p - 90 + 8, false)
                 in 100..107 -> currentBg = ansi8Color(p - 100 + 8, false)
-                38 -> {
-                    if (i + 1 < params.size && params[i + 1] == 5 && i + 2 < params.size) {
-                        currentFg = ansi256Color(params[i + 2])
-                        i += 2
-                    }
-                }
-                48 -> {
-                    if (i + 1 < params.size && params[i + 1] == 5 && i + 2 < params.size) {
-                        currentBg = ansi256Color(params[i + 2])
-                        i += 2
-                    }
-                }
             }
             i++
         }
     }
 
+    private inline fun parseExtendedColor(
+        params: List<Int>,
+        i: Int,
+        apply: (Color) -> Unit,
+    ): Int {
+        if (i + 1 >= params.size) return i
+        return when (params[i + 1]) {
+            5 -> {
+                // 256-color: 38;5;N
+                if (i + 2 < params.size) {
+                    apply(ansi256Color(params[i + 2]))
+                    i + 2
+                } else i + 1
+            }
+            2 -> {
+                // RGB: 38;2;R;G;B
+                if (i + 4 < params.size) {
+                    apply(Color(params[i + 2], params[i + 3], params[i + 4]))
+                    i + 4
+                } else i + 1
+            }
+            else -> i + 1
+        }
+    }
+
+    private fun trimTrailingSpaces(chars: MutableList<StyledChar>): List<StyledChar> {
+        var end = chars.size
+        while (end > 0 && chars[end - 1].char == ' ' && chars[end - 1].bg == Color.Transparent) {
+            end--
+        }
+        return if (end == chars.size) chars.toList() else chars.subList(0, end).toList()
+    }
+
     companion object {
         val DEFAULT_FG = Color(0xFFE0E0E0)
+        val TERMINAL_BG = Color(0xFF1A1A2E)
 
         private val ANSI_COLORS = arrayOf(
             Color(0xFF000000), // black

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/AnsiParser.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/AnsiParser.kt
@@ -1,0 +1,168 @@
+package com.zremote.ui.screens.terminal
+
+import androidx.compose.ui.graphics.Color
+
+data class StyledChar(
+    val char: Char,
+    val fg: Color = Color(0xFFE0E0E0),
+    val bg: Color = Color.Transparent,
+    val bold: Boolean = false,
+)
+
+data class TerminalLine(val chars: List<StyledChar>)
+
+class AnsiParser {
+    private var currentFg = DEFAULT_FG
+    private var currentBg = Color.Transparent
+    private var bold = false
+
+    fun parse(bytes: ByteArray): List<TerminalLine> {
+        val text = String(bytes, Charsets.UTF_8)
+        val lines = mutableListOf<TerminalLine>()
+        var currentLine = mutableListOf<StyledChar>()
+
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            when {
+                c == '\u001B' && i + 1 < text.length && text[i + 1] == '[' -> {
+                    i = parseEscapeSequence(text, i + 2)
+                }
+                c == '\n' -> {
+                    lines.add(TerminalLine(currentLine.toList()))
+                    currentLine = mutableListOf()
+                    i++
+                }
+                c == '\r' -> {
+                    i++
+                }
+                else -> {
+                    currentLine.add(StyledChar(c, currentFg, currentBg, bold))
+                    i++
+                }
+            }
+        }
+        if (currentLine.isNotEmpty()) {
+            lines.add(TerminalLine(currentLine.toList()))
+        }
+        return lines
+    }
+
+    private fun parseEscapeSequence(text: String, start: Int): Int {
+        var i = start
+        val params = mutableListOf<Int>()
+        var current = 0
+        var hasParam = false
+
+        while (i < text.length) {
+            val c = text[i]
+            when {
+                c in '0'..'9' -> {
+                    current = current * 10 + (c - '0')
+                    hasParam = true
+                    i++
+                }
+                c == ';' -> {
+                    params.add(if (hasParam) current else 0)
+                    current = 0
+                    hasParam = false
+                    i++
+                }
+                c == 'm' -> {
+                    params.add(if (hasParam) current else 0)
+                    applySgr(params)
+                    return i + 1
+                }
+                c.isLetter() -> {
+                    return i + 1
+                }
+                else -> {
+                    return i + 1
+                }
+            }
+        }
+        return i
+    }
+
+    private fun applySgr(params: List<Int>) {
+        if (params.isEmpty() || (params.size == 1 && params[0] == 0)) {
+            currentFg = DEFAULT_FG
+            currentBg = Color.Transparent
+            bold = false
+            return
+        }
+
+        var i = 0
+        while (i < params.size) {
+            when (val p = params[i]) {
+                0 -> { currentFg = DEFAULT_FG; currentBg = Color.Transparent; bold = false }
+                1 -> bold = true
+                22 -> bold = false
+                in 30..37 -> currentFg = ansi8Color(p - 30, bold)
+                39 -> currentFg = DEFAULT_FG
+                in 40..47 -> currentBg = ansi8Color(p - 40, false)
+                49 -> currentBg = Color.Transparent
+                in 90..97 -> currentFg = ansi8Color(p - 90 + 8, false)
+                in 100..107 -> currentBg = ansi8Color(p - 100 + 8, false)
+                38 -> {
+                    if (i + 1 < params.size && params[i + 1] == 5 && i + 2 < params.size) {
+                        currentFg = ansi256Color(params[i + 2])
+                        i += 2
+                    }
+                }
+                48 -> {
+                    if (i + 1 < params.size && params[i + 1] == 5 && i + 2 < params.size) {
+                        currentBg = ansi256Color(params[i + 2])
+                        i += 2
+                    }
+                }
+            }
+            i++
+        }
+    }
+
+    companion object {
+        val DEFAULT_FG = Color(0xFFE0E0E0)
+
+        private val ANSI_COLORS = arrayOf(
+            Color(0xFF000000), // black
+            Color(0xFFCD3131), // red
+            Color(0xFF0DBC79), // green
+            Color(0xFFE5E510), // yellow
+            Color(0xFF2472C8), // blue
+            Color(0xFFBC3FBC), // magenta
+            Color(0xFF11A8CD), // cyan
+            Color(0xFFE5E5E5), // white
+            Color(0xFF666666), // bright black
+            Color(0xFFF14C4C), // bright red
+            Color(0xFF23D18B), // bright green
+            Color(0xFFF5F543), // bright yellow
+            Color(0xFF3B8EEA), // bright blue
+            Color(0xFFD670D6), // bright magenta
+            Color(0xFF29B8DB), // bright cyan
+            Color(0xFFFFFFFF), // bright white
+        )
+
+        fun ansi8Color(index: Int, bold: Boolean): Color {
+            val effectiveIndex = if (bold && index < 8) index + 8 else index
+            return ANSI_COLORS.getOrElse(effectiveIndex) { DEFAULT_FG }
+        }
+
+        fun ansi256Color(index: Int): Color {
+            return when {
+                index < 16 -> ANSI_COLORS.getOrElse(index) { DEFAULT_FG }
+                index < 232 -> {
+                    val i = index - 16
+                    val r = (i / 36) * 51
+                    val g = ((i % 36) / 6) * 51
+                    val b = (i % 6) * 51
+                    Color(r, g, b)
+                }
+                else -> {
+                    val gray = 8 + (index - 232) * 10
+                    Color(gray, gray, gray)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -131,6 +130,11 @@ private fun QuickCommandBar(
 ) {
     var inputText by remember { mutableStateOf("") }
 
+    val sendCommand = {
+        onSendInput(inputText + "\r")
+        inputText = ""
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -139,8 +143,10 @@ private fun QuickCommandBar(
     ) {
         // Quick action buttons
         Row(modifier = Modifier.fillMaxWidth()) {
+            QuickButton("Enter") { sendCommand() }
             QuickButton("Ctrl+C") { onSendControl('c') }
             QuickButton("Tab") { onSendInput("\t") }
+            QuickButton("S+Tab") { onSendInput("\u001B[Z") }
             QuickButton("Esc") { onSendInput("\u001B") }
             QuickButton("Up") { onSendInput("\u001B[A") }
             QuickButton("Down") { onSendInput("\u001B[B") }
@@ -150,13 +156,7 @@ private fun QuickCommandBar(
         BasicTextField(
             value = inputText,
             onValueChange = { inputText = it },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-            keyboardActions = KeyboardActions(
-                onSend = {
-                    onSendInput(inputText + "\n")
-                    inputText = ""
-                },
-            ),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.None),
             textStyle = MaterialTheme.typography.bodyMedium.copy(
                 color = MaterialTheme.colorScheme.onSurface,
                 fontFamily = FontFamily.Monospace,

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
@@ -1,7 +1,9 @@
 package com.zremote.ui.screens.terminal
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,11 +23,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -45,6 +49,8 @@ fun TerminalScreen(
 ) {
     val lines by viewModel.lines.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
+    var fontSize by remember { mutableFloatStateOf(13f) }
+    val horizontalScrollState = rememberScrollState()
 
     LaunchedEffect(sessionId) {
         viewModel.connectToSession(sessionId)
@@ -57,17 +63,29 @@ fun TerminalScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        // Terminal output area
-        LazyColumn(
-            state = listState,
+        // Terminal output area with pinch-to-zoom and shared horizontal scroll
+        Box(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
                 .background(Background)
-                .padding(horizontal = 4.dp),
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        fontSize = (fontSize * zoom).coerceIn(6f, 28f)
+                        horizontalScrollState.dispatchRawDelta(-pan.x)
+                    }
+                },
         ) {
-            items(lines) { line ->
-                TerminalLineView(line)
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .horizontalScroll(horizontalScrollState)
+                    .padding(horizontal = 4.dp),
+            ) {
+                items(lines) { line ->
+                    TerminalLineView(line, fontSize)
+                }
             }
         }
 
@@ -80,14 +98,13 @@ fun TerminalScreen(
 }
 
 @Composable
-private fun TerminalLineView(line: TerminalLine) {
+private fun TerminalLineView(line: TerminalLine, fontSize: Float) {
     val annotated = remember(line) { lineToAnnotatedString(line) }
     Text(
         text = annotated,
         fontFamily = FontFamily.Monospace,
-        fontSize = 13.sp,
-        lineHeight = 17.sp,
-        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        fontSize = fontSize.sp,
+        lineHeight = (fontSize * 1.3f).sp,
     )
 }
 

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
@@ -2,7 +2,6 @@ package com.zremote.ui.screens.terminal
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -86,8 +85,8 @@ private fun TerminalLineView(line: TerminalLine) {
     Text(
         text = annotated,
         fontFamily = FontFamily.Monospace,
-        fontSize = 12.sp,
-        lineHeight = 16.sp,
+        fontSize = 13.sp,
+        lineHeight = 17.sp,
         modifier = Modifier.horizontalScroll(rememberScrollState()),
     )
 }

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalScreen.kt
@@ -1,0 +1,173 @@
+package com.zremote.ui.screens.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zremote.ui.theme.Background
+
+@Composable
+fun TerminalScreen(
+    sessionId: String,
+    viewModel: TerminalViewModel = hiltViewModel(),
+) {
+    val lines by viewModel.lines.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(sessionId) {
+        viewModel.connectToSession(sessionId)
+    }
+
+    LaunchedEffect(lines.size) {
+        if (lines.isNotEmpty()) {
+            listState.animateScrollToItem(lines.size - 1)
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Terminal output area
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(Background)
+                .padding(horizontal = 4.dp),
+        ) {
+            items(lines) { line ->
+                TerminalLineView(line)
+            }
+        }
+
+        // Quick command bar
+        QuickCommandBar(
+            onSendInput = { viewModel.sendInput(it) },
+            onSendControl = { viewModel.sendControlChar(it) },
+        )
+    }
+}
+
+@Composable
+private fun TerminalLineView(line: TerminalLine) {
+    val annotated = remember(line) { lineToAnnotatedString(line) }
+    Text(
+        text = annotated,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+    )
+}
+
+private fun lineToAnnotatedString(line: TerminalLine): AnnotatedString {
+    return buildAnnotatedString {
+        for (sc in line.chars) {
+            pushStyle(
+                SpanStyle(
+                    color = sc.fg,
+                    background = sc.bg,
+                    fontWeight = if (sc.bold) FontWeight.Bold else FontWeight.Normal,
+                )
+            )
+            append(sc.char)
+            pop()
+        }
+    }
+}
+
+@Composable
+private fun QuickCommandBar(
+    onSendInput: (String) -> Unit,
+    onSendControl: (Char) -> Unit,
+) {
+    var inputText by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(8.dp),
+    ) {
+        // Quick action buttons
+        Row(modifier = Modifier.fillMaxWidth()) {
+            QuickButton("Ctrl+C") { onSendControl('c') }
+            QuickButton("Tab") { onSendInput("\t") }
+            QuickButton("Esc") { onSendInput("\u001B") }
+            QuickButton("Up") { onSendInput("\u001B[A") }
+            QuickButton("Down") { onSendInput("\u001B[B") }
+        }
+
+        // Text input field
+        BasicTextField(
+            value = inputText,
+            onValueChange = { inputText = it },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+            keyboardActions = KeyboardActions(
+                onSend = {
+                    onSendInput(inputText + "\n")
+                    inputText = ""
+                },
+            ),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+                fontFamily = FontFamily.Monospace,
+            ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.shapes.small,
+                )
+                .padding(12.dp),
+        )
+    }
+}
+
+@Composable
+private fun QuickButton(label: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = Modifier.padding(end = 4.dp),
+    ) {
+        Text(label, fontSize = 11.sp)
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalViewModel.kt
@@ -1,14 +1,17 @@
 package com.zremote.ui.screens.terminal
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.zremote.data.ConnectionManager
 import com.zremote.sdk.TerminalListener
 import com.zremote.sdk.ZRemoteTerminal
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,7 +19,7 @@ class TerminalViewModel @Inject constructor(
     private val connectionManager: ConnectionManager,
 ) : ViewModel() {
 
-    private val parser = AnsiParser()
+    private val vt = VtTerminal(80, 24)
     private var terminal: ZRemoteTerminal? = null
 
     private val _lines = MutableStateFlow<List<TerminalLine>>(emptyList())
@@ -29,9 +32,23 @@ class TerminalViewModel @Inject constructor(
     val error: StateFlow<String?> = _error.asStateFlow()
 
     fun connectToSession(sessionId: String) {
-        val client = connectionManager.client ?: return
-        terminal?.disconnect()
-        terminal = client.connectTerminal(sessionId, Listener())
+        val client = connectionManager.client
+        if (client == null) {
+            Log.e("ZRemote", "TerminalVM.connectToSession($sessionId) client is null")
+            _error.value = "Not connected to server"
+            return
+        }
+        try {
+            terminal?.disconnect()
+            terminal = client.connectTerminal(sessionId, Listener())
+            _isConnected.value = true
+        } catch (e: Exception) {
+            Log.e("ZRemote", "TerminalVM.connectToSession($sessionId) Exception", e)
+            _error.value = e.message ?: e.toString()
+        } catch (e: Error) {
+            Log.e("ZRemote", "TerminalVM.connectToSession($sessionId) Error", e)
+            _error.value = e.message ?: e.toString()
+        }
     }
 
     fun sendInput(data: String) {
@@ -45,6 +62,7 @@ class TerminalViewModel @Inject constructor(
 
     fun resize(cols: UShort, rows: UShort) {
         terminal?.resize(cols, rows)
+        vt.resize(cols.toInt(), rows.toInt())
     }
 
     override fun onCleared() {
@@ -54,8 +72,14 @@ class TerminalViewModel @Inject constructor(
 
     private inner class Listener : TerminalListener {
         override fun onOutput(data: ByteArray) {
-            val newLines = parser.parse(data)
-            _lines.update { it + newLines }
+            viewModelScope.launch(Dispatchers.Default) {
+                try {
+                    vt.write(data)
+                    _lines.value = vt.getDisplayLines()
+                } catch (e: Exception) {
+                    Log.e("ZRemote", "TerminalVM.onOutput error", e)
+                }
+            }
         }
 
         override fun onPaneOutput(paneId: String, data: ByteArray) {
@@ -67,17 +91,28 @@ class TerminalViewModel @Inject constructor(
 
         override fun onSessionClosed(exitCode: Int?) {
             _isConnected.value = false
+            if (exitCode != null) {
+                _error.value = "Session closed (exit $exitCode)"
+            }
         }
 
         override fun onScrollbackStart(cols: UShort, rows: UShort) {
-            _lines.value = emptyList()
+            vt.reset()
+            if (cols.toInt() > 0 && rows.toInt() > 0) {
+                vt.resize(cols.toInt(), rows.toInt())
+            }
         }
 
         override fun onScrollbackEnd(truncated: Boolean) {}
-        override fun onSessionSuspended() { _isConnected.value = false }
-        override fun onSessionResumed() { _isConnected.value = true }
+        override fun onSessionSuspended() {
+            _isConnected.value = false
+        }
+        override fun onSessionResumed() {
+            _isConnected.value = true
+        }
 
         override fun onError(message: String) {
+            Log.e("ZRemote", "TerminalVM.onError: $message")
             _error.value = message
         }
 

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/TerminalViewModel.kt
@@ -1,0 +1,88 @@
+package com.zremote.ui.screens.terminal
+
+import androidx.lifecycle.ViewModel
+import com.zremote.data.ConnectionManager
+import com.zremote.sdk.TerminalListener
+import com.zremote.sdk.ZRemoteTerminal
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class TerminalViewModel @Inject constructor(
+    private val connectionManager: ConnectionManager,
+) : ViewModel() {
+
+    private val parser = AnsiParser()
+    private var terminal: ZRemoteTerminal? = null
+
+    private val _lines = MutableStateFlow<List<TerminalLine>>(emptyList())
+    val lines: StateFlow<List<TerminalLine>> = _lines.asStateFlow()
+
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun connectToSession(sessionId: String) {
+        val client = connectionManager.client ?: return
+        terminal?.disconnect()
+        terminal = client.connectTerminal(sessionId, Listener())
+    }
+
+    fun sendInput(data: String) {
+        terminal?.sendInput(data.toByteArray())
+    }
+
+    fun sendControlChar(c: Char) {
+        val code = c.code - 'a'.code + 1
+        terminal?.sendInput(byteArrayOf(code.toByte()))
+    }
+
+    fun resize(cols: UShort, rows: UShort) {
+        terminal?.resize(cols, rows)
+    }
+
+    override fun onCleared() {
+        terminal?.disconnect()
+        terminal = null
+    }
+
+    private inner class Listener : TerminalListener {
+        override fun onOutput(data: ByteArray) {
+            val newLines = parser.parse(data)
+            _lines.update { it + newLines }
+        }
+
+        override fun onPaneOutput(paneId: String, data: ByteArray) {
+            onOutput(data)
+        }
+
+        override fun onPaneAdded(paneId: String, index: UShort) {}
+        override fun onPaneRemoved(paneId: String) {}
+
+        override fun onSessionClosed(exitCode: Int?) {
+            _isConnected.value = false
+        }
+
+        override fun onScrollbackStart(cols: UShort, rows: UShort) {
+            _lines.value = emptyList()
+        }
+
+        override fun onScrollbackEnd(truncated: Boolean) {}
+        override fun onSessionSuspended() { _isConnected.value = false }
+        override fun onSessionResumed() { _isConnected.value = true }
+
+        override fun onError(message: String) {
+            _error.value = message
+        }
+
+        override fun onDisconnected() {
+            _isConnected.value = false
+        }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/screens/terminal/VtTerminal.kt
+++ b/android/app/src/main/java/com/zremote/ui/screens/terminal/VtTerminal.kt
@@ -1,0 +1,864 @@
+package com.zremote.ui.screens.terminal
+
+import androidx.compose.ui.graphics.Color
+import com.zremote.ui.screens.terminal.AnsiParser.Companion.DEFAULT_FG
+import com.zremote.ui.screens.terminal.AnsiParser.Companion.TERMINAL_BG
+import com.zremote.ui.screens.terminal.AnsiParser.Companion.ansi256Color
+import com.zremote.ui.screens.terminal.AnsiParser.Companion.ansi8Color
+
+data class Cell(
+    var char: Char = ' ',
+    var fg: Color = DEFAULT_FG,
+    var bg: Color = Color.Transparent,
+    var bold: Boolean = false,
+    var dim: Boolean = false,
+    var italic: Boolean = false,
+    var underline: Boolean = false,
+    var reverse: Boolean = false,
+) {
+    fun reset() {
+        char = ' '
+        fg = DEFAULT_FG
+        bg = Color.Transparent
+        bold = false
+        dim = false
+        italic = false
+        underline = false
+        reverse = false
+    }
+
+    fun copyFrom(other: Cell) {
+        char = other.char
+        fg = other.fg
+        bg = other.bg
+        bold = other.bold
+        dim = other.dim
+        italic = other.italic
+        underline = other.underline
+        reverse = other.reverse
+    }
+}
+
+private enum class ParseState {
+    Normal,
+    Escape,
+    Csi,
+    Osc,
+    CharsetDesignation,
+    DcsPassthrough,
+}
+
+class VtTerminal(
+    private var cols: Int = 80,
+    private var rows: Int = 24,
+) {
+    private var cells: Array<Array<Cell>> = makeGrid(cols, rows)
+    private val scrollback: MutableList<Array<Cell>> = mutableListOf()
+
+    var cursorRow: Int = 0
+        private set
+    var cursorCol: Int = 0
+        private set
+
+    private var savedCursorRow: Int = 0
+    private var savedCursorCol: Int = 0
+    private var savedSgrState: SgrState = SgrState()
+
+    private var scrollTop: Int = 0
+    private var scrollBottom: Int = rows - 1
+
+    private var altScreen: Array<Array<Cell>>? = null
+    private var altCursorRow: Int = 0
+    private var altCursorCol: Int = 0
+
+    private var sgrState: SgrState = SgrState()
+    private var parseState: ParseState = ParseState.Normal
+    private var autoWrap: Boolean = true
+    private var wrapPending: Boolean = false
+
+    // CSI parser state
+    private val csiParams = mutableListOf<Int>()
+    private var csiCurrentParam: Int = 0
+    private var csiHasParam: Boolean = false
+    private var csiPrivateMarker: Char = '\u0000'
+    private var csiIntermediates = StringBuilder()
+
+    // OSC parser state
+    private val oscBuffer = StringBuilder()
+    private var oscPrevWasEsc = false
+
+    // UTF-8 decoder state
+    private var utf8Remaining = 0
+    private var utf8Codepoint = 0
+
+    companion object {
+        private const val MAX_SCROLLBACK = 1000
+        private const val TAB_WIDTH = 8
+    }
+
+    data class SgrState(
+        var fg: Color = DEFAULT_FG,
+        var bg: Color = Color.Transparent,
+        var bold: Boolean = false,
+        var dim: Boolean = false,
+        var italic: Boolean = false,
+        var underline: Boolean = false,
+        var reverse: Boolean = false,
+    ) {
+        fun reset() {
+            fg = DEFAULT_FG
+            bg = Color.Transparent
+            bold = false
+            dim = false
+            italic = false
+            underline = false
+            reverse = false
+        }
+
+        fun copyFrom(other: SgrState) {
+            fg = other.fg
+            bg = other.bg
+            bold = other.bold
+            dim = other.dim
+            italic = other.italic
+            underline = other.underline
+            reverse = other.reverse
+        }
+    }
+
+    @Synchronized
+    fun write(data: ByteArray) {
+        for (b in data) {
+            val byte = b.toInt() and 0xFF
+            if (utf8Remaining > 0) {
+                if (byte and 0xC0 == 0x80) {
+                    utf8Codepoint = (utf8Codepoint shl 6) or (byte and 0x3F)
+                    utf8Remaining--
+                    if (utf8Remaining == 0) {
+                        processChar(utf8Codepoint.toChar())
+                    }
+                } else {
+                    // Invalid continuation byte, reset and reprocess
+                    utf8Remaining = 0
+                    processChar('\uFFFD')
+                    processByte(byte)
+                }
+            } else {
+                processByte(byte)
+            }
+        }
+    }
+
+    private fun processByte(byte: Int) {
+        when {
+            byte and 0x80 == 0 -> processChar(byte.toChar())
+            byte and 0xE0 == 0xC0 -> { utf8Remaining = 1; utf8Codepoint = byte and 0x1F }
+            byte and 0xF0 == 0xE0 -> { utf8Remaining = 2; utf8Codepoint = byte and 0x0F }
+            byte and 0xF8 == 0xF0 -> { utf8Remaining = 3; utf8Codepoint = byte and 0x07 }
+            else -> processChar('\uFFFD')
+        }
+    }
+
+    private fun processChar(c: Char) {
+        when (parseState) {
+            ParseState.Normal -> processNormal(c)
+            ParseState.Escape -> processEscape(c)
+            ParseState.Csi -> processCsi(c)
+            ParseState.Osc -> processOsc(c)
+            ParseState.CharsetDesignation -> {
+                // Consume the designation byte and return to normal
+                parseState = ParseState.Normal
+            }
+            ParseState.DcsPassthrough -> processDcs(c)
+        }
+    }
+
+    private fun processNormal(c: Char) {
+        when {
+            c == '\u001B' -> parseState = ParseState.Escape
+            c == '\n' -> lineFeed()
+            c == '\r' -> { cursorCol = 0; wrapPending = false }
+            c == '\b' -> { if (cursorCol > 0) cursorCol--; wrapPending = false }
+            c == '\t' -> {
+                val nextTab = ((cursorCol / TAB_WIDTH) + 1) * TAB_WIDTH
+                cursorCol = nextTab.coerceAtMost(cols - 1)
+                wrapPending = false
+            }
+            c == '\u0007' -> { /* BEL - ignore */ }
+            c == '\u000E' || c == '\u000F' -> { /* Shift In/Out - ignore */ }
+            c < ' ' -> { /* Other control chars - ignore */ }
+            else -> putChar(c)
+        }
+    }
+
+    private fun processEscape(c: Char) {
+        parseState = ParseState.Normal
+        when (c) {
+            '[' -> {
+                parseState = ParseState.Csi
+                csiParams.clear()
+                csiCurrentParam = 0
+                csiHasParam = false
+                csiPrivateMarker = '\u0000'
+                csiIntermediates.clear()
+            }
+            ']' -> {
+                parseState = ParseState.Osc
+                oscBuffer.clear()
+                oscPrevWasEsc = false
+            }
+            '(', ')', '*', '+' -> {
+                parseState = ParseState.CharsetDesignation
+            }
+            'c' -> reset() // RIS - Full reset
+            'D' -> index() // Index (scroll up)
+            'M' -> reverseIndex() // Reverse index (scroll down)
+            'E' -> { // Next line
+                cursorCol = 0
+                index()
+            }
+            '7' -> saveCursor() // DECSC
+            '8' -> restoreCursor() // DECRC
+            '=' , '>' -> { /* Keypad mode - ignore */ }
+            'P' -> {
+                parseState = ParseState.DcsPassthrough
+            }
+            '\\' -> { /* ST (String Terminator) - ignore */ }
+            else -> { /* Unknown escape - ignore */ }
+        }
+    }
+
+    private fun processCsi(c: Char) {
+        when {
+            c in '0'..'9' -> {
+                csiCurrentParam = csiCurrentParam * 10 + (c - '0')
+                csiHasParam = true
+            }
+            c == ';' || c == ':' -> {
+                csiParams.add(if (csiHasParam) csiCurrentParam else 0)
+                csiCurrentParam = 0
+                csiHasParam = false
+            }
+            c == '?' || c == '>' || c == '!' -> {
+                if (csiParams.isEmpty() && !csiHasParam) {
+                    csiPrivateMarker = c
+                } else {
+                    // Ignore invalid position for private marker
+                }
+            }
+            c in ' '..'/' -> {
+                csiIntermediates.append(c)
+            }
+            c in '@'..'~' -> {
+                // Final byte
+                csiParams.add(if (csiHasParam) csiCurrentParam else 0)
+                executeCsi(c)
+                parseState = ParseState.Normal
+            }
+            else -> {
+                // Malformed, bail
+                parseState = ParseState.Normal
+            }
+        }
+    }
+
+    private fun processOsc(c: Char) {
+        when {
+            c == '\u0007' -> {
+                // BEL terminates OSC
+                parseState = ParseState.Normal
+            }
+            c == '\\' && oscPrevWasEsc -> {
+                // ESC \ (ST) terminates OSC
+                parseState = ParseState.Normal
+            }
+            c == '\u001B' -> {
+                oscPrevWasEsc = true
+                return
+            }
+            else -> {
+                if (oscPrevWasEsc) {
+                    // ESC followed by something other than \, treat as new escape
+                    oscPrevWasEsc = false
+                    parseState = ParseState.Escape
+                    processEscape(c)
+                    return
+                }
+                oscBuffer.append(c)
+            }
+        }
+        oscPrevWasEsc = false
+    }
+
+    private fun processDcs(c: Char) {
+        // DCS passthrough: consume until ST (ESC \) or BEL
+        when {
+            c == '\u0007' -> parseState = ParseState.Normal
+            c == '\\' && oscPrevWasEsc -> parseState = ParseState.Normal
+            c == '\u001B' -> oscPrevWasEsc = true
+            else -> oscPrevWasEsc = false
+        }
+    }
+
+    private fun executeCsi(finalByte: Char) {
+        if (csiPrivateMarker == '?') {
+            executePrivateMode(finalByte)
+            return
+        }
+        if (csiPrivateMarker != '\u0000') {
+            // Other private markers (>, !) - ignore
+            return
+        }
+
+        val p = csiParams
+        when (finalByte) {
+            'm' -> applySgr(p)
+            'A' -> { // Cursor up
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorRow = (cursorRow - n).coerceAtLeast(scrollTop)
+                wrapPending = false
+            }
+            'B' -> { // Cursor down
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorRow = (cursorRow + n).coerceAtMost(scrollBottom)
+                wrapPending = false
+            }
+            'C' -> { // Cursor forward
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorCol = (cursorCol + n).coerceAtMost(cols - 1)
+                wrapPending = false
+            }
+            'D' -> { // Cursor backward
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorCol = (cursorCol - n).coerceAtLeast(0)
+                wrapPending = false
+            }
+            'H', 'f' -> { // Cursor position
+                cursorRow = (maxOf(p.getOrDefault(0, 1), 1) - 1).coerceIn(0, rows - 1)
+                cursorCol = (maxOf(p.getOrDefault(1, 1), 1) - 1).coerceIn(0, cols - 1)
+                wrapPending = false
+            }
+            'G' -> { // Cursor horizontal absolute
+                cursorCol = (maxOf(p.getOrDefault(0, 1), 1) - 1).coerceIn(0, cols - 1)
+                wrapPending = false
+            }
+            'd' -> { // Cursor vertical absolute
+                cursorRow = (maxOf(p.getOrDefault(0, 1), 1) - 1).coerceIn(0, rows - 1)
+                wrapPending = false
+            }
+            'J' -> eraseInDisplay(p.getOrDefault(0, 0))
+            'K' -> eraseInLine(p.getOrDefault(0, 0))
+            'X' -> { // Erase characters
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                val end = (cursorCol + n).coerceAtMost(cols)
+                for (col in cursorCol until end) {
+                    cells[cursorRow][col].reset()
+                }
+            }
+            'L' -> { // Insert lines
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                insertLines(n)
+            }
+            'M' -> { // Delete lines
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                deleteLines(n)
+            }
+            '@' -> { // Insert characters
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                insertChars(n)
+            }
+            'P' -> { // Delete characters
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                deleteChars(n)
+            }
+            'S' -> { // Scroll up
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                repeat(n) { scrollUp() }
+            }
+            'T' -> { // Scroll down
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                repeat(n) { scrollDown() }
+            }
+            'r' -> { // Set scroll region (DECSTBM)
+                val top = (maxOf(p.getOrDefault(0, 1), 1) - 1).coerceIn(0, rows - 1)
+                val bottom = (maxOf(p.getOrDefault(1, rows), 1) - 1).coerceIn(0, rows - 1)
+                if (top < bottom) {
+                    scrollTop = top
+                    scrollBottom = bottom
+                }
+                cursorRow = 0
+                cursorCol = 0
+                wrapPending = false
+            }
+            's' -> saveCursor()
+            'u' -> restoreCursor()
+            'n' -> { /* Device status report - ignore */ }
+            'h' -> { // Set mode (non-private)
+                // Handle auto-wrap: SM mode 7
+                if (p.getOrDefault(0, 0) == 7) autoWrap = true
+            }
+            'l' -> { // Reset mode (non-private)
+                if (p.getOrDefault(0, 0) == 7) autoWrap = false
+            }
+            'E' -> { // Cursor next line
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorRow = (cursorRow + n).coerceAtMost(scrollBottom)
+                cursorCol = 0
+                wrapPending = false
+            }
+            'F' -> { // Cursor previous line
+                val n = maxOf(p.getOrDefault(0, 1), 1)
+                cursorRow = (cursorRow - n).coerceAtLeast(scrollTop)
+                cursorCol = 0
+                wrapPending = false
+            }
+        }
+    }
+
+    private fun executePrivateMode(finalByte: Char) {
+        val p = csiParams
+        when (finalByte) {
+            'h' -> { // Set private mode
+                for (mode in p) {
+                    when (mode) {
+                        1049 -> enterAltScreen()
+                        47, 1047 -> enterAltScreen()
+                        7 -> autoWrap = true
+                        // 25 (cursor visible), 2004 (bracketed paste), etc. - ignore
+                    }
+                }
+            }
+            'l' -> { // Reset private mode
+                for (mode in p) {
+                    when (mode) {
+                        1049 -> leaveAltScreen()
+                        47, 1047 -> leaveAltScreen()
+                        7 -> autoWrap = false
+                    }
+                }
+            }
+        }
+    }
+
+    private fun putChar(c: Char) {
+        if (wrapPending && autoWrap) {
+            cursorCol = 0
+            index()
+            wrapPending = false
+        }
+
+        if (cursorRow in 0 until rows && cursorCol in 0 until cols) {
+            val cell = cells[cursorRow][cursorCol]
+            cell.char = c
+            cell.fg = sgrState.fg
+            cell.bg = sgrState.bg
+            cell.bold = sgrState.bold
+            cell.dim = sgrState.dim
+            cell.italic = sgrState.italic
+            cell.underline = sgrState.underline
+            cell.reverse = sgrState.reverse
+        }
+
+        if (cursorCol >= cols - 1) {
+            wrapPending = true
+        } else {
+            cursorCol++
+        }
+    }
+
+    private fun lineFeed() {
+        wrapPending = false
+        if (cursorRow == scrollBottom) {
+            scrollUp()
+        } else if (cursorRow < rows - 1) {
+            cursorRow++
+        }
+    }
+
+    private fun index() {
+        if (cursorRow == scrollBottom) {
+            scrollUp()
+        } else if (cursorRow < rows - 1) {
+            cursorRow++
+        }
+    }
+
+    private fun reverseIndex() {
+        if (cursorRow == scrollTop) {
+            scrollDown()
+        } else if (cursorRow > 0) {
+            cursorRow--
+        }
+    }
+
+    private fun scrollUp() {
+        // Save the top line to scrollback (only if in main screen)
+        if (altScreen == null && scrollTop == 0) {
+            scrollback.add(cells[0].map { Cell().apply { copyFrom(it) } }.toTypedArray())
+            if (scrollback.size > MAX_SCROLLBACK) {
+                scrollback.removeAt(0)
+            }
+        }
+
+        // Shift lines up within scroll region
+        for (row in scrollTop until scrollBottom) {
+            val src = cells[row + 1]
+            val dst = cells[row]
+            for (col in 0 until cols) {
+                dst[col].copyFrom(src[col])
+            }
+        }
+
+        // Clear the bottom line of scroll region
+        for (col in 0 until cols) {
+            cells[scrollBottom][col].reset()
+        }
+    }
+
+    private fun scrollDown() {
+        // Shift lines down within scroll region
+        for (row in scrollBottom downTo scrollTop + 1) {
+            val src = cells[row - 1]
+            val dst = cells[row]
+            for (col in 0 until cols) {
+                dst[col].copyFrom(src[col])
+            }
+        }
+
+        // Clear the top line of scroll region
+        for (col in 0 until cols) {
+            cells[scrollTop][col].reset()
+        }
+    }
+
+    private fun insertLines(n: Int) {
+        if (cursorRow < scrollTop || cursorRow > scrollBottom) return
+        val count = n.coerceAtMost(scrollBottom - cursorRow + 1)
+        // Shift lines down
+        for (row in scrollBottom downTo cursorRow + count) {
+            for (col in 0 until cols) {
+                cells[row][col].copyFrom(cells[row - count][col])
+            }
+        }
+        // Clear inserted lines
+        for (row in cursorRow until (cursorRow + count).coerceAtMost(scrollBottom + 1)) {
+            for (col in 0 until cols) {
+                cells[row][col].reset()
+            }
+        }
+    }
+
+    private fun deleteLines(n: Int) {
+        if (cursorRow < scrollTop || cursorRow > scrollBottom) return
+        val count = n.coerceAtMost(scrollBottom - cursorRow + 1)
+        // Shift lines up
+        for (row in cursorRow..scrollBottom - count) {
+            for (col in 0 until cols) {
+                cells[row][col].copyFrom(cells[row + count][col])
+            }
+        }
+        // Clear bottom lines
+        for (row in (scrollBottom - count + 1).coerceAtLeast(cursorRow)..scrollBottom) {
+            for (col in 0 until cols) {
+                cells[row][col].reset()
+            }
+        }
+    }
+
+    private fun insertChars(n: Int) {
+        val count = n.coerceAtMost(cols - cursorCol)
+        // Shift characters right
+        for (col in cols - 1 downTo cursorCol + count) {
+            cells[cursorRow][col].copyFrom(cells[cursorRow][col - count])
+        }
+        // Clear inserted positions
+        for (col in cursorCol until (cursorCol + count).coerceAtMost(cols)) {
+            cells[cursorRow][col].reset()
+        }
+    }
+
+    private fun deleteChars(n: Int) {
+        val count = n.coerceAtMost(cols - cursorCol)
+        // Shift characters left
+        for (col in cursorCol until cols - count) {
+            cells[cursorRow][col].copyFrom(cells[cursorRow][col + count])
+        }
+        // Clear end positions
+        for (col in (cols - count).coerceAtLeast(cursorCol) until cols) {
+            cells[cursorRow][col].reset()
+        }
+    }
+
+    private fun eraseInDisplay(mode: Int) {
+        when (mode) {
+            0 -> { // Erase below (including cursor position)
+                eraseInLine(0)
+                for (row in cursorRow + 1 until rows) {
+                    for (col in 0 until cols) {
+                        cells[row][col].reset()
+                    }
+                }
+            }
+            1 -> { // Erase above (including cursor position)
+                for (row in 0 until cursorRow) {
+                    for (col in 0 until cols) {
+                        cells[row][col].reset()
+                    }
+                }
+                eraseInLine(1)
+            }
+            2 -> { // Erase all
+                for (row in 0 until rows) {
+                    for (col in 0 until cols) {
+                        cells[row][col].reset()
+                    }
+                }
+            }
+            3 -> { // Erase all + scrollback
+                scrollback.clear()
+                for (row in 0 until rows) {
+                    for (col in 0 until cols) {
+                        cells[row][col].reset()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun eraseInLine(mode: Int) {
+        when (mode) {
+            0 -> { // Erase right (including cursor position)
+                for (col in cursorCol until cols) {
+                    cells[cursorRow][col].reset()
+                }
+            }
+            1 -> { // Erase left (including cursor position)
+                for (col in 0..cursorCol.coerceAtMost(cols - 1)) {
+                    cells[cursorRow][col].reset()
+                }
+            }
+            2 -> { // Erase whole line
+                for (col in 0 until cols) {
+                    cells[cursorRow][col].reset()
+                }
+            }
+        }
+    }
+
+    private fun enterAltScreen() {
+        if (altScreen != null) return
+        // Save current screen and cursor
+        altCursorRow = cursorRow
+        altCursorCol = cursorCol
+        altScreen = cells
+        // Create fresh screen
+        cells = makeGrid(cols, rows)
+        cursorRow = 0
+        cursorCol = 0
+        wrapPending = false
+    }
+
+    private fun leaveAltScreen() {
+        val saved = altScreen ?: return
+        cells = saved
+        altScreen = null
+        cursorRow = altCursorRow
+        cursorCol = altCursorCol
+        wrapPending = false
+    }
+
+    private fun saveCursor() {
+        savedCursorRow = cursorRow
+        savedCursorCol = cursorCol
+        savedSgrState = SgrState().apply { copyFrom(sgrState) }
+    }
+
+    private fun restoreCursor() {
+        cursorRow = savedCursorRow.coerceIn(0, rows - 1)
+        cursorCol = savedCursorCol.coerceIn(0, cols - 1)
+        sgrState.copyFrom(savedSgrState)
+        wrapPending = false
+    }
+
+    private fun applySgr(params: List<Int>) {
+        if (params.isEmpty() || (params.size == 1 && params[0] == 0)) {
+            sgrState.reset()
+            return
+        }
+
+        var i = 0
+        while (i < params.size) {
+            when (val p = params[i]) {
+                0 -> sgrState.reset()
+                1 -> sgrState.bold = true
+                2 -> sgrState.dim = true
+                3 -> sgrState.italic = true
+                4 -> sgrState.underline = true
+                5, 6 -> { /* blink - ignore */ }
+                7 -> sgrState.reverse = true
+                8 -> { /* hidden - ignore */ }
+                9 -> { /* strikethrough - ignore */ }
+                22 -> { sgrState.bold = false; sgrState.dim = false }
+                23 -> sgrState.italic = false
+                24 -> sgrState.underline = false
+                25 -> { /* not blink */ }
+                27 -> sgrState.reverse = false
+                28 -> { /* not hidden */ }
+                29 -> { /* not strikethrough */ }
+                in 30..37 -> sgrState.fg = ansi8Color(p - 30, sgrState.bold)
+                38 -> { i = parseExtendedColor(params, i) { sgrState.fg = it } }
+                39 -> sgrState.fg = DEFAULT_FG
+                in 40..47 -> sgrState.bg = ansi8Color(p - 40, false)
+                48 -> { i = parseExtendedColor(params, i) { sgrState.bg = it } }
+                49 -> sgrState.bg = Color.Transparent
+                in 90..97 -> sgrState.fg = ansi8Color(p - 90 + 8, false)
+                in 100..107 -> sgrState.bg = ansi8Color(p - 100 + 8, false)
+            }
+            i++
+        }
+    }
+
+    private inline fun parseExtendedColor(
+        params: List<Int>,
+        i: Int,
+        apply: (Color) -> Unit,
+    ): Int {
+        if (i + 1 >= params.size) return i
+        return when (params[i + 1]) {
+            5 -> {
+                if (i + 2 < params.size) {
+                    apply(ansi256Color(params[i + 2]))
+                    i + 2
+                } else i + 1
+            }
+            2 -> {
+                if (i + 4 < params.size) {
+                    apply(Color(params[i + 2], params[i + 3], params[i + 4]))
+                    i + 4
+                } else i + 1
+            }
+            else -> i + 1
+        }
+    }
+
+    @Synchronized
+    fun getDisplayLines(): List<TerminalLine> {
+        val result = mutableListOf<TerminalLine>()
+
+        // Add scrollback lines (skip trailing empty ones)
+        for (row in scrollback) {
+            val line = cellRowToTerminalLine(row)
+            if (line.chars.isNotEmpty()) {
+                result.add(line)
+            }
+        }
+
+        // Add visible grid lines (always include all rows to preserve layout)
+        for (row in 0 until rows) {
+            result.add(cellRowToTerminalLine(cells[row]))
+        }
+
+        return result
+    }
+
+    private fun cellRowToTerminalLine(row: Array<Cell>): TerminalLine {
+        val chars = mutableListOf<StyledChar>()
+        for (cell in row) {
+            val fg: Color
+            val bg: Color
+            if (cell.reverse) {
+                fg = if (cell.bg == Color.Transparent) TERMINAL_BG else cell.bg
+                bg = cell.fg
+            } else {
+                fg = cell.fg
+                bg = cell.bg
+            }
+            chars.add(
+                StyledChar(
+                    char = cell.char,
+                    fg = fg,
+                    bg = bg,
+                    bold = cell.bold,
+                )
+            )
+        }
+
+        // Trim trailing spaces with transparent background
+        var end = chars.size
+        while (end > 0 && chars[end - 1].char == ' ' && chars[end - 1].bg == Color.Transparent) {
+            end--
+        }
+
+        return TerminalLine(if (end == chars.size) chars else chars.subList(0, end))
+    }
+
+    @Synchronized
+    fun resize(newCols: Int, newRows: Int) {
+        if (newCols <= 0 || newRows <= 0) return
+        if (newCols == cols && newRows == rows) return
+
+        val newCells = makeGrid(newCols, newRows)
+
+        // Copy existing content
+        val copyRows = minOf(rows, newRows)
+        val copyCols = minOf(cols, newCols)
+        for (row in 0 until copyRows) {
+            for (col in 0 until copyCols) {
+                newCells[row][col].copyFrom(cells[row][col])
+            }
+        }
+
+        cells = newCells
+        cols = newCols
+        rows = newRows
+
+        cursorRow = cursorRow.coerceIn(0, rows - 1)
+        cursorCol = cursorCol.coerceIn(0, cols - 1)
+
+        scrollTop = 0
+        scrollBottom = rows - 1
+
+        // Resize alt screen if active
+        altScreen?.let {
+            val newAlt = makeGrid(newCols, newRows)
+            val altCopyRows = minOf(it.size, newRows)
+            val altCopyCols = minOf(if (it.isNotEmpty()) it[0].size else 0, newCols)
+            for (row in 0 until altCopyRows) {
+                for (col in 0 until altCopyCols) {
+                    newAlt[row][col].copyFrom(it[row][col])
+                }
+            }
+            altScreen = newAlt
+        }
+
+        wrapPending = false
+    }
+
+    @Synchronized
+    fun reset() {
+        cells = makeGrid(cols, rows)
+        scrollback.clear()
+        cursorRow = 0
+        cursorCol = 0
+        savedCursorRow = 0
+        savedCursorCol = 0
+        savedSgrState = SgrState()
+        scrollTop = 0
+        scrollBottom = rows - 1
+        altScreen = null
+        sgrState.reset()
+        parseState = ParseState.Normal
+        autoWrap = true
+        wrapPending = false
+        utf8Remaining = 0
+        utf8Codepoint = 0
+    }
+
+    private fun List<Int>.getOrDefault(index: Int, default: Int): Int {
+        return if (index < size) this[index] else default
+    }
+
+    private fun makeGrid(gridCols: Int, gridRows: Int): Array<Array<Cell>> {
+        return Array(gridRows) { Array(gridCols) { Cell() } }
+    }
+}

--- a/android/app/src/main/java/com/zremote/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/zremote/ui/theme/Color.kt
@@ -1,0 +1,24 @@
+package com.zremote.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Dark theme palette matching desktop GPUI client
+val Background = Color(0xFF1A1A2E)
+val Surface = Color(0xFF1E1E32)
+val SurfaceVariant = Color(0xFF252540)
+val Primary = Color(0xFF6C63FF)
+val PrimaryVariant = Color(0xFF5A52D5)
+val Secondary = Color(0xFF03DAC6)
+val OnBackground = Color(0xFFE0E0E0)
+val OnSurface = Color(0xFFE0E0E0)
+val OnSurfaceVariant = Color(0xFFA0A0B0)
+val OnPrimary = Color(0xFFFFFFFF)
+val Error = Color(0xFFCF6679)
+
+// Status colors for agentic loops
+val StatusWorking = Color(0xFF60A5FA)
+val StatusWaitingForInput = Color(0xFFFBBF24)
+val StatusError = Color(0xFFEF4444)
+val StatusCompleted = Color(0xFF4ADE80)
+val StatusOffline = Color(0xFF6B7280)
+val StatusOnline = Color(0xFF4ADE80)

--- a/android/app/src/main/java/com/zremote/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/zremote/ui/theme/Theme.kt
@@ -1,0 +1,27 @@
+package com.zremote.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    secondary = Secondary,
+    background = Background,
+    surface = Surface,
+    surfaceVariant = SurfaceVariant,
+    onBackground = OnBackground,
+    onSurface = OnSurface,
+    onSurfaceVariant = OnSurfaceVariant,
+    error = Error,
+)
+
+@Composable
+fun ZRemoteTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = DarkColorScheme,
+        typography = Typography,
+        content = content,
+    )
+}

--- a/android/app/src/main/java/com/zremote/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/zremote/ui/theme/Type.kt
@@ -1,0 +1,41 @@
+package com.zremote.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    headlineMedium = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp,
+        letterSpacing = 0.sp,
+    ),
+    titleMedium = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        letterSpacing = 0.1.sp,
+    ),
+    bodyLarge = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 13.sp,
+        letterSpacing = 0.sp,
+    ),
+    bodyMedium = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        letterSpacing = 0.sp,
+    ),
+    bodySmall = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 11.sp,
+        letterSpacing = 0.sp,
+    ),
+    labelSmall = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 10.sp,
+        letterSpacing = 0.sp,
+        fontFamily = FontFamily.Monospace,
+    ),
+)

--- a/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#1A1A2E" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#6C63FF"
+        android:pathData="M54,30 L54,78 M30,54 L78,54"
+        android:strokeWidth="6"
+        android:strokeColor="#6C63FF" />
+    <path
+        android:fillColor="#6C63FF"
+        android:pathData="M38,38 L54,30 L70,38 L70,70 L54,78 L38,70 Z" />
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.ZRemote" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ksp) apply false
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ serialization = "1.7.3"
 navigation = "2.8.5"
 lifecycle = "2.8.7"
 datastore = "1.1.4"
+jna = "5.14.0"
 core-ktx = "1.15.0"
 activity-compose = "1.9.3"
 
@@ -42,6 +43,9 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+
+# JNA (for UniFFI generated bindings)
+jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,47 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+compose-bom = "2025.01.00"
+hilt = "2.53"
+ksp = "2.1.0-1.0.29"
+navigation = "2.8.5"
+lifecycle = "2.8.7"
+datastore = "1.1.4"
+core-ktx = "1.15.0"
+activity-compose = "1.9.3"
+
+[libraries]
+# Compose
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
+
+# AndroidX
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+
+# Navigation
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+
+# Lifecycle
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+
+# Hilt
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+
+# DataStore
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.1.0"
 compose-bom = "2025.01.00"
 hilt = "2.53"
 ksp = "2.1.0-1.0.29"
+serialization = "1.7.3"
 navigation = "2.8.5"
 lifecycle = "2.8.7"
 datastore = "1.1.4"
@@ -36,6 +37,9 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
 
+# Serialization
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
@@ -45,3 +49,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -12,7 +12,8 @@ pluginManagement {
     }
 }
 
-dependencyResolution {
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolution {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ZRemote"
+include(":app")

--- a/crates/zremote-client/src/terminal.rs
+++ b/crates/zremote-client/src/terminal.rs
@@ -109,6 +109,9 @@ impl TerminalSession {
                 }
                 Err(e) => {
                     error!(error = %e, "failed to connect terminal WebSocket");
+                    let _ = output_tx.send(TerminalEvent::Error {
+                        message: format!("WebSocket connection failed: {e}"),
+                    });
                     let _ = output_tx.send(TerminalEvent::SessionClosed { exit_code: None });
                 }
             }

--- a/crates/zremote-client/tests/terminal.rs
+++ b/crates/zremote-client/tests/terminal.rs
@@ -258,6 +258,7 @@ async fn connect_spawned_failure_sends_session_closed() {
     let session =
         TerminalSession::connect_spawned("ws://127.0.0.1:1/ws/terminal/nope".to_string(), &handle);
 
+    // First event should be Error with connection failure message
     let event = tokio::time::timeout(
         std::time::Duration::from_secs(5),
         session.output_rx.recv_async(),
@@ -267,10 +268,29 @@ async fn connect_spawned_failure_sends_session_closed() {
     .unwrap();
 
     match event {
+        TerminalEvent::Error { message } => {
+            assert!(
+                message.contains("WebSocket connection failed"),
+                "error should mention connection failure, got: {message}",
+            );
+        }
+        other => panic!("expected Error on failed connect, got {other:?}"),
+    }
+
+    // Second event should be SessionClosed
+    let event2 = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        session.output_rx.recv_async(),
+    )
+    .await
+    .expect("should receive SessionClosed within timeout")
+    .unwrap();
+
+    match event2 {
         TerminalEvent::SessionClosed { exit_code } => {
             assert_eq!(exit_code, None, "failed connect should have no exit code");
         }
-        other => panic!("expected SessionClosed on failed connect, got {other:?}"),
+        other => panic!("expected SessionClosed after Error, got {other:?}"),
     }
 }
 

--- a/crates/zremote-ffi/Cargo.toml
+++ b/crates/zremote-ffi/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "zremote-ffi"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "zremote_ffi"
+
+[lints]
+workspace = true
+
+[dependencies]
+zremote-client.workspace = true
+uniffi = { version = "0.29", features = ["cli"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
+tokio-util.workspace = true
+tracing.workspace = true
+flume.workspace = true
+serde_json.workspace = true
+thiserror = "2"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"

--- a/crates/zremote-ffi/src/client.rs
+++ b/crates/zremote-ffi/src/client.rs
@@ -1,0 +1,803 @@
+use std::sync::Arc;
+
+use zremote_client::ApiClient;
+
+use crate::error::FfiError;
+use crate::events::{EventListener, ZRemoteEventStream};
+use crate::terminal::{TerminalListener, ZRemoteTerminal};
+use crate::types::{
+    FfiAddProjectRequest, FfiAgenticLoop, FfiClaudeSessionInfo, FfiClaudeTask, FfiConfigValue,
+    FfiCreateClaudeTaskRequest, FfiCreateSessionRequest, FfiCreateSessionResponse,
+    FfiCreateWorktreeRequest, FfiDirectoryEntry, FfiExtractedMemory, FfiHost, FfiKnowledgeBase,
+    FfiListClaudeTasksFilter, FfiListLoopsFilter, FfiMemory, FfiMemoryCategory, FfiModeInfo,
+    FfiProject, FfiSearchRequest, FfiSearchResult, FfiSession, FfiUpdateHostRequest,
+    FfiUpdateProjectRequest, FfiWorktreeInfo,
+};
+
+/// FFI-safe client for the `ZRemote` REST + WebSocket API.
+///
+/// Owns a Tokio runtime (via `Arc`) for async bridging. All async methods
+/// become `suspend fun` in Kotlin and `async` in Swift.
+///
+/// The runtime is shared with derived `ZRemoteEventStream` and `ZRemoteTerminal`
+/// handles, so it stays alive as long as any handle exists.
+#[derive(uniffi::Object)]
+pub struct ZRemoteClient {
+    inner: ApiClient,
+    runtime: Arc<tokio::runtime::Runtime>,
+}
+
+#[uniffi::export]
+#[allow(clippy::needless_pass_by_value)] // UniFFI requires owned types at FFI boundary
+impl ZRemoteClient {
+    /// Create a new client connected to the given server URL.
+    #[uniffi::constructor]
+    pub fn new(base_url: String) -> Result<Arc<Self>, FfiError> {
+        let inner = ApiClient::new(&base_url).map_err(FfiError::from)?;
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .map_err(|e| FfiError::Http {
+                    message: format!("failed to create tokio runtime: {e}"),
+                })?,
+        );
+        Ok(Arc::new(Self { inner, runtime }))
+    }
+
+    /// Get the base URL of the server.
+    pub fn base_url(&self) -> String {
+        self.inner.base_url().to_string()
+    }
+
+    // -----------------------------------------------------------------------
+    // Health & Mode
+    // -----------------------------------------------------------------------
+
+    /// Check server health.
+    pub async fn health(&self) -> Result<(), FfiError> {
+        self.inner.health().await.map_err(Into::into)
+    }
+
+    /// Get server mode ("server" or "local").
+    pub async fn get_mode(&self) -> Result<String, FfiError> {
+        self.inner.get_mode().await.map_err(Into::into)
+    }
+
+    /// Get server mode and version.
+    pub async fn get_mode_info(&self) -> Result<FfiModeInfo, FfiError> {
+        self.inner
+            .get_mode_info()
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Hosts
+    // -----------------------------------------------------------------------
+
+    /// List all hosts.
+    pub async fn list_hosts(&self) -> Result<Vec<FfiHost>, FfiError> {
+        self.inner
+            .list_hosts()
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Get a single host by ID.
+    pub async fn get_host(&self, host_id: String) -> Result<FfiHost, FfiError> {
+        self.inner
+            .get_host(&host_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Update a host's name.
+    pub async fn update_host(
+        &self,
+        host_id: String,
+        req: FfiUpdateHostRequest,
+    ) -> Result<FfiHost, FfiError> {
+        let sdk_req = zremote_client::types::UpdateHostRequest { name: req.name };
+        self.inner
+            .update_host(&host_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Delete a host.
+    pub async fn delete_host(&self, host_id: String) -> Result<(), FfiError> {
+        self.inner.delete_host(&host_id).await.map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Sessions
+    // -----------------------------------------------------------------------
+
+    /// List sessions for a host.
+    pub async fn list_sessions(&self, host_id: String) -> Result<Vec<FfiSession>, FfiError> {
+        self.inner
+            .list_sessions(&host_id)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Create a new terminal session.
+    pub async fn create_session(
+        &self,
+        host_id: String,
+        req: FfiCreateSessionRequest,
+    ) -> Result<FfiCreateSessionResponse, FfiError> {
+        let sdk_req: zremote_client::CreateSessionRequest = req.into();
+        self.inner
+            .create_session(&host_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Get a single session by ID.
+    pub async fn get_session(&self, session_id: String) -> Result<FfiSession, FfiError> {
+        self.inner
+            .get_session(&session_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Update a session (e.g. rename).
+    pub async fn update_session(
+        &self,
+        session_id: String,
+        name: Option<String>,
+    ) -> Result<FfiSession, FfiError> {
+        let sdk_req = zremote_client::types::UpdateSessionRequest { name };
+        self.inner
+            .update_session(&session_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Close a session.
+    pub async fn close_session(&self, session_id: String) -> Result<(), FfiError> {
+        self.inner
+            .close_session(&session_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Purge a closed session's data.
+    pub async fn purge_session(&self, session_id: String) -> Result<(), FfiError> {
+        self.inner
+            .purge_session(&session_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Projects
+    // -----------------------------------------------------------------------
+
+    /// List projects for a host.
+    pub async fn list_projects(&self, host_id: String) -> Result<Vec<FfiProject>, FfiError> {
+        self.inner
+            .list_projects(&host_id)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Get a single project by ID.
+    pub async fn get_project(&self, project_id: String) -> Result<FfiProject, FfiError> {
+        self.inner
+            .get_project(&project_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Update a project.
+    pub async fn update_project(
+        &self,
+        project_id: String,
+        req: FfiUpdateProjectRequest,
+    ) -> Result<FfiProject, FfiError> {
+        let sdk_req = zremote_client::types::UpdateProjectRequest { pinned: req.pinned };
+        self.inner
+            .update_project(&project_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Delete a project.
+    pub async fn delete_project(&self, project_id: String) -> Result<(), FfiError> {
+        self.inner
+            .delete_project(&project_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Add a project by path.
+    pub async fn add_project(
+        &self,
+        host_id: String,
+        req: FfiAddProjectRequest,
+    ) -> Result<(), FfiError> {
+        let sdk_req = zremote_client::types::AddProjectRequest { path: req.path };
+        self.inner
+            .add_project(&host_id, &sdk_req)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Trigger project scan on a host.
+    pub async fn trigger_scan(&self, host_id: String) -> Result<(), FfiError> {
+        self.inner.trigger_scan(&host_id).await.map_err(Into::into)
+    }
+
+    /// Trigger git refresh for a project.
+    pub async fn trigger_git_refresh(&self, project_id: String) -> Result<(), FfiError> {
+        self.inner
+            .trigger_git_refresh(&project_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// List sessions associated with a project.
+    pub async fn list_project_sessions(
+        &self,
+        project_id: String,
+    ) -> Result<Vec<FfiSession>, FfiError> {
+        self.inner
+            .list_project_sessions(&project_id)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Worktrees
+    // -----------------------------------------------------------------------
+
+    /// List worktrees for a project.
+    pub async fn list_worktrees(
+        &self,
+        project_id: String,
+    ) -> Result<Vec<FfiWorktreeInfo>, FfiError> {
+        self.inner
+            .list_worktrees(&project_id)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Create a new worktree.
+    pub async fn create_worktree(
+        &self,
+        project_id: String,
+        req: FfiCreateWorktreeRequest,
+    ) -> Result<FfiWorktreeInfo, FfiError> {
+        let sdk_req = zremote_client::CreateWorktreeRequest {
+            branch: req.branch,
+            path: req.path,
+            new_branch: req.new_branch,
+        };
+        self.inner
+            .create_worktree(&project_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Delete a worktree.
+    pub async fn delete_worktree(
+        &self,
+        project_id: String,
+        worktree_id: String,
+    ) -> Result<(), FfiError> {
+        self.inner
+            .delete_worktree(&project_id, &worktree_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Settings (returned as JSON string for complex nested types)
+    // -----------------------------------------------------------------------
+
+    /// Get project settings as a JSON string.
+    pub async fn get_settings_json(&self, project_id: String) -> Result<String, FfiError> {
+        let settings = self
+            .inner
+            .get_settings(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&settings).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Save project settings from a JSON string.
+    pub async fn save_settings_json(
+        &self,
+        project_id: String,
+        settings_json: String,
+    ) -> Result<String, FfiError> {
+        let settings: zremote_client::ProjectSettings = serde_json::from_str(&settings_json)
+            .map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })?;
+        let result = self
+            .inner
+            .save_settings(&project_id, &settings)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Actions (returned as JSON string for dynamic types)
+    // -----------------------------------------------------------------------
+
+    /// List available actions for a project. Returns JSON string.
+    pub async fn list_actions(&self, project_id: String) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .list_actions(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Run a project action. Returns result as JSON string.
+    pub async fn run_action(
+        &self,
+        project_id: String,
+        action_name: String,
+    ) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .run_action(&project_id, &action_name)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Resolve action inputs. Returns JSON string.
+    pub async fn resolve_action_inputs(
+        &self,
+        project_id: String,
+        action_name: String,
+        body_json: String,
+    ) -> Result<String, FfiError> {
+        let body: serde_json::Value =
+            serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })?;
+        let result = self
+            .inner
+            .resolve_action_inputs(&project_id, &action_name, &body)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Resolve a prompt template. Returns JSON string.
+    pub async fn resolve_prompt(
+        &self,
+        project_id: String,
+        prompt_name: String,
+        body_json: String,
+    ) -> Result<String, FfiError> {
+        let body: serde_json::Value =
+            serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })?;
+        let result = self
+            .inner
+            .resolve_prompt(&project_id, &prompt_name, &body)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Configure a project with Claude. Returns JSON string.
+    pub async fn configure_with_claude(&self, project_id: String) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .configure_with_claude(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Directory
+    // -----------------------------------------------------------------------
+
+    /// Browse a directory on a host.
+    pub async fn browse_directory(
+        &self,
+        host_id: String,
+        path: Option<String>,
+    ) -> Result<Vec<FfiDirectoryEntry>, FfiError> {
+        self.inner
+            .browse_directory(&host_id, path.as_deref())
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Agentic Loops
+    // -----------------------------------------------------------------------
+
+    /// List agentic loops with optional filters.
+    pub async fn list_loops(
+        &self,
+        filter: FfiListLoopsFilter,
+    ) -> Result<Vec<FfiAgenticLoop>, FfiError> {
+        let sdk_filter: zremote_client::ListLoopsFilter = filter.into();
+        self.inner
+            .list_loops(&sdk_filter)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Get a single agentic loop by ID.
+    pub async fn get_loop(&self, loop_id: String) -> Result<FfiAgenticLoop, FfiError> {
+        self.inner
+            .get_loop(&loop_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Config
+    // -----------------------------------------------------------------------
+
+    /// Get a global config value.
+    pub async fn get_global_config(&self, key: String) -> Result<FfiConfigValue, FfiError> {
+        self.inner
+            .get_global_config(&key)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Set a global config value.
+    pub async fn set_global_config(
+        &self,
+        key: String,
+        value: String,
+    ) -> Result<FfiConfigValue, FfiError> {
+        self.inner
+            .set_global_config(&key, &value)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Get a host-scoped config value.
+    pub async fn get_host_config(
+        &self,
+        host_id: String,
+        key: String,
+    ) -> Result<FfiConfigValue, FfiError> {
+        self.inner
+            .get_host_config(&host_id, &key)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Set a host-scoped config value.
+    pub async fn set_host_config(
+        &self,
+        host_id: String,
+        key: String,
+        value: String,
+    ) -> Result<FfiConfigValue, FfiError> {
+        self.inner
+            .set_host_config(&host_id, &key, &value)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // Knowledge
+    // -----------------------------------------------------------------------
+
+    /// Get knowledge service status for a project.
+    pub async fn get_knowledge_status(
+        &self,
+        project_id: String,
+    ) -> Result<Option<FfiKnowledgeBase>, FfiError> {
+        self.inner
+            .get_knowledge_status(&project_id)
+            .await
+            .map(|opt| opt.map(Into::into))
+            .map_err(Into::into)
+    }
+
+    /// Trigger knowledge indexing for a project.
+    pub async fn trigger_index(
+        &self,
+        project_id: String,
+        force_reindex: bool,
+    ) -> Result<(), FfiError> {
+        let req = zremote_client::types::IndexRequest { force_reindex };
+        self.inner
+            .trigger_index(&project_id, &req)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Search knowledge for a project.
+    pub async fn search_knowledge(
+        &self,
+        project_id: String,
+        req: FfiSearchRequest,
+    ) -> Result<Vec<FfiSearchResult>, FfiError> {
+        let sdk_req: zremote_client::types::SearchRequest = req.into();
+        self.inner
+            .search_knowledge(&project_id, &sdk_req)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// List memories for a project.
+    pub async fn list_memories(
+        &self,
+        project_id: String,
+        category: Option<String>,
+    ) -> Result<Vec<FfiMemory>, FfiError> {
+        self.inner
+            .list_memories(&project_id, category.as_deref())
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Update a memory entry.
+    pub async fn update_memory(
+        &self,
+        project_id: String,
+        memory_id: String,
+        content: Option<String>,
+        category: Option<FfiMemoryCategory>,
+    ) -> Result<FfiMemory, FfiError> {
+        let sdk_req = zremote_client::types::UpdateMemoryRequest {
+            content,
+            category: category.map(Into::into),
+        };
+        self.inner
+            .update_memory(&project_id, &memory_id, &sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Delete a memory entry.
+    pub async fn delete_memory(
+        &self,
+        project_id: String,
+        memory_id: String,
+    ) -> Result<(), FfiError> {
+        self.inner
+            .delete_memory(&project_id, &memory_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Extract memories from a loop transcript.
+    pub async fn extract_memories(
+        &self,
+        project_id: String,
+        loop_id: String,
+    ) -> Result<Vec<FfiExtractedMemory>, FfiError> {
+        let req = zremote_client::types::ExtractRequest { loop_id };
+        self.inner
+            .extract_memories(&project_id, &req)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Generate CLAUDE.md instructions for a project. Returns JSON string.
+    pub async fn generate_instructions(&self, project_id: String) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .generate_instructions(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Write CLAUDE.md for a project. Returns JSON string.
+    pub async fn write_claude_md(&self, project_id: String) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .write_claude_md(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Bootstrap a project (init knowledge + extract). Returns JSON string.
+    pub async fn bootstrap_project(&self, project_id: String) -> Result<String, FfiError> {
+        let result = self
+            .inner
+            .bootstrap_project(&project_id)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    /// Control the knowledge service on a host.
+    pub async fn control_knowledge_service(
+        &self,
+        host_id: String,
+        action: String,
+    ) -> Result<String, FfiError> {
+        let req = zremote_client::types::ServiceControlRequest { action };
+        let result = self
+            .inner
+            .control_knowledge_service(&host_id, &req)
+            .await
+            .map_err(FfiError::from)?;
+        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+            message: e.to_string(),
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Claude Tasks
+    // -----------------------------------------------------------------------
+
+    /// List Claude tasks with optional filters.
+    pub async fn list_claude_tasks(
+        &self,
+        filter: FfiListClaudeTasksFilter,
+    ) -> Result<Vec<FfiClaudeTask>, FfiError> {
+        let sdk_filter: zremote_client::ListClaudeTasksFilter = filter.into();
+        self.inner
+            .list_claude_tasks(&sdk_filter)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Create a new Claude task.
+    pub async fn create_claude_task(
+        &self,
+        req: FfiCreateClaudeTaskRequest,
+    ) -> Result<FfiClaudeTask, FfiError> {
+        let sdk_req: zremote_client::CreateClaudeTaskRequest = req.into();
+        self.inner
+            .create_claude_task(&sdk_req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Get a single Claude task by ID.
+    pub async fn get_claude_task(&self, task_id: String) -> Result<FfiClaudeTask, FfiError> {
+        self.inner
+            .get_claude_task(&task_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Resume a Claude task.
+    pub async fn resume_claude_task(
+        &self,
+        task_id: String,
+        initial_prompt: Option<String>,
+    ) -> Result<FfiClaudeTask, FfiError> {
+        let req = zremote_client::ResumeClaudeTaskRequest { initial_prompt };
+        self.inner
+            .resume_claude_task(&task_id, &req)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Discover existing Claude sessions on a host.
+    pub async fn discover_claude_sessions(
+        &self,
+        host_id: String,
+        project_path: String,
+    ) -> Result<Vec<FfiClaudeSessionInfo>, FfiError> {
+        self.inner
+            .discover_claude_sessions(&host_id, &project_path)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    // -----------------------------------------------------------------------
+    // WebSocket connections
+    // -----------------------------------------------------------------------
+
+    /// Connect to the server event stream.
+    /// Events are delivered via the `EventListener` callback interface.
+    /// Returns a handle that can be used to disconnect.
+    pub fn connect_events(&self, listener: Box<dyn EventListener>) -> Arc<ZRemoteEventStream> {
+        let url = self.inner.events_ws_url();
+        let event_stream = zremote_client::EventStream::connect(url, self.runtime.handle());
+        ZRemoteEventStream::start(event_stream, listener, &self.runtime)
+    }
+
+    /// Connect to a terminal session WebSocket.
+    /// Output is delivered via the `TerminalListener` callback interface.
+    /// Returns a handle for sending input, resizing, and disconnecting.
+    pub fn connect_terminal(
+        &self,
+        session_id: String,
+        listener: Box<dyn TerminalListener>,
+    ) -> Arc<ZRemoteTerminal> {
+        let url = self.inner.terminal_ws_url(&session_id);
+        let session = zremote_client::TerminalSession::connect_spawned(url, self.runtime.handle());
+        ZRemoteTerminal::start(session, listener, &self.runtime)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_invalid_url_returns_error() {
+        let result = ZRemoteClient::new("not a url".to_string());
+        match result {
+            Err(FfiError::InvalidUrl { .. }) => {}
+            Err(other) => panic!("expected InvalidUrl, got {other:?}"),
+            Ok(_) => panic!("expected error for invalid URL"),
+        }
+    }
+
+    #[test]
+    fn constructor_valid_url_succeeds() {
+        let result = ZRemoteClient::new("http://localhost:3000".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn base_url_returned_correctly() {
+        let client = ZRemoteClient::new("http://localhost:3000/".to_string())
+            .expect("valid URL should succeed");
+        assert_eq!(client.base_url(), "http://localhost:3000");
+    }
+}

--- a/crates/zremote-ffi/src/client.rs
+++ b/crates/zremote-ffi/src/client.rs
@@ -56,22 +56,26 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// Check server health.
-    pub async fn health(&self) -> Result<(), FfiError> {
-        self.inner.health().await.map_err(Into::into)
+    pub fn health(&self) -> Result<(), FfiError> {
+        self.runtime
+            .block_on(async { self.inner.health().await.map_err(Into::into) })
     }
 
     /// Get server mode ("server" or "local").
-    pub async fn get_mode(&self) -> Result<String, FfiError> {
-        self.inner.get_mode().await.map_err(Into::into)
+    pub fn get_mode(&self) -> Result<String, FfiError> {
+        self.runtime
+            .block_on(async { self.inner.get_mode().await.map_err(Into::into) })
     }
 
     /// Get server mode and version.
-    pub async fn get_mode_info(&self) -> Result<FfiModeInfo, FfiError> {
-        self.inner
-            .get_mode_info()
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_mode_info(&self) -> Result<FfiModeInfo, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_mode_info()
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -79,40 +83,47 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List all hosts.
-    pub async fn list_hosts(&self) -> Result<Vec<FfiHost>, FfiError> {
-        self.inner
-            .list_hosts()
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_hosts(&self) -> Result<Vec<FfiHost>, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .list_hosts()
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Get a single host by ID.
-    pub async fn get_host(&self, host_id: String) -> Result<FfiHost, FfiError> {
-        self.inner
-            .get_host(&host_id)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_host(&self, host_id: String) -> Result<FfiHost, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_host(&host_id)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Update a host's name.
-    pub async fn update_host(
+    pub fn update_host(
         &self,
         host_id: String,
         req: FfiUpdateHostRequest,
     ) -> Result<FfiHost, FfiError> {
-        let sdk_req = zremote_client::types::UpdateHostRequest { name: req.name };
-        self.inner
-            .update_host(&host_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::types::UpdateHostRequest { name: req.name };
+            self.inner
+                .update_host(&host_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Delete a host.
-    pub async fn delete_host(&self, host_id: String) -> Result<(), FfiError> {
-        self.inner.delete_host(&host_id).await.map_err(Into::into)
+    pub fn delete_host(&self, host_id: String) -> Result<(), FfiError> {
+        self.runtime
+            .block_on(async { self.inner.delete_host(&host_id).await.map_err(Into::into) })
     }
 
     // -----------------------------------------------------------------------
@@ -120,65 +131,77 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List sessions for a host.
-    pub async fn list_sessions(&self, host_id: String) -> Result<Vec<FfiSession>, FfiError> {
-        self.inner
-            .list_sessions(&host_id)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_sessions(&self, host_id: String) -> Result<Vec<FfiSession>, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .list_sessions(&host_id)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Create a new terminal session.
-    pub async fn create_session(
+    pub fn create_session(
         &self,
         host_id: String,
         req: FfiCreateSessionRequest,
     ) -> Result<FfiCreateSessionResponse, FfiError> {
-        let sdk_req: zremote_client::CreateSessionRequest = req.into();
-        self.inner
-            .create_session(&host_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req: zremote_client::CreateSessionRequest = req.into();
+            self.inner
+                .create_session(&host_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Get a single session by ID.
-    pub async fn get_session(&self, session_id: String) -> Result<FfiSession, FfiError> {
-        self.inner
-            .get_session(&session_id)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_session(&self, session_id: String) -> Result<FfiSession, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_session(&session_id)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Update a session (e.g. rename).
-    pub async fn update_session(
+    pub fn update_session(
         &self,
         session_id: String,
         name: Option<String>,
     ) -> Result<FfiSession, FfiError> {
-        let sdk_req = zremote_client::types::UpdateSessionRequest { name };
-        self.inner
-            .update_session(&session_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::types::UpdateSessionRequest { name };
+            self.inner
+                .update_session(&session_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Close a session.
-    pub async fn close_session(&self, session_id: String) -> Result<(), FfiError> {
-        self.inner
-            .close_session(&session_id)
-            .await
-            .map_err(Into::into)
+    pub fn close_session(&self, session_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .close_session(&session_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// Purge a closed session's data.
-    pub async fn purge_session(&self, session_id: String) -> Result<(), FfiError> {
-        self.inner
-            .purge_session(&session_id)
-            .await
-            .map_err(Into::into)
+    pub fn purge_session(&self, session_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .purge_session(&session_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -186,81 +209,89 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List projects for a host.
-    pub async fn list_projects(&self, host_id: String) -> Result<Vec<FfiProject>, FfiError> {
-        self.inner
-            .list_projects(&host_id)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_projects(&self, host_id: String) -> Result<Vec<FfiProject>, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .list_projects(&host_id)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Get a single project by ID.
-    pub async fn get_project(&self, project_id: String) -> Result<FfiProject, FfiError> {
-        self.inner
-            .get_project(&project_id)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_project(&self, project_id: String) -> Result<FfiProject, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_project(&project_id)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Update a project.
-    pub async fn update_project(
+    pub fn update_project(
         &self,
         project_id: String,
         req: FfiUpdateProjectRequest,
     ) -> Result<FfiProject, FfiError> {
-        let sdk_req = zremote_client::types::UpdateProjectRequest { pinned: req.pinned };
-        self.inner
-            .update_project(&project_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::types::UpdateProjectRequest { pinned: req.pinned };
+            self.inner
+                .update_project(&project_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Delete a project.
-    pub async fn delete_project(&self, project_id: String) -> Result<(), FfiError> {
-        self.inner
-            .delete_project(&project_id)
-            .await
-            .map_err(Into::into)
+    pub fn delete_project(&self, project_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .delete_project(&project_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// Add a project by path.
-    pub async fn add_project(
-        &self,
-        host_id: String,
-        req: FfiAddProjectRequest,
-    ) -> Result<(), FfiError> {
-        let sdk_req = zremote_client::types::AddProjectRequest { path: req.path };
-        self.inner
-            .add_project(&host_id, &sdk_req)
-            .await
-            .map_err(Into::into)
+    pub fn add_project(&self, host_id: String, req: FfiAddProjectRequest) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::types::AddProjectRequest { path: req.path };
+            self.inner
+                .add_project(&host_id, &sdk_req)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// Trigger project scan on a host.
-    pub async fn trigger_scan(&self, host_id: String) -> Result<(), FfiError> {
-        self.inner.trigger_scan(&host_id).await.map_err(Into::into)
+    pub fn trigger_scan(&self, host_id: String) -> Result<(), FfiError> {
+        self.runtime
+            .block_on(async { self.inner.trigger_scan(&host_id).await.map_err(Into::into) })
     }
 
     /// Trigger git refresh for a project.
-    pub async fn trigger_git_refresh(&self, project_id: String) -> Result<(), FfiError> {
-        self.inner
-            .trigger_git_refresh(&project_id)
-            .await
-            .map_err(Into::into)
+    pub fn trigger_git_refresh(&self, project_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .trigger_git_refresh(&project_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// List sessions associated with a project.
-    pub async fn list_project_sessions(
-        &self,
-        project_id: String,
-    ) -> Result<Vec<FfiSession>, FfiError> {
-        self.inner
-            .list_project_sessions(&project_id)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_project_sessions(&self, project_id: String) -> Result<Vec<FfiSession>, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .list_project_sessions(&project_id)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -268,45 +299,44 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List worktrees for a project.
-    pub async fn list_worktrees(
-        &self,
-        project_id: String,
-    ) -> Result<Vec<FfiWorktreeInfo>, FfiError> {
-        self.inner
-            .list_worktrees(&project_id)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_worktrees(&self, project_id: String) -> Result<Vec<FfiWorktreeInfo>, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .list_worktrees(&project_id)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Create a new worktree.
-    pub async fn create_worktree(
+    pub fn create_worktree(
         &self,
         project_id: String,
         req: FfiCreateWorktreeRequest,
     ) -> Result<FfiWorktreeInfo, FfiError> {
-        let sdk_req = zremote_client::CreateWorktreeRequest {
-            branch: req.branch,
-            path: req.path,
-            new_branch: req.new_branch,
-        };
-        self.inner
-            .create_worktree(&project_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::CreateWorktreeRequest {
+                branch: req.branch,
+                path: req.path,
+                new_branch: req.new_branch,
+            };
+            self.inner
+                .create_worktree(&project_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Delete a worktree.
-    pub async fn delete_worktree(
-        &self,
-        project_id: String,
-        worktree_id: String,
-    ) -> Result<(), FfiError> {
-        self.inner
-            .delete_worktree(&project_id, &worktree_id)
-            .await
-            .map_err(Into::into)
+    pub fn delete_worktree(&self, project_id: String, worktree_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .delete_worktree(&project_id, &worktree_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -314,34 +344,38 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// Get project settings as a JSON string.
-    pub async fn get_settings_json(&self, project_id: String) -> Result<String, FfiError> {
-        let settings = self
-            .inner
-            .get_settings(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&settings).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn get_settings_json(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let settings = self
+                .inner
+                .get_settings(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&settings).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Save project settings from a JSON string.
-    pub async fn save_settings_json(
+    pub fn save_settings_json(
         &self,
         project_id: String,
         settings_json: String,
     ) -> Result<String, FfiError> {
-        let settings: zremote_client::ProjectSettings = serde_json::from_str(&settings_json)
-            .map_err(|e| FfiError::Serialization {
+        self.runtime.block_on(async {
+            let settings: zremote_client::ProjectSettings = serde_json::from_str(&settings_json)
+                .map_err(|e| FfiError::Serialization {
+                    message: e.to_string(),
+                })?;
+            let result = self
+                .inner
+                .save_settings(&project_id, &settings)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
                 message: e.to_string(),
-            })?;
-        let result = self
-            .inner
-            .save_settings(&project_id, &settings)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+            })
         })
     }
 
@@ -350,84 +384,90 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List available actions for a project. Returns JSON string.
-    pub async fn list_actions(&self, project_id: String) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .list_actions(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn list_actions(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .list_actions(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Run a project action. Returns result as JSON string.
-    pub async fn run_action(
-        &self,
-        project_id: String,
-        action_name: String,
-    ) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .run_action(&project_id, &action_name)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn run_action(&self, project_id: String, action_name: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .run_action(&project_id, &action_name)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Resolve action inputs. Returns JSON string.
-    pub async fn resolve_action_inputs(
+    pub fn resolve_action_inputs(
         &self,
         project_id: String,
         action_name: String,
         body_json: String,
     ) -> Result<String, FfiError> {
-        let body: serde_json::Value =
-            serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+        self.runtime.block_on(async {
+            let body: serde_json::Value =
+                serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+                    message: e.to_string(),
+                })?;
+            let result = self
+                .inner
+                .resolve_action_inputs(&project_id, &action_name, &body)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
                 message: e.to_string(),
-            })?;
-        let result = self
-            .inner
-            .resolve_action_inputs(&project_id, &action_name, &body)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+            })
         })
     }
 
     /// Resolve a prompt template. Returns JSON string.
-    pub async fn resolve_prompt(
+    pub fn resolve_prompt(
         &self,
         project_id: String,
         prompt_name: String,
         body_json: String,
     ) -> Result<String, FfiError> {
-        let body: serde_json::Value =
-            serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+        self.runtime.block_on(async {
+            let body: serde_json::Value =
+                serde_json::from_str(&body_json).map_err(|e| FfiError::Serialization {
+                    message: e.to_string(),
+                })?;
+            let result = self
+                .inner
+                .resolve_prompt(&project_id, &prompt_name, &body)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
                 message: e.to_string(),
-            })?;
-        let result = self
-            .inner
-            .resolve_prompt(&project_id, &prompt_name, &body)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+            })
         })
     }
 
     /// Configure a project with Claude. Returns JSON string.
-    pub async fn configure_with_claude(&self, project_id: String) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .configure_with_claude(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn configure_with_claude(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .configure_with_claude(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
@@ -436,16 +476,18 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// Browse a directory on a host.
-    pub async fn browse_directory(
+    pub fn browse_directory(
         &self,
         host_id: String,
         path: Option<String>,
     ) -> Result<Vec<FfiDirectoryEntry>, FfiError> {
-        self.inner
-            .browse_directory(&host_id, path.as_deref())
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .browse_directory(&host_id, path.as_deref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -453,25 +495,26 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List agentic loops with optional filters.
-    pub async fn list_loops(
-        &self,
-        filter: FfiListLoopsFilter,
-    ) -> Result<Vec<FfiAgenticLoop>, FfiError> {
-        let sdk_filter: zremote_client::ListLoopsFilter = filter.into();
-        self.inner
-            .list_loops(&sdk_filter)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+    pub fn list_loops(&self, filter: FfiListLoopsFilter) -> Result<Vec<FfiAgenticLoop>, FfiError> {
+        self.runtime.block_on(async {
+            let sdk_filter: zremote_client::ListLoopsFilter = filter.into();
+            self.inner
+                .list_loops(&sdk_filter)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Get a single agentic loop by ID.
-    pub async fn get_loop(&self, loop_id: String) -> Result<FfiAgenticLoop, FfiError> {
-        self.inner
-            .get_loop(&loop_id)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_loop(&self, loop_id: String) -> Result<FfiAgenticLoop, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_loop(&loop_id)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -479,52 +522,60 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// Get a global config value.
-    pub async fn get_global_config(&self, key: String) -> Result<FfiConfigValue, FfiError> {
-        self.inner
-            .get_global_config(&key)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_global_config(&self, key: String) -> Result<FfiConfigValue, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_global_config(&key)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Set a global config value.
-    pub async fn set_global_config(
+    pub fn set_global_config(
         &self,
         key: String,
         value: String,
     ) -> Result<FfiConfigValue, FfiError> {
-        self.inner
-            .set_global_config(&key, &value)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .set_global_config(&key, &value)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Get a host-scoped config value.
-    pub async fn get_host_config(
+    pub fn get_host_config(
         &self,
         host_id: String,
         key: String,
     ) -> Result<FfiConfigValue, FfiError> {
-        self.inner
-            .get_host_config(&host_id, &key)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .get_host_config(&host_id, &key)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Set a host-scoped config value.
-    pub async fn set_host_config(
+    pub fn set_host_config(
         &self,
         host_id: String,
         key: String,
         value: String,
     ) -> Result<FfiConfigValue, FfiError> {
-        self.inner
-            .set_host_config(&host_id, &key, &value)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .set_host_config(&host_id, &key, &value)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -532,152 +583,166 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// Get knowledge service status for a project.
-    pub async fn get_knowledge_status(
+    pub fn get_knowledge_status(
         &self,
         project_id: String,
     ) -> Result<Option<FfiKnowledgeBase>, FfiError> {
-        self.inner
-            .get_knowledge_status(&project_id)
-            .await
-            .map(|opt| opt.map(Into::into))
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .get_knowledge_status(&project_id)
+                .await
+                .map(|opt| opt.map(Into::into))
+                .map_err(Into::into)
+        })
     }
 
     /// Trigger knowledge indexing for a project.
-    pub async fn trigger_index(
-        &self,
-        project_id: String,
-        force_reindex: bool,
-    ) -> Result<(), FfiError> {
-        let req = zremote_client::types::IndexRequest { force_reindex };
-        self.inner
-            .trigger_index(&project_id, &req)
-            .await
-            .map_err(Into::into)
+    pub fn trigger_index(&self, project_id: String, force_reindex: bool) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            let req = zremote_client::types::IndexRequest { force_reindex };
+            self.inner
+                .trigger_index(&project_id, &req)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// Search knowledge for a project.
-    pub async fn search_knowledge(
+    pub fn search_knowledge(
         &self,
         project_id: String,
         req: FfiSearchRequest,
     ) -> Result<Vec<FfiSearchResult>, FfiError> {
-        let sdk_req: zremote_client::types::SearchRequest = req.into();
-        self.inner
-            .search_knowledge(&project_id, &sdk_req)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req: zremote_client::types::SearchRequest = req.into();
+            self.inner
+                .search_knowledge(&project_id, &sdk_req)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// List memories for a project.
-    pub async fn list_memories(
+    pub fn list_memories(
         &self,
         project_id: String,
         category: Option<String>,
     ) -> Result<Vec<FfiMemory>, FfiError> {
-        self.inner
-            .list_memories(&project_id, category.as_deref())
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .list_memories(&project_id, category.as_deref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Update a memory entry.
-    pub async fn update_memory(
+    pub fn update_memory(
         &self,
         project_id: String,
         memory_id: String,
         content: Option<String>,
         category: Option<FfiMemoryCategory>,
     ) -> Result<FfiMemory, FfiError> {
-        let sdk_req = zremote_client::types::UpdateMemoryRequest {
-            content,
-            category: category.map(Into::into),
-        };
-        self.inner
-            .update_memory(&project_id, &memory_id, &sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req = zremote_client::types::UpdateMemoryRequest {
+                content,
+                category: category.map(Into::into),
+            };
+            self.inner
+                .update_memory(&project_id, &memory_id, &sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Delete a memory entry.
-    pub async fn delete_memory(
-        &self,
-        project_id: String,
-        memory_id: String,
-    ) -> Result<(), FfiError> {
-        self.inner
-            .delete_memory(&project_id, &memory_id)
-            .await
-            .map_err(Into::into)
+    pub fn delete_memory(&self, project_id: String, memory_id: String) -> Result<(), FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .delete_memory(&project_id, &memory_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     /// Extract memories from a loop transcript.
-    pub async fn extract_memories(
+    pub fn extract_memories(
         &self,
         project_id: String,
         loop_id: String,
     ) -> Result<Vec<FfiExtractedMemory>, FfiError> {
-        let req = zremote_client::types::ExtractRequest { loop_id };
-        self.inner
-            .extract_memories(&project_id, &req)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let req = zremote_client::types::ExtractRequest { loop_id };
+            self.inner
+                .extract_memories(&project_id, &req)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Generate CLAUDE.md instructions for a project. Returns JSON string.
-    pub async fn generate_instructions(&self, project_id: String) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .generate_instructions(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn generate_instructions(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .generate_instructions(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Write CLAUDE.md for a project. Returns JSON string.
-    pub async fn write_claude_md(&self, project_id: String) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .write_claude_md(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn write_claude_md(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .write_claude_md(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Bootstrap a project (init knowledge + extract). Returns JSON string.
-    pub async fn bootstrap_project(&self, project_id: String) -> Result<String, FfiError> {
-        let result = self
-            .inner
-            .bootstrap_project(&project_id)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+    pub fn bootstrap_project(&self, project_id: String) -> Result<String, FfiError> {
+        self.runtime.block_on(async {
+            let result = self
+                .inner
+                .bootstrap_project(&project_id)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
     /// Control the knowledge service on a host.
-    pub async fn control_knowledge_service(
+    pub fn control_knowledge_service(
         &self,
         host_id: String,
         action: String,
     ) -> Result<String, FfiError> {
-        let req = zremote_client::types::ServiceControlRequest { action };
-        let result = self
-            .inner
-            .control_knowledge_service(&host_id, &req)
-            .await
-            .map_err(FfiError::from)?;
-        serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
-            message: e.to_string(),
+        self.runtime.block_on(async {
+            let req = zremote_client::types::ServiceControlRequest { action };
+            let result = self
+                .inner
+                .control_knowledge_service(&host_id, &req)
+                .await
+                .map_err(FfiError::from)?;
+            serde_json::to_string(&result).map_err(|e| FfiError::Serialization {
+                message: e.to_string(),
+            })
         })
     }
 
@@ -686,65 +751,75 @@ impl ZRemoteClient {
     // -----------------------------------------------------------------------
 
     /// List Claude tasks with optional filters.
-    pub async fn list_claude_tasks(
+    pub fn list_claude_tasks(
         &self,
         filter: FfiListClaudeTasksFilter,
     ) -> Result<Vec<FfiClaudeTask>, FfiError> {
-        let sdk_filter: zremote_client::ListClaudeTasksFilter = filter.into();
-        self.inner
-            .list_claude_tasks(&sdk_filter)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_filter: zremote_client::ListClaudeTasksFilter = filter.into();
+            self.inner
+                .list_claude_tasks(&sdk_filter)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     /// Create a new Claude task.
-    pub async fn create_claude_task(
+    pub fn create_claude_task(
         &self,
         req: FfiCreateClaudeTaskRequest,
     ) -> Result<FfiClaudeTask, FfiError> {
-        let sdk_req: zremote_client::CreateClaudeTaskRequest = req.into();
-        self.inner
-            .create_claude_task(&sdk_req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let sdk_req: zremote_client::CreateClaudeTaskRequest = req.into();
+            self.inner
+                .create_claude_task(&sdk_req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Get a single Claude task by ID.
-    pub async fn get_claude_task(&self, task_id: String) -> Result<FfiClaudeTask, FfiError> {
-        self.inner
-            .get_claude_task(&task_id)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+    pub fn get_claude_task(&self, task_id: String) -> Result<FfiClaudeTask, FfiError> {
+        self.runtime.block_on(async {
+            self.inner
+                .get_claude_task(&task_id)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Resume a Claude task.
-    pub async fn resume_claude_task(
+    pub fn resume_claude_task(
         &self,
         task_id: String,
         initial_prompt: Option<String>,
     ) -> Result<FfiClaudeTask, FfiError> {
-        let req = zremote_client::ResumeClaudeTaskRequest { initial_prompt };
-        self.inner
-            .resume_claude_task(&task_id, &req)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            let req = zremote_client::ResumeClaudeTaskRequest { initial_prompt };
+            self.inner
+                .resume_claude_task(&task_id, &req)
+                .await
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 
     /// Discover existing Claude sessions on a host.
-    pub async fn discover_claude_sessions(
+    pub fn discover_claude_sessions(
         &self,
         host_id: String,
         project_path: String,
     ) -> Result<Vec<FfiClaudeSessionInfo>, FfiError> {
-        self.inner
-            .discover_claude_sessions(&host_id, &project_path)
-            .await
-            .map(|v| v.into_iter().map(Into::into).collect())
-            .map_err(Into::into)
+        self.runtime.block_on(async {
+            self.inner
+                .discover_claude_sessions(&host_id, &project_path)
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+                .map_err(Into::into)
+        })
     }
 
     // -----------------------------------------------------------------------

--- a/crates/zremote-ffi/src/error.rs
+++ b/crates/zremote-ffi/src/error.rs
@@ -1,0 +1,80 @@
+use zremote_client::ApiError;
+
+/// FFI-safe error type for all client operations.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FfiError {
+    /// HTTP request failed (network, DNS, timeout).
+    #[error("HTTP error: {message}")]
+    Http { message: String },
+
+    /// Server returned a non-success HTTP status.
+    #[error("Server error ({status_code}): {message}")]
+    Server { status_code: u16, message: String },
+
+    /// JSON serialization/deserialization error.
+    #[error("Serialization error: {message}")]
+    Serialization { message: String },
+
+    /// URL parsing or validation failed.
+    #[error("Invalid URL: {message}")]
+    InvalidUrl { message: String },
+
+    /// Internal channel was closed.
+    #[error("Channel closed")]
+    ChannelClosed,
+
+    /// WebSocket disconnected.
+    #[error("WebSocket error: {message}")]
+    WebSocket { message: String },
+}
+
+impl From<ApiError> for FfiError {
+    fn from(err: ApiError) -> Self {
+        match err {
+            ApiError::Http(e) => Self::Http {
+                message: e.to_string(),
+            },
+            ApiError::ServerError { status, message } => Self::Server {
+                status_code: status.as_u16(),
+                message,
+            },
+            ApiError::Serialization(e) => Self::Serialization {
+                message: e.to_string(),
+            },
+            ApiError::InvalidUrl(msg) => Self::InvalidUrl { message: msg },
+            ApiError::ChannelClosed => Self::ChannelClosed,
+            ApiError::WebSocket(e) => Self::WebSocket {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_error_invalid_url_converts() {
+        let api_err = ApiError::InvalidUrl("bad url".to_string());
+        let ffi_err = FfiError::from(api_err);
+        assert!(matches!(ffi_err, FfiError::InvalidUrl { .. }));
+    }
+
+    #[test]
+    fn api_error_channel_closed_converts() {
+        let ffi_err = FfiError::from(ApiError::ChannelClosed);
+        assert!(matches!(ffi_err, FfiError::ChannelClosed));
+    }
+
+    #[test]
+    fn display_formatting() {
+        let err = FfiError::Server {
+            status_code: 404,
+            message: "not found".to_string(),
+        };
+        let display = format!("{err}");
+        assert!(display.contains("404"));
+        assert!(display.contains("not found"));
+    }
+}

--- a/crates/zremote-ffi/src/events.rs
+++ b/crates/zremote-ffi/src/events.rs
@@ -1,0 +1,274 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use zremote_client::{ClientEvent, EventStream};
+
+use crate::types::{FfiHostInfo, FfiLoopInfo, FfiSessionInfo};
+
+/// Callback interface for receiving server events.
+///
+/// Implement this trait in Kotlin/Swift to receive real-time events.
+/// All methods are called from a background thread -- dispatch to the
+/// main thread if updating UI.
+#[uniffi::export(callback_interface)]
+pub trait EventListener: Send + Sync {
+    // Connection lifecycle
+    fn on_connected(&self);
+    fn on_disconnected(&self);
+
+    // Hosts
+    fn on_host_connected(&self, host: FfiHostInfo);
+    fn on_host_disconnected(&self, host_id: String);
+    fn on_host_status_changed(&self, host_id: String, status: String);
+
+    // Sessions
+    fn on_session_created(&self, session: FfiSessionInfo);
+    fn on_session_closed(&self, session_id: String, exit_code: Option<i32>);
+    fn on_session_updated(&self, session_id: String);
+    fn on_session_suspended(&self, session_id: String);
+    fn on_session_resumed(&self, session_id: String);
+
+    // Projects
+    fn on_projects_updated(&self, host_id: String);
+
+    // Agentic loops
+    fn on_loop_detected(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+    fn on_loop_status_changed(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+    fn on_loop_ended(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+
+    // Knowledge
+    fn on_knowledge_status_changed(&self, host_id: String, status: String, error: Option<String>);
+    fn on_indexing_progress(
+        &self,
+        project_id: String,
+        project_path: String,
+        status: String,
+        files_processed: u64,
+        files_total: u64,
+    );
+    fn on_memory_extracted(&self, project_id: String, loop_id: String, memory_count: u32);
+
+    // Worktrees
+    fn on_worktree_error(&self, host_id: String, project_path: String, message: String);
+
+    // Claude tasks
+    fn on_claude_task_started(
+        &self,
+        task_id: String,
+        session_id: String,
+        host_id: String,
+        project_path: String,
+    );
+    fn on_claude_task_updated(&self, task_id: String, status: String, loop_id: Option<String>);
+    fn on_claude_task_ended(&self, task_id: String, status: String, summary: Option<String>);
+    fn on_claude_session_metrics(&self, metrics: crate::types::FfiClaudeSessionMetrics);
+}
+
+/// Handle to a running event stream connection.
+/// Call `disconnect()` or drop to stop receiving events.
+#[derive(uniffi::Object)]
+pub struct ZRemoteEventStream {
+    cancel: CancellationToken,
+    _runtime: Arc<tokio::runtime::Runtime>,
+}
+
+#[uniffi::export]
+impl ZRemoteEventStream {
+    /// Stop the event stream and disconnect the WebSocket.
+    pub fn disconnect(&self) {
+        self.cancel.cancel();
+    }
+}
+
+impl ZRemoteEventStream {
+    /// Start the event stream dispatcher.
+    pub(crate) fn start(
+        event_stream: EventStream,
+        listener: Box<dyn EventListener>,
+        runtime: &Arc<tokio::runtime::Runtime>,
+    ) -> Arc<Self> {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let listener = Arc::from(listener);
+
+        runtime.spawn(async move {
+            dispatch_events(event_stream, listener, cancel_clone).await;
+        });
+
+        Arc::new(Self {
+            cancel,
+            _runtime: Arc::clone(runtime),
+        })
+    }
+}
+
+async fn dispatch_events(
+    event_stream: EventStream,
+    listener: Arc<dyn EventListener>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                debug!("event stream dispatcher cancelled");
+                listener.on_disconnected();
+                return;
+            }
+            result = event_stream.rx.recv_async() => {
+                if let Ok(event) = result {
+                    dispatch_single_event(&listener, event);
+                } else {
+                    debug!("event stream channel closed");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)] // One match arm per ServerEvent variant
+fn dispatch_single_event(listener: &Arc<dyn EventListener>, event: ClientEvent) {
+    match event {
+        ClientEvent::Connected => listener.on_connected(),
+        ClientEvent::Disconnected => listener.on_disconnected(),
+        ClientEvent::Server(boxed) => match *boxed {
+            zremote_client::types::ServerEvent::HostConnected { host } => {
+                listener.on_host_connected(host.into());
+            }
+            zremote_client::types::ServerEvent::HostDisconnected { host_id } => {
+                listener.on_host_disconnected(host_id);
+            }
+            zremote_client::types::ServerEvent::HostStatusChanged { host_id, status } => {
+                listener.on_host_status_changed(host_id, status);
+            }
+            zremote_client::types::ServerEvent::SessionCreated { session } => {
+                listener.on_session_created(session.into());
+            }
+            zremote_client::types::ServerEvent::SessionClosed {
+                session_id,
+                exit_code,
+            } => {
+                listener.on_session_closed(session_id, exit_code);
+            }
+            zremote_client::types::ServerEvent::SessionUpdated { session_id } => {
+                listener.on_session_updated(session_id);
+            }
+            zremote_client::types::ServerEvent::SessionSuspended { session_id } => {
+                listener.on_session_suspended(session_id);
+            }
+            zremote_client::types::ServerEvent::SessionResumed { session_id } => {
+                listener.on_session_resumed(session_id);
+            }
+            zremote_client::types::ServerEvent::ProjectsUpdated { host_id } => {
+                listener.on_projects_updated(host_id);
+            }
+            zremote_client::types::ServerEvent::LoopDetected {
+                loop_info,
+                host_id,
+                hostname,
+            } => {
+                listener.on_loop_detected(loop_info.into(), host_id, hostname);
+            }
+            zremote_client::types::ServerEvent::LoopStatusChanged {
+                loop_info,
+                host_id,
+                hostname,
+            } => {
+                listener.on_loop_status_changed(loop_info.into(), host_id, hostname);
+            }
+            zremote_client::types::ServerEvent::LoopEnded {
+                loop_info,
+                host_id,
+                hostname,
+            } => {
+                listener.on_loop_ended(loop_info.into(), host_id, hostname);
+            }
+            zremote_client::types::ServerEvent::KnowledgeStatusChanged {
+                host_id,
+                status,
+                error,
+            } => {
+                listener.on_knowledge_status_changed(host_id, status, error);
+            }
+            zremote_client::types::ServerEvent::IndexingProgress {
+                project_id,
+                project_path,
+                status,
+                files_processed,
+                files_total,
+            } => {
+                listener.on_indexing_progress(
+                    project_id,
+                    project_path,
+                    status,
+                    files_processed,
+                    files_total,
+                );
+            }
+            zremote_client::types::ServerEvent::MemoryExtracted {
+                project_id,
+                loop_id,
+                memory_count,
+            } => {
+                listener.on_memory_extracted(project_id, loop_id, memory_count);
+            }
+            zremote_client::types::ServerEvent::WorktreeError {
+                host_id,
+                project_path,
+                message,
+            } => {
+                listener.on_worktree_error(host_id, project_path, message);
+            }
+            zremote_client::types::ServerEvent::ClaudeTaskStarted {
+                task_id,
+                session_id,
+                host_id,
+                project_path,
+            } => {
+                listener.on_claude_task_started(task_id, session_id, host_id, project_path);
+            }
+            zremote_client::types::ServerEvent::ClaudeTaskUpdated {
+                task_id,
+                status,
+                loop_id,
+            } => {
+                listener.on_claude_task_updated(task_id, status, loop_id);
+            }
+            zremote_client::types::ServerEvent::ClaudeTaskEnded {
+                task_id,
+                status,
+                summary,
+            } => {
+                listener.on_claude_task_ended(task_id, status, summary);
+            }
+            zremote_client::types::ServerEvent::ClaudeSessionMetrics {
+                session_id,
+                model,
+                context_used_pct,
+                context_window_size,
+                cost_usd,
+                tokens_in,
+                tokens_out,
+                lines_added,
+                lines_removed,
+                rate_limit_5h_pct,
+                rate_limit_7d_pct,
+            } => {
+                listener.on_claude_session_metrics(crate::types::FfiClaudeSessionMetrics {
+                    session_id,
+                    model,
+                    context_used_pct,
+                    context_window_size,
+                    cost_usd,
+                    tokens_in,
+                    tokens_out,
+                    lines_added,
+                    lines_removed,
+                    rate_limit_5h_pct,
+                    rate_limit_7d_pct,
+                });
+            }
+        },
+    }
+}

--- a/crates/zremote-ffi/src/events.rs
+++ b/crates/zremote-ffi/src/events.rs
@@ -112,12 +112,16 @@ async fn dispatch_events(
         tokio::select! {
             () = cancel.cancelled() => {
                 debug!("event stream dispatcher cancelled");
-                listener.on_disconnected();
+                let l = Arc::clone(&listener);
+                let _ = tokio::task::spawn_blocking(move || l.on_disconnected()).await;
                 return;
             }
             result = event_stream.rx.recv_async() => {
                 if let Ok(event) = result {
-                    dispatch_single_event(&listener, event);
+                    let l = Arc::clone(&listener);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dispatch_single_event(&l, event);
+                    }).await;
                 } else {
                     debug!("event stream channel closed");
                     return;

--- a/crates/zremote-ffi/src/lib.rs
+++ b/crates/zremote-ffi/src/lib.rs
@@ -1,0 +1,18 @@
+//! `UniFFI` bindings for the `ZRemote` client SDK.
+//!
+//! This crate wraps `zremote-client` with FFI-safe types and callback interfaces,
+//! generating Kotlin and Swift bindings via Mozilla `UniFFI`.
+
+mod client;
+mod error;
+mod events;
+mod terminal;
+mod types;
+
+pub use client::ZRemoteClient;
+pub use error::FfiError;
+pub use events::{EventListener, ZRemoteEventStream};
+pub use terminal::{TerminalListener, ZRemoteTerminal};
+pub use types::*;
+
+uniffi::setup_scaffolding!();

--- a/crates/zremote-ffi/src/terminal.rs
+++ b/crates/zremote-ffi/src/terminal.rs
@@ -116,10 +116,14 @@ async fn dispatch_terminal_events(
             }
             result = output_rx.recv_async() => {
                 if let Ok(event) = result {
-                    dispatch_terminal_event(&listener, event);
+                    let l = Arc::clone(&listener);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dispatch_terminal_event(&l, event);
+                    }).await;
                 } else {
                     debug!("terminal output channel closed");
-                    listener.on_disconnected();
+                    let l = Arc::clone(&listener);
+                    let _ = tokio::task::spawn_blocking(move || l.on_disconnected()).await;
                     return;
                 }
             }

--- a/crates/zremote-ffi/src/terminal.rs
+++ b/crates/zremote-ffi/src/terminal.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use zremote_client::{TerminalSession, types::TerminalEvent, types::TerminalInput};
+
+use crate::error::FfiError;
+
+/// Callback interface for receiving terminal output and lifecycle events.
+///
+/// Implement this trait in Kotlin/Swift to receive terminal data.
+/// `on_output` receives raw bytes (maps to `ByteArray` in Kotlin).
+/// All methods are called from a background thread.
+#[uniffi::export(callback_interface)]
+pub trait TerminalListener: Send + Sync {
+    fn on_output(&self, data: Vec<u8>);
+    fn on_pane_output(&self, pane_id: String, data: Vec<u8>);
+    fn on_pane_added(&self, pane_id: String, index: u16);
+    fn on_pane_removed(&self, pane_id: String);
+    fn on_session_closed(&self, exit_code: Option<i32>);
+    fn on_scrollback_start(&self, cols: u16, rows: u16);
+    fn on_scrollback_end(&self, truncated: bool);
+    fn on_session_suspended(&self);
+    fn on_session_resumed(&self);
+    fn on_error(&self, message: String);
+    fn on_disconnected(&self);
+}
+
+/// Handle to a running terminal WebSocket session.
+/// Call `disconnect()` or drop to close the terminal connection.
+#[derive(uniffi::Object)]
+pub struct ZRemoteTerminal {
+    input_tx: flume::Sender<TerminalInput>,
+    resize_tx: flume::Sender<(u16, u16)>,
+    image_paste_tx: flume::Sender<String>,
+    cancel: CancellationToken,
+}
+
+#[uniffi::export]
+impl ZRemoteTerminal {
+    /// Send terminal input data (main pane).
+    pub fn send_input(&self, data: Vec<u8>) -> Result<(), FfiError> {
+        self.input_tx
+            .try_send(TerminalInput::Data(data))
+            .map_err(|_| FfiError::ChannelClosed)
+    }
+
+    /// Send terminal input data to a specific pane.
+    pub fn send_pane_input(&self, pane_id: String, data: Vec<u8>) -> Result<(), FfiError> {
+        self.input_tx
+            .try_send(TerminalInput::PaneData { pane_id, data })
+            .map_err(|_| FfiError::ChannelClosed)
+    }
+
+    /// Resize the terminal.
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<(), FfiError> {
+        self.resize_tx
+            .try_send((cols, rows))
+            .map_err(|_| FfiError::ChannelClosed)
+    }
+
+    /// Paste a base64-encoded image.
+    pub fn paste_image(&self, base64_data: String) -> Result<(), FfiError> {
+        self.image_paste_tx
+            .try_send(base64_data)
+            .map_err(|_| FfiError::ChannelClosed)
+    }
+
+    /// Disconnect the terminal session.
+    pub fn disconnect(&self) {
+        self.cancel.cancel();
+    }
+}
+
+impl ZRemoteTerminal {
+    /// Wrap a `TerminalSession` with a callback-based output dispatcher.
+    pub(crate) fn start(
+        session: TerminalSession,
+        listener: Box<dyn TerminalListener>,
+        runtime: &Arc<tokio::runtime::Runtime>,
+    ) -> Arc<Self> {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let listener = Arc::from(listener);
+
+        let input_tx = session.input_tx.clone();
+        let resize_tx = session.resize_tx.clone();
+        let image_paste_tx = session.image_paste_tx.clone();
+        let output_rx = session.output_rx.clone();
+
+        runtime.spawn(async move {
+            dispatch_terminal_events(output_rx, listener, cancel_clone).await;
+            // Keep session alive until dispatcher exits
+            drop(session);
+        });
+
+        Arc::new(Self {
+            input_tx,
+            resize_tx,
+            image_paste_tx,
+            cancel,
+        })
+    }
+}
+
+async fn dispatch_terminal_events(
+    output_rx: flume::Receiver<TerminalEvent>,
+    listener: Arc<dyn TerminalListener>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                debug!("terminal dispatcher cancelled");
+                return;
+            }
+            result = output_rx.recv_async() => {
+                if let Ok(event) = result {
+                    dispatch_terminal_event(&listener, event);
+                } else {
+                    debug!("terminal output channel closed");
+                    listener.on_disconnected();
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn dispatch_terminal_event(listener: &Arc<dyn TerminalListener>, event: TerminalEvent) {
+    match event {
+        TerminalEvent::Output(data) => listener.on_output(data),
+        TerminalEvent::PaneOutput { pane_id, data } => listener.on_pane_output(pane_id, data),
+        TerminalEvent::PaneAdded { pane_id, index } => listener.on_pane_added(pane_id, index),
+        TerminalEvent::PaneRemoved { pane_id } => listener.on_pane_removed(pane_id),
+        TerminalEvent::SessionClosed { exit_code } => listener.on_session_closed(exit_code),
+        TerminalEvent::ScrollbackStart { cols, rows } => listener.on_scrollback_start(cols, rows),
+        TerminalEvent::ScrollbackEnd { truncated } => listener.on_scrollback_end(truncated),
+        TerminalEvent::SessionSuspended => listener.on_session_suspended(),
+        TerminalEvent::SessionResumed => listener.on_session_resumed(),
+        TerminalEvent::Error { message } => listener.on_error(message),
+        TerminalEvent::Disconnected => listener.on_disconnected(),
+    }
+}

--- a/crates/zremote-ffi/src/types.rs
+++ b/crates/zremote-ffi/src/types.rs
@@ -1,0 +1,868 @@
+// ---------------------------------------------------------------------------
+// FFI enums
+// ---------------------------------------------------------------------------
+
+/// Agentic loop status.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FfiAgenticStatus {
+    Working,
+    WaitingForInput,
+    Error,
+    Completed,
+    Unknown,
+}
+
+impl From<zremote_client::AgenticStatus> for FfiAgenticStatus {
+    fn from(s: zremote_client::AgenticStatus) -> Self {
+        match s {
+            zremote_client::AgenticStatus::Working => Self::Working,
+            zremote_client::AgenticStatus::WaitingForInput => Self::WaitingForInput,
+            zremote_client::AgenticStatus::Error => Self::Error,
+            zremote_client::AgenticStatus::Completed => Self::Completed,
+            zremote_client::AgenticStatus::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// Claude task status.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FfiClaudeTaskStatus {
+    Starting,
+    Active,
+    Completed,
+    Error,
+}
+
+impl From<zremote_client::ClaudeTaskStatus> for FfiClaudeTaskStatus {
+    fn from(s: zremote_client::ClaudeTaskStatus) -> Self {
+        match s {
+            zremote_client::ClaudeTaskStatus::Starting => Self::Starting,
+            zremote_client::ClaudeTaskStatus::Active => Self::Active,
+            zremote_client::ClaudeTaskStatus::Completed => Self::Completed,
+            zremote_client::ClaudeTaskStatus::Error => Self::Error,
+        }
+    }
+}
+
+/// Knowledge service status.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FfiKnowledgeServiceStatus {
+    Starting,
+    Ready,
+    Indexing,
+    Error,
+    Stopped,
+}
+
+impl From<zremote_client::KnowledgeServiceStatus> for FfiKnowledgeServiceStatus {
+    fn from(s: zremote_client::KnowledgeServiceStatus) -> Self {
+        match s {
+            zremote_client::KnowledgeServiceStatus::Starting => Self::Starting,
+            zremote_client::KnowledgeServiceStatus::Ready => Self::Ready,
+            zremote_client::KnowledgeServiceStatus::Indexing => Self::Indexing,
+            zremote_client::KnowledgeServiceStatus::Error => Self::Error,
+            zremote_client::KnowledgeServiceStatus::Stopped => Self::Stopped,
+        }
+    }
+}
+
+/// Memory category.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FfiMemoryCategory {
+    Pattern,
+    Decision,
+    Pitfall,
+    Preference,
+    Architecture,
+    Convention,
+}
+
+impl From<zremote_client::MemoryCategory> for FfiMemoryCategory {
+    fn from(c: zremote_client::MemoryCategory) -> Self {
+        match c {
+            zremote_client::MemoryCategory::Pattern => Self::Pattern,
+            zremote_client::MemoryCategory::Decision => Self::Decision,
+            zremote_client::MemoryCategory::Pitfall => Self::Pitfall,
+            zremote_client::MemoryCategory::Preference => Self::Preference,
+            zremote_client::MemoryCategory::Architecture => Self::Architecture,
+            zremote_client::MemoryCategory::Convention => Self::Convention,
+        }
+    }
+}
+
+impl From<FfiMemoryCategory> for zremote_client::MemoryCategory {
+    fn from(c: FfiMemoryCategory) -> Self {
+        match c {
+            FfiMemoryCategory::Pattern => Self::Pattern,
+            FfiMemoryCategory::Decision => Self::Decision,
+            FfiMemoryCategory::Pitfall => Self::Pitfall,
+            FfiMemoryCategory::Preference => Self::Preference,
+            FfiMemoryCategory::Architecture => Self::Architecture,
+            FfiMemoryCategory::Convention => Self::Convention,
+        }
+    }
+}
+
+/// Knowledge search tier.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FfiSearchTier {
+    L0,
+    L1,
+    L2,
+}
+
+impl From<zremote_client::SearchTier> for FfiSearchTier {
+    fn from(t: zremote_client::SearchTier) -> Self {
+        match t {
+            zremote_client::SearchTier::L0 => Self::L0,
+            zremote_client::SearchTier::L1 => Self::L1,
+            zremote_client::SearchTier::L2 => Self::L2,
+        }
+    }
+}
+
+impl From<FfiSearchTier> for zremote_client::SearchTier {
+    fn from(t: FfiSearchTier) -> Self {
+        match t {
+            FfiSearchTier::L0 => Self::L0,
+            FfiSearchTier::L1 => Self::L1,
+            FfiSearchTier::L2 => Self::L2,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FFI response records
+// ---------------------------------------------------------------------------
+
+/// Host as returned by the API.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiHost {
+    pub id: String,
+    pub name: String,
+    pub hostname: String,
+    pub status: String,
+    pub last_seen_at: Option<String>,
+    pub agent_version: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<zremote_client::types::Host> for FfiHost {
+    fn from(h: zremote_client::types::Host) -> Self {
+        Self {
+            id: h.id,
+            name: h.name,
+            hostname: h.hostname,
+            status: h.status,
+            last_seen_at: h.last_seen_at,
+            agent_version: h.agent_version,
+            os: h.os,
+            arch: h.arch,
+            created_at: h.created_at,
+            updated_at: h.updated_at,
+        }
+    }
+}
+
+/// Session creation response.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiCreateSessionResponse {
+    pub id: String,
+    pub status: String,
+}
+
+impl From<zremote_client::types::CreateSessionResponse> for FfiCreateSessionResponse {
+    fn from(r: zremote_client::types::CreateSessionResponse) -> Self {
+        Self {
+            id: r.id,
+            status: r.status,
+        }
+    }
+}
+
+/// Terminal session.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiSession {
+    pub id: String,
+    pub host_id: String,
+    pub name: Option<String>,
+    pub shell: Option<String>,
+    pub status: String,
+    pub working_dir: Option<String>,
+    pub project_id: Option<String>,
+    pub pid: Option<i64>,
+    pub exit_code: Option<i32>,
+    pub created_at: String,
+    pub closed_at: Option<String>,
+}
+
+impl From<zremote_client::types::Session> for FfiSession {
+    fn from(s: zremote_client::types::Session) -> Self {
+        Self {
+            id: s.id,
+            host_id: s.host_id,
+            name: s.name,
+            shell: s.shell,
+            status: s.status,
+            working_dir: s.working_dir,
+            project_id: s.project_id,
+            pid: s.pid,
+            exit_code: s.exit_code,
+            created_at: s.created_at,
+            closed_at: s.closed_at,
+        }
+    }
+}
+
+/// Project.
+#[derive(Debug, Clone, uniffi::Record)]
+#[allow(clippy::struct_excessive_bools)] // Mirrors SDK type with multiple boolean fields
+pub struct FfiProject {
+    pub id: String,
+    pub host_id: String,
+    pub path: String,
+    pub name: String,
+    pub has_claude_config: bool,
+    pub has_zremote_config: bool,
+    pub project_type: String,
+    pub created_at: String,
+    pub parent_project_id: Option<String>,
+    pub git_branch: Option<String>,
+    pub git_commit_hash: Option<String>,
+    pub git_commit_message: Option<String>,
+    pub git_is_dirty: bool,
+    pub git_ahead: i32,
+    pub git_behind: i32,
+    pub git_remotes: Option<String>,
+    pub git_updated_at: Option<String>,
+    pub pinned: bool,
+}
+
+impl From<zremote_client::types::Project> for FfiProject {
+    fn from(p: zremote_client::types::Project) -> Self {
+        Self {
+            id: p.id,
+            host_id: p.host_id,
+            path: p.path,
+            name: p.name,
+            has_claude_config: p.has_claude_config,
+            has_zremote_config: p.has_zremote_config,
+            project_type: p.project_type,
+            created_at: p.created_at,
+            parent_project_id: p.parent_project_id,
+            git_branch: p.git_branch,
+            git_commit_hash: p.git_commit_hash,
+            git_commit_message: p.git_commit_message,
+            git_is_dirty: p.git_is_dirty,
+            git_ahead: p.git_ahead,
+            git_behind: p.git_behind,
+            git_remotes: p.git_remotes,
+            git_updated_at: p.git_updated_at,
+            pinned: p.pinned,
+        }
+    }
+}
+
+/// Agentic loop.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiAgenticLoop {
+    pub id: String,
+    pub session_id: String,
+    pub project_path: Option<String>,
+    pub tool_name: String,
+    pub status: FfiAgenticStatus,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub end_reason: Option<String>,
+    pub task_name: Option<String>,
+}
+
+impl From<zremote_client::types::AgenticLoop> for FfiAgenticLoop {
+    fn from(l: zremote_client::types::AgenticLoop) -> Self {
+        Self {
+            id: l.id,
+            session_id: l.session_id,
+            project_path: l.project_path,
+            tool_name: l.tool_name,
+            status: l.status.into(),
+            started_at: l.started_at,
+            ended_at: l.ended_at,
+            end_reason: l.end_reason,
+            task_name: l.task_name,
+        }
+    }
+}
+
+/// Config key-value pair.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiConfigValue {
+    pub key: String,
+    pub value: String,
+    pub updated_at: String,
+}
+
+impl From<zremote_client::types::ConfigValue> for FfiConfigValue {
+    fn from(c: zremote_client::types::ConfigValue) -> Self {
+        Self {
+            key: c.key,
+            value: c.value,
+            updated_at: c.updated_at,
+        }
+    }
+}
+
+/// Server mode info.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiModeInfo {
+    pub mode: String,
+    pub version: Option<String>,
+}
+
+impl From<zremote_client::types::ModeInfo> for FfiModeInfo {
+    fn from(m: zremote_client::types::ModeInfo) -> Self {
+        Self {
+            mode: m.mode,
+            version: m.version,
+        }
+    }
+}
+
+/// Knowledge base status.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiKnowledgeBase {
+    pub id: String,
+    pub host_id: String,
+    pub status: FfiKnowledgeServiceStatus,
+    pub openviking_version: Option<String>,
+    pub last_error: Option<String>,
+    pub started_at: Option<String>,
+    pub updated_at: String,
+}
+
+impl From<zremote_client::types::KnowledgeBase> for FfiKnowledgeBase {
+    fn from(k: zremote_client::types::KnowledgeBase) -> Self {
+        Self {
+            id: k.id,
+            host_id: k.host_id,
+            status: k.status.into(),
+            openviking_version: k.openviking_version,
+            last_error: k.last_error,
+            started_at: k.started_at,
+            updated_at: k.updated_at,
+        }
+    }
+}
+
+/// Knowledge memory entry.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiMemory {
+    pub id: String,
+    pub project_id: String,
+    pub loop_id: Option<String>,
+    pub key: String,
+    pub content: String,
+    pub category: FfiMemoryCategory,
+    pub confidence: f64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<zremote_client::types::Memory> for FfiMemory {
+    fn from(m: zremote_client::types::Memory) -> Self {
+        Self {
+            id: m.id,
+            project_id: m.project_id,
+            loop_id: m.loop_id,
+            key: m.key,
+            content: m.content,
+            category: m.category.into(),
+            confidence: m.confidence,
+            created_at: m.created_at,
+            updated_at: m.updated_at,
+        }
+    }
+}
+
+/// Claude task.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiClaudeTask {
+    pub id: String,
+    pub session_id: String,
+    pub host_id: String,
+    pub project_path: String,
+    pub project_id: Option<String>,
+    pub model: Option<String>,
+    pub initial_prompt: Option<String>,
+    pub claude_session_id: Option<String>,
+    pub resume_from: Option<String>,
+    pub status: FfiClaudeTaskStatus,
+    pub options_json: Option<String>,
+    pub loop_id: Option<String>,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub total_cost_usd: Option<f64>,
+    pub total_tokens_in: Option<i64>,
+    pub total_tokens_out: Option<i64>,
+    pub summary: Option<String>,
+    pub task_name: Option<String>,
+    pub created_at: String,
+}
+
+impl From<zremote_client::types::ClaudeTask> for FfiClaudeTask {
+    fn from(t: zremote_client::types::ClaudeTask) -> Self {
+        Self {
+            id: t.id,
+            session_id: t.session_id,
+            host_id: t.host_id,
+            project_path: t.project_path,
+            project_id: t.project_id,
+            model: t.model,
+            initial_prompt: t.initial_prompt,
+            claude_session_id: t.claude_session_id,
+            resume_from: t.resume_from,
+            status: t.status.into(),
+            options_json: t.options_json,
+            loop_id: t.loop_id,
+            started_at: t.started_at,
+            ended_at: t.ended_at,
+            total_cost_usd: t.total_cost_usd,
+            total_tokens_in: t.total_tokens_in,
+            total_tokens_out: t.total_tokens_out,
+            summary: t.summary,
+            task_name: t.task_name,
+            created_at: t.created_at,
+        }
+    }
+}
+
+/// Directory entry.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiDirectoryEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+}
+
+impl From<zremote_client::DirectoryEntry> for FfiDirectoryEntry {
+    fn from(d: zremote_client::DirectoryEntry) -> Self {
+        Self {
+            name: d.name,
+            is_dir: d.is_dir,
+            is_symlink: d.is_symlink,
+        }
+    }
+}
+
+/// Worktree info.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiWorktreeInfo {
+    pub path: String,
+    pub branch: Option<String>,
+    pub commit_hash: Option<String>,
+    pub is_detached: bool,
+    pub is_locked: bool,
+    pub is_dirty: bool,
+    pub commit_message: Option<String>,
+}
+
+impl From<zremote_client::WorktreeInfo> for FfiWorktreeInfo {
+    fn from(w: zremote_client::WorktreeInfo) -> Self {
+        Self {
+            path: w.path,
+            branch: w.branch,
+            commit_hash: w.commit_hash,
+            is_detached: w.is_detached,
+            is_locked: w.is_locked,
+            is_dirty: w.is_dirty,
+            commit_message: w.commit_message,
+        }
+    }
+}
+
+/// Knowledge search result.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiSearchResult {
+    pub path: String,
+    pub score: f64,
+    pub snippet: String,
+    pub line_start: Option<u32>,
+    pub line_end: Option<u32>,
+    pub tier: FfiSearchTier,
+}
+
+impl From<zremote_client::SearchResult> for FfiSearchResult {
+    fn from(r: zremote_client::SearchResult) -> Self {
+        Self {
+            path: r.path,
+            score: r.score,
+            snippet: r.snippet,
+            line_start: r.line_start,
+            line_end: r.line_end,
+            tier: r.tier.into(),
+        }
+    }
+}
+
+/// Extracted memory from transcript.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiExtractedMemory {
+    pub key: String,
+    pub content: String,
+    pub category: FfiMemoryCategory,
+    pub confidence: f64,
+    pub source_loop_id: String,
+}
+
+impl From<zremote_client::ExtractedMemory> for FfiExtractedMemory {
+    fn from(m: zremote_client::ExtractedMemory) -> Self {
+        Self {
+            key: m.key,
+            content: m.content,
+            category: m.category.into(),
+            confidence: m.confidence,
+            source_loop_id: m.source_loop_id.to_string(),
+        }
+    }
+}
+
+/// Claude session info (for resume/discover).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiClaudeSessionInfo {
+    pub session_id: String,
+    pub project_path: String,
+    pub model: Option<String>,
+    pub last_active: Option<String>,
+    pub message_count: Option<u32>,
+    pub summary: Option<String>,
+}
+
+impl From<zremote_client::ClaudeSessionInfo> for FfiClaudeSessionInfo {
+    fn from(s: zremote_client::ClaudeSessionInfo) -> Self {
+        Self {
+            session_id: s.session_id,
+            project_path: s.project_path,
+            model: s.model,
+            last_active: s.last_active,
+            message_count: s.message_count,
+            summary: s.summary,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event info records (used in EventListener callbacks)
+// ---------------------------------------------------------------------------
+
+/// Loop info in server events.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiLoopInfo {
+    pub id: String,
+    pub session_id: String,
+    pub project_path: Option<String>,
+    pub tool_name: String,
+    pub status: FfiAgenticStatus,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub end_reason: Option<String>,
+    pub task_name: Option<String>,
+}
+
+impl From<zremote_client::types::LoopInfo> for FfiLoopInfo {
+    fn from(l: zremote_client::types::LoopInfo) -> Self {
+        Self {
+            id: l.id,
+            session_id: l.session_id,
+            project_path: l.project_path,
+            tool_name: l.tool_name,
+            status: l.status.into(),
+            started_at: l.started_at,
+            ended_at: l.ended_at,
+            end_reason: l.end_reason,
+            task_name: l.task_name,
+        }
+    }
+}
+
+/// Host info in server events.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiHostInfo {
+    pub id: String,
+    pub hostname: String,
+    pub status: String,
+    pub agent_version: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+}
+
+impl From<zremote_client::types::HostInfo> for FfiHostInfo {
+    fn from(h: zremote_client::types::HostInfo) -> Self {
+        Self {
+            id: h.id,
+            hostname: h.hostname,
+            status: h.status,
+            agent_version: h.agent_version,
+            os: h.os,
+            arch: h.arch,
+        }
+    }
+}
+
+/// Claude session metrics from event stream.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiClaudeSessionMetrics {
+    pub session_id: String,
+    pub model: Option<String>,
+    pub context_used_pct: Option<f64>,
+    pub context_window_size: Option<u64>,
+    pub cost_usd: Option<f64>,
+    pub tokens_in: Option<u64>,
+    pub tokens_out: Option<u64>,
+    pub lines_added: Option<i64>,
+    pub lines_removed: Option<i64>,
+    pub rate_limit_5h_pct: Option<u64>,
+    pub rate_limit_7d_pct: Option<u64>,
+}
+
+/// Session info in server events.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiSessionInfo {
+    pub id: String,
+    pub host_id: String,
+    pub shell: Option<String>,
+    pub status: String,
+}
+
+impl From<zremote_client::types::SessionInfo> for FfiSessionInfo {
+    fn from(s: zremote_client::types::SessionInfo) -> Self {
+        Self {
+            id: s.id,
+            host_id: s.host_id,
+            shell: s.shell,
+            status: s.status,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FFI request records
+// ---------------------------------------------------------------------------
+
+/// Request to create a new terminal session.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiCreateSessionRequest {
+    pub name: Option<String>,
+    pub shell: Option<String>,
+    pub cols: u16,
+    pub rows: u16,
+    pub working_dir: Option<String>,
+}
+
+impl From<FfiCreateSessionRequest> for zremote_client::CreateSessionRequest {
+    fn from(r: FfiCreateSessionRequest) -> Self {
+        Self {
+            name: r.name,
+            shell: r.shell,
+            cols: r.cols,
+            rows: r.rows,
+            working_dir: r.working_dir,
+        }
+    }
+}
+
+/// Request to update a host name.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiUpdateHostRequest {
+    pub name: String,
+}
+
+/// Request to update a project.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiUpdateProjectRequest {
+    pub pinned: Option<bool>,
+}
+
+/// Request to add a project.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiAddProjectRequest {
+    pub path: String,
+}
+
+/// Request to create a worktree.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiCreateWorktreeRequest {
+    pub branch: String,
+    pub path: Option<String>,
+    pub new_branch: bool,
+}
+
+/// Filter for listing agentic loops.
+#[derive(Debug, Clone, Default, uniffi::Record)]
+pub struct FfiListLoopsFilter {
+    pub status: Option<String>,
+    pub host_id: Option<String>,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+}
+
+impl From<FfiListLoopsFilter> for zremote_client::ListLoopsFilter {
+    fn from(f: FfiListLoopsFilter) -> Self {
+        Self {
+            status: f.status,
+            host_id: f.host_id,
+            session_id: f.session_id,
+            project_id: f.project_id,
+        }
+    }
+}
+
+/// Filter for listing Claude tasks.
+#[derive(Debug, Clone, Default, uniffi::Record)]
+pub struct FfiListClaudeTasksFilter {
+    pub host_id: Option<String>,
+    pub status: Option<String>,
+    pub project_id: Option<String>,
+}
+
+impl From<FfiListClaudeTasksFilter> for zremote_client::ListClaudeTasksFilter {
+    fn from(f: FfiListClaudeTasksFilter) -> Self {
+        Self {
+            host_id: f.host_id,
+            status: f.status,
+            project_id: f.project_id,
+        }
+    }
+}
+
+/// Request to create a Claude task.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiCreateClaudeTaskRequest {
+    pub host_id: String,
+    pub project_path: String,
+    pub project_id: Option<String>,
+    pub model: Option<String>,
+    pub initial_prompt: Option<String>,
+    pub allowed_tools: Vec<String>,
+    pub skip_permissions: Option<bool>,
+    pub output_format: Option<String>,
+    pub custom_flags: Option<String>,
+}
+
+impl From<FfiCreateClaudeTaskRequest> for zremote_client::CreateClaudeTaskRequest {
+    fn from(r: FfiCreateClaudeTaskRequest) -> Self {
+        Self {
+            host_id: r.host_id,
+            project_path: r.project_path,
+            project_id: r.project_id,
+            model: r.model,
+            initial_prompt: r.initial_prompt,
+            allowed_tools: if r.allowed_tools.is_empty() {
+                None
+            } else {
+                Some(r.allowed_tools)
+            },
+            skip_permissions: r.skip_permissions,
+            output_format: r.output_format,
+            custom_flags: r.custom_flags,
+        }
+    }
+}
+
+/// Request to search knowledge.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiSearchRequest {
+    pub query: String,
+    pub tier: Option<FfiSearchTier>,
+    pub max_results: Option<u32>,
+}
+
+impl From<FfiSearchRequest> for zremote_client::types::SearchRequest {
+    fn from(r: FfiSearchRequest) -> Self {
+        Self {
+            query: r.query,
+            tier: r.tier.map(Into::into),
+            max_results: r.max_results,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agentic_status_maps_each_variant() {
+        assert!(matches!(
+            FfiAgenticStatus::from(zremote_client::AgenticStatus::Working),
+            FfiAgenticStatus::Working
+        ));
+        assert!(matches!(
+            FfiAgenticStatus::from(zremote_client::AgenticStatus::WaitingForInput),
+            FfiAgenticStatus::WaitingForInput
+        ));
+        assert!(matches!(
+            FfiAgenticStatus::from(zremote_client::AgenticStatus::Error),
+            FfiAgenticStatus::Error
+        ));
+        assert!(matches!(
+            FfiAgenticStatus::from(zremote_client::AgenticStatus::Completed),
+            FfiAgenticStatus::Completed
+        ));
+        assert!(matches!(
+            FfiAgenticStatus::from(zremote_client::AgenticStatus::Unknown),
+            FfiAgenticStatus::Unknown
+        ));
+    }
+
+    #[test]
+    fn memory_category_roundtrip() {
+        let cat = zremote_client::MemoryCategory::Architecture;
+        let ffi: FfiMemoryCategory = cat.into();
+        let back: zremote_client::MemoryCategory = ffi.into();
+        assert!(matches!(back, zremote_client::MemoryCategory::Architecture));
+    }
+
+    #[test]
+    fn search_tier_roundtrip() {
+        let tier = zremote_client::SearchTier::L2;
+        let ffi: FfiSearchTier = tier.into();
+        let back: zremote_client::SearchTier = ffi.into();
+        assert!(matches!(back, zremote_client::SearchTier::L2));
+    }
+
+    #[test]
+    fn create_claude_task_empty_tools() {
+        let ffi = FfiCreateClaudeTaskRequest {
+            host_id: "h1".to_string(),
+            project_path: "/tmp".to_string(),
+            project_id: None,
+            model: None,
+            initial_prompt: Some("hello".to_string()),
+            allowed_tools: vec![],
+            skip_permissions: None,
+            output_format: None,
+            custom_flags: None,
+        };
+        let sdk: zremote_client::CreateClaudeTaskRequest = ffi.into();
+        assert!(sdk.allowed_tools.is_none());
+    }
+
+    #[test]
+    fn create_claude_task_with_tools() {
+        let ffi = FfiCreateClaudeTaskRequest {
+            host_id: "h1".to_string(),
+            project_path: "/tmp".to_string(),
+            project_id: None,
+            model: None,
+            initial_prompt: None,
+            allowed_tools: vec!["bash".to_string(), "read".to_string()],
+            skip_permissions: None,
+            output_format: None,
+            custom_flags: None,
+        };
+        let sdk: zremote_client::CreateClaudeTaskRequest = ffi.into();
+        assert_eq!(sdk.allowed_tools.unwrap().len(), 2);
+    }
+}

--- a/crates/zremote-ffi/uniffi-bindgen.rs
+++ b/crates/zremote-ffi/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main();
+}

--- a/crates/zremote-ffi/uniffi.toml
+++ b/crates/zremote-ffi/uniffi.toml
@@ -1,0 +1,6 @@
+[bindings.kotlin]
+package_name = "com.zremote.sdk"
+cdylib_name = "zremote_ffi"
+
+[bindings.swift]
+module_name = "ZRemoteSDK"

--- a/docs/android-build.md
+++ b/docs/android-build.md
@@ -1,0 +1,164 @@
+# Android Build Guide (NixOS)
+
+Building the ZRemote Android app on NixOS requires special handling because Android SDK ships pre-built x86_64 Linux binaries (aapt2, zipalign, d8) that expect a standard FHS filesystem layout.
+
+## Quick Start
+
+```bash
+nix develop --command bash scripts/build-android-apk.sh --install
+```
+
+This builds everything from scratch and installs on a connected phone.
+
+## Prerequisites
+
+### 1. NixOS: programs.nix-ld
+
+Android SDK binaries are dynamically linked against `/lib64/ld-linux-x86-64.so.2`. On NixOS, this is a stub that rejects execution. `programs.nix-ld` replaces the stub with a real dynamic linker.
+
+```nix
+# In your NixOS configuration:
+programs.nix-ld = {
+  enable = true;
+  libraries = with pkgs; [
+    zlib            # libz.so - used by aapt2, d8
+    stdenv.cc.cc.lib  # libstdc++.so - used by various SDK tools
+  ];
+};
+```
+
+Then `sudo nixos-rebuild switch`.
+
+**Without this, every Gradle build fails** with:
+```
+AAPT2 Daemon startup failed
+NixOS cannot run dynamically linked executables intended for generic linux environments
+```
+
+### 2. nix develop shell
+
+The `flake.nix` provides everything else:
+
+| Tool | Source | Purpose |
+|------|--------|---------|
+| Rust + aarch64-linux-android target | rust-overlay | Cross-compile native library |
+| cargo-ndk | nixpkgs | Wraps cargo for Android NDK cross-compilation |
+| Android SDK (platforms, build-tools) | nixpkgs androidenv | Android compilation toolchain |
+| Android NDK 27.x | nixpkgs androidenv | C/C++ cross-compiler for native code |
+| Gradle 8.x | nixpkgs | Android build system |
+| JDK 21 | nixpkgs (via nix shell) | Required by Gradle and Android toolchain |
+
+### 3. Phone setup (for --install)
+
+1. Settings > About phone > tap "Build number" 7 times
+2. Settings > System > Developer options > enable "USB debugging"
+3. Connect USB, confirm authorization dialog on phone
+4. Verify: `adb devices` shows your device as "device" (not "unauthorized")
+
+## Build Pipeline
+
+The build has 4 stages. The script `scripts/build-android-apk.sh` runs all of them.
+
+### Stage 1: Cross-compile Rust FFI (cargo-ndk)
+
+```bash
+cargo ndk -t arm64-v8a -o android/app/src/main/jniLibs build --profile release-android -p zremote-ffi
+```
+
+Produces `jniLibs/arm64-v8a/libzremote_ffi.so` (~4 MB). This is the native library loaded at runtime via JNA.
+
+### Stage 2: Generate Kotlin bindings (uniffi-bindgen)
+
+```bash
+# Build host-platform debug library (needed because uniffi-bindgen can't read cross-compiled .so metadata)
+cargo build -p zremote-ffi
+
+# Generate Kotlin from host library
+cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+    --library target/debug/libzremote_ffi.so \
+    --language kotlin \
+    --out-dir android/app/src/main/java
+```
+
+Produces `android/app/src/main/java/com/zremote/sdk/zremote_ffi.kt` (~8000 lines).
+
+**Why host debug build?** UniFFI's `--library` mode loads the .so and reads embedded metadata via `dlopen`. A cross-compiled arm64 .so can't be loaded on x86_64. The debug build includes full metadata; release builds may strip it.
+
+### Stage 3: Patch UniFFI codegen bugs
+
+UniFFI 0.29 has a known issue where generated Kotlin Exception subclasses declare `val message: String` in the constructor, which conflicts with `Throwable.message` (inherited from `kotlin.Exception`). The script patches this automatically.
+
+Before:
+```kotlin
+class Http(val `message`: kotlin.String) : FfiException() {
+    override val message
+        get() = "message=${ `message` }"
+}
+```
+
+After:
+```kotlin
+class Http(override val `message`: kotlin.String) : FfiException() {
+}
+```
+
+### Stage 4: Gradle build
+
+```bash
+cd android && gradle assembleDebug --no-daemon
+```
+
+Produces `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+## What Can Go Wrong
+
+### "AAPT2 Daemon startup failed"
+
+nix-ld is not configured or missing libraries. See Prerequisites section.
+
+### "Crate not found in libzremote_ffi.so" (uniffi-bindgen)
+
+You're trying to generate bindings from the cross-compiled .so. Use the host debug build instead (Stage 2).
+
+### Empty `com/zremote/sdk/` after binding generation
+
+Same cause -- uniffi-bindgen silently produces nothing when it can't read metadata. Check that `target/debug/libzremote_ffi.so` exists and was built for the host platform.
+
+### "Unresolved reference: FfiError"
+
+The generated bindings use `FfiException` (not `FfiError`). If app code references `FfiError`, update it to `FfiException`.
+
+### ClassNotFoundException on device
+
+Manifest uses relative class names (`.app.ZRemoteApp`) that get prefixed with the namespace (`com.zremote.app`), resulting in `com.zremote.app.app.ZRemoteApp`. Use fully qualified names in AndroidManifest.xml.
+
+### Permission denied on build directory
+
+If Docker was used for a previous build attempt, files may be owned by root. Fix with `sudo chown -R $USER:users android/`.
+
+## Manual Steps
+
+### Install APK
+```bash
+adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+### View crash logs
+```bash
+adb logcat -s AndroidRuntime | grep -A 20 "FATAL"
+```
+
+### Release build
+
+Requires signing key. See `android/README.md` for keystore setup.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/build-android-apk.sh` | Full build pipeline script |
+| `scripts/build-android.sh` | Native library + binding generation only |
+| `android/app/src/main/jniLibs/` | Cross-compiled .so (gitignored) |
+| `android/app/src/main/java/com/zremote/sdk/` | Generated UniFFI bindings (gitignored) |
+| `crates/zremote-ffi/` | Rust FFI crate (source of truth) |
+| `crates/zremote-ffi/uniffi.toml` | UniFFI config (package name, cdylib name) |

--- a/docs/prompts/implement-mobile-improvements.md
+++ b/docs/prompts/implement-mobile-improvements.md
@@ -18,7 +18,11 @@ The RFC at `docs/rfc/rfc-mobile-app-improvements.md` documents 15 improvements d
 
 ### Step 0: Setup
 
-1. **Enter worktree** -- always work in an isolated worktree, never modify main directly
+1. **Continue in existing worktree** -- this work builds on branch `worktree-rfc-mobile-update` (PR #9). Do NOT create a new worktree or branch. If the worktree at `.claude/worktrees/rfc-mobile-update` exists, work there. If it doesn't exist (e.g. was cleaned up), create a new worktree from the `worktree-rfc-mobile-update` branch:
+   ```bash
+   git worktree add .claude/worktrees/rfc-mobile-update worktree-rfc-mobile-update
+   ```
+   All commands must run from `.claude/worktrees/rfc-mobile-update/`.
 2. **Read the RFC** at `docs/rfc/rfc-mobile-app-improvements.md` -- read the entire document
 3. **Read CLAUDE.md** -- understand the project's development workflow, coding conventions, and mandatory review process
 4. **Explore current Android code** -- read all files under `android/app/src/main/java/com/zremote/` to understand existing patterns, especially `HostListScreen.kt` (it has the correct patterns for empty states, pull-to-refresh, error handling that other screens are missing)
@@ -168,7 +172,7 @@ If you encounter a situation where one of these is needed to complete an in-scop
 
 ## Rules (from CLAUDE.md -- mandatory)
 
-1. **Always work in a worktree** -- `EnterWorktree` before any changes
+1. **Work in the existing worktree** -- branch `worktree-rfc-mobile-update`, path `.claude/worktrees/rfc-mobile-update/`. Do NOT create a new branch or worktree.
 2. **Read before modify** -- always read a file before editing it
 3. **No mocks** -- real implementations only. If blocked by missing server API, add placeholder UI text explaining the dependency
 4. **No skipping** -- every item assigned to a sprint must be fully implemented
@@ -186,4 +190,4 @@ At the end, the worktree should have:
 - All P1 items (#5, #6 partial, #8, #10, #11, #12) implemented
 - P2 item #13 implemented
 - Updated RFC with completion status for each item
-- PR created targeting `main`
+- Commits pushed to `worktree-rfc-mobile-update` branch (PR #9 already exists)

--- a/docs/prompts/implement-mobile-improvements.md
+++ b/docs/prompts/implement-mobile-improvements.md
@@ -1,0 +1,189 @@
+# Agent Prompt: Implement Mobile App Post-MVP Improvements
+
+## Your Role
+
+You are **team lead** for implementing `docs/rfc/rfc-mobile-app-improvements.md`. You plan, delegate to teammates, review, and merge. Follow the Implementation Workflow in `CLAUDE.md` exactly.
+
+## Context
+
+The ZRemote Android MVP was completed in PR #9 (`worktree-rfc-mobile-update` branch). It includes:
+- `crates/zremote-ffi/` -- Rust UniFFI bindings (60+ API methods, EventListener/TerminalListener callbacks)
+- `android/` -- Jetpack Compose app (Hilt DI, 6 screens, terminal viewer, foreground service notifications)
+- `scripts/build-android.sh` -- cargo-ndk cross-compilation + Kotlin binding generation
+- `.github/workflows/android-build.yml` -- CI for Android builds
+
+The RFC at `docs/rfc/rfc-mobile-app-improvements.md` documents 15 improvements discovered during code review. You will implement them in phased sprints.
+
+## Instructions
+
+### Step 0: Setup
+
+1. **Enter worktree** -- always work in an isolated worktree, never modify main directly
+2. **Read the RFC** at `docs/rfc/rfc-mobile-app-improvements.md` -- read the entire document
+3. **Read CLAUDE.md** -- understand the project's development workflow, coding conventions, and mandatory review process
+4. **Explore current Android code** -- read all files under `android/app/src/main/java/com/zremote/` to understand existing patterns, especially `HostListScreen.kt` (it has the correct patterns for empty states, pull-to-refresh, error handling that other screens are missing)
+5. **Create team** via `TeamCreate`
+6. **Create tasks** via `TaskCreate` with dependencies matching the phased plan below
+
+### Step 1: Sprint 1 -- P0 Quality Fixes (Items #1-4 + #8)
+
+These are all Android/Kotlin changes. No Rust changes needed.
+
+**Phase 1A: Component library (#8 partial -- prerequisite for other fixes)**
+
+Create reusable composables FIRST since items #1-4 all need them:
+- `android/app/src/main/java/com/zremote/ui/components/StatusDot.kt` -- colored circle, takes color parameter
+- `android/app/src/main/java/com/zremote/ui/components/EmptyState.kt` -- icon + message + optional hint, centered
+- `android/app/src/main/java/com/zremote/ui/components/ErrorState.kt` -- error message + retry button
+- `android/app/src/main/java/com/zremote/ui/components/LoadingState.kt` -- centered CircularProgressIndicator
+- `android/app/src/main/java/com/zremote/ui/components/RefreshableList.kt` -- PullToRefreshBox + LazyColumn wrapper
+- `android/app/src/main/java/com/zremote/ui/components/DetailRow.kt` -- label + value pair (extract from LoopDetailScreen)
+
+Reference `HostListScreen.kt` for the existing empty state pattern. Make components generic and reusable.
+
+**Phase 1B: Fix ViewModels (#2 -- error handling)**
+
+Add `_error: MutableStateFlow<String?>` and proper error exposure to:
+- `SessionListViewModel.kt` -- currently uses `catch (_: Exception) { _sessions.value = emptyList() }`
+- `LoopListViewModel.kt` -- same silent catch pattern
+- `LoopDetailViewModel.kt` -- same
+- `TaskListViewModel.kt` -- same
+
+Pattern to follow (from `HostListViewModel.kt`):
+```kotlin
+private val _error = MutableStateFlow<String?>(null)
+val error: StateFlow<String?> = _error.asStateFlow()
+
+fun refresh() {
+    viewModelScope.launch {
+        _isLoading.value = true
+        _error.value = null
+        try { ... }
+        catch (e: Exception) { _error.value = e.message }
+        finally { _isLoading.value = false }
+    }
+}
+```
+
+**Phase 1C: Fix Screens (#1 empty states, #3 pull-to-refresh, #4 loading)**
+
+Update all list screens to use the new components:
+- `SessionListScreen.kt` -- add PullToRefreshBox, EmptyState, ErrorState, LoadingState
+- `LoopListScreen.kt` -- same
+- `TaskListScreen.kt` -- same
+
+Also refactor `HostListScreen.kt` to use the shared components instead of inline composables.
+
+**Review after Sprint 1:**
+- Spawn `code-reviewer` to verify consistency across all screens
+- Verify: every list screen has loading, empty, error, and pull-to-refresh states
+- Commit with descriptive message
+
+### Step 2: Sprint 2 -- P1 Features (Items #5, #8 complete, #11, #12)
+
+**Phase 2A: Complete component library (#8)**
+
+Refactor existing screens to use shared components:
+- Replace inline `StatusDot` (Surface+CircleShape) in HostCard, SessionCard with `StatusDot` component
+- Replace `DetailRow` in LoopDetailScreen with shared component
+- Verify no duplicated UI patterns remain
+
+**Phase 2B: Projects screen (#5)**
+
+Create:
+- `android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/projects/ProjectListViewModel.kt`
+
+Features:
+- List projects per host: name, path, git branch, dirty status, ahead/behind counts
+- Show badges for `has_claude_config` / `has_zremote_config`
+- Pull-to-refresh, empty state, error handling (using shared components)
+- Navigation: add as sub-screen under host detail, or add Projects tab to bottom navigation
+
+Use API: `client.listProjects(hostId)`, `client.triggerGitRefresh(projectId)`, `client.triggerScan(hostId)`
+
+Wire into `NavGraph.kt` with a new `ProjectsRoute(hostId: String)`.
+
+**Phase 2C: Build infrastructure (#11, #12)**
+
+- Gradle wrapper: if Gradle is available, run `gradle wrapper --gradle-version 8.11` in `android/`. If not, create the properties file manually pointing to Gradle 8.11 distribution.
+- ProGuard rules: update `android/app/proguard-rules.pro` with rules from RFC (Kotlin serialization, Hilt, Compose keeps)
+
+**Review after Sprint 2:**
+- `code-reviewer` for architecture and consistency
+- Verify Projects screen follows same patterns as other screens
+- Commit
+
+### Step 3: Sprint 3 -- P1 Advanced (Items #6, #10)
+
+**Phase 3A: Task detail screen (#6)**
+
+Create:
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailViewModel.kt`
+
+Features:
+- Display task metadata: model, initial prompt, cost, tokens in/out, started/ended times
+- Show summary when completed
+- Link to associated loop (navigate to LoopDetailScreen)
+- Loading/error states
+
+Wire `TaskListScreen` cards to navigate to detail. Add `TaskDetailRoute(taskId: String)` to NavGraph.
+
+Note: Approve/deny buttons are **blocked by server-side API** (endpoints don't exist yet). Add a placeholder section in the UI saying "Permission approval requires server v0.8+" or similar. Do NOT mock the API.
+
+**Phase 3B: Session creation (#10)**
+
+Add to `SessionListScreen.kt`:
+- FloatingActionButton that opens a bottom sheet
+- Bottom sheet with: shell selection (optional text field), working directory (optional), terminal dimensions (auto-detect from screen)
+- On submit: call `client.createSession(hostId, FfiCreateSessionRequest(...))`, then navigate to `TerminalRoute(session.id)`
+
+**Review after Sprint 3:**
+- `code-reviewer` for architecture
+- Verify all new screens have loading/empty/error states
+- Commit
+
+### Step 4: Sprint 4 -- P2 Polish (Items #13)
+
+**Phase 4A: Notification preferences (#13)**
+
+Add to Settings screen:
+- Section "Notifications" with toggles per channel:
+  - Loop completions, Loop errors, Permission requests, Task completions, Task errors, Host disconnections
+- Store in DataStore preferences
+- Update `NotificationEventListener.kt` to check preferences before sending
+
+**Review and commit.**
+
+### Items NOT to implement (deferred)
+
+These items require external dependencies or major architecture changes beyond this RFC scope:
+- **#7 FCM push** -- requires Firebase project setup + server-side changes (new Axum endpoints, FCM dispatch module, SQL migration). Create a separate RFC.
+- **#9 VT100 emulation** -- requires integrating termux terminal-emulator library or equivalent. Current ANSI parser is sufficient for MVP.
+- **#14 Offline cache** -- requires adding Room database dependency and caching layer. Separate feature.
+- **#15 QR pairing** -- requires CameraX + ML Kit + server-side QR generation. Separate feature.
+
+If you encounter a situation where one of these is needed to complete an in-scope item, document the dependency and move on.
+
+## Rules (from CLAUDE.md -- mandatory)
+
+1. **Always work in a worktree** -- `EnterWorktree` before any changes
+2. **Read before modify** -- always read a file before editing it
+3. **No mocks** -- real implementations only. If blocked by missing server API, add placeholder UI text explaining the dependency
+4. **No skipping** -- every item assigned to a sprint must be fully implemented
+5. **Code review is mandatory** -- spawn `code-reviewer` after each sprint. Fix ALL findings before committing
+6. **Tests** -- Kotlin unit tests are not required for Compose UI (no test infrastructure set up yet), but if you add business logic utilities (e.g., date formatting, status mapping), write tests
+7. **Commit messages** -- descriptive, reference RFC item numbers
+8. **Verify Rust crate** -- after any changes, run `cargo test -p zremote-ffi && cargo clippy -p zremote-ffi` to ensure nothing is broken
+9. **PR at the end** -- create a PR with summary of all changes, referencing the RFC
+
+## Expected Output
+
+At the end, the worktree should have:
+- Sprint commits (one per sprint, squash if needed)
+- All P0 items (#1-4) fully implemented
+- All P1 items (#5, #6 partial, #8, #10, #11, #12) implemented
+- P2 item #13 implemented
+- Updated RFC with completion status for each item
+- PR created targeting `main`

--- a/docs/rfc/rfc-mobile-app-improvements.md
+++ b/docs/rfc/rfc-mobile-app-improvements.md
@@ -1,0 +1,338 @@
+# RFC: ZRemote Mobile App -- Post-MVP Improvements
+
+## Status: Planned
+
+## Context
+
+The ZRemote Android MVP (Phase 0-4) is complete with:
+- `zremote-ffi` Rust crate (UniFFI bindings, 60+ API methods, callback interfaces)
+- Android build pipeline (cargo-ndk, CI workflow, size-optimized profile)
+- Jetpack Compose app (hosts, sessions, loops, tasks, terminal viewer, settings)
+- Push notifications via foreground service (client-driven, Option A)
+
+This RFC documents known gaps, quality improvements, and feature enhancements discovered during code review. Items are prioritized by impact on user experience and app stability.
+
+---
+
+## P0: Must Fix (blocking quality issues)
+
+### 1. Empty states on all list screens
+
+**Problem:** Only `HostListScreen` shows an empty state message. `LoopListScreen`, `TaskListScreen`, and `SessionListScreen` render a blank screen when there's no data. Users can't tell if data is loading, missing, or if there's an error.
+
+**Files to modify:**
+- `android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt`
+
+**Solution:** Extract reusable `EmptyState` and `ErrorState` composables. Each screen should show:
+- Loading: `CircularProgressIndicator` centered
+- Empty: icon + message + action hint (e.g., "No active loops")
+- Error: error message + retry button
+
+**Pattern (from HostListScreen):**
+```kotlin
+@Composable
+fun EmptyState(icon: ImageVector, message: String, hint: String? = null) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(48.dp))
+            Text(message, style = MaterialTheme.typography.bodyLarge)
+            hint?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+        }
+    }
+}
+```
+
+---
+
+### 2. Error handling in all ViewModels
+
+**Problem:** `SessionListViewModel`, `LoopListViewModel`, `LoopDetailViewModel`, and `TaskListViewModel` silently swallow exceptions:
+```kotlin
+catch (_: Exception) {
+    _sessions.value = emptyList()  // User sees nothing, no idea what went wrong
+}
+```
+
+Only `HostListViewModel` properly exposes errors via `_error` StateFlow.
+
+**Files to modify:**
+- `android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListViewModel.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/loops/LoopListViewModel.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/loops/LoopDetailViewModel.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListViewModel.kt`
+
+**Solution:** Add `_error: MutableStateFlow<String?>` to every ViewModel. Set it in catch blocks. Display in screens via `ErrorState` composable with retry action.
+
+---
+
+### 3. Pull-to-refresh on all list screens
+
+**Problem:** Only `HostListScreen` has `PullToRefreshBox`. Other list screens have no way to manually refresh data.
+
+**Files to modify:**
+- `android/app/src/main/java/com/zremote/ui/screens/sessions/SessionListScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/loops/LoopListScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskListScreen.kt`
+
+**Solution:** Wrap `LazyColumn` in `PullToRefreshBox` in all list screens. Each ViewModel already has a `refresh()` or `load*()` method.
+
+---
+
+### 4. Loading state indicators
+
+**Problem:** ViewModels track `_isLoading` but screens don't display it. No visual feedback during API calls.
+
+**Files to modify:** Same as #3 (screens).
+
+**Solution:** Show `CircularProgressIndicator` when `isLoading == true && items.isEmpty()`. When items exist, show pull-to-refresh indicator.
+
+---
+
+## P1: Should Fix (significant UX improvements)
+
+### 5. Projects screen
+
+**Problem:** `android/app/src/main/java/com/zremote/ui/screens/projects/` directory exists but is empty. Projects are a P1 feature in the original RFC.
+
+**Files to create:**
+- `ProjectListScreen.kt`
+- `ProjectListViewModel.kt`
+
+**Features:**
+- List projects per host with git branch, dirty status, ahead/behind
+- Show `has_claude_config` / `has_zremote_config` badges
+- Tap to view project details (settings, worktrees, actions)
+- Add Projects tab to bottom navigation (or as sub-screen under Hosts)
+
+**API methods available in SDK:**
+- `listProjects(hostId)` -> `Vec<FfiProject>`
+- `getProject(projectId)` -> `FfiProject`
+- `triggerGitRefresh(projectId)`
+- `triggerScan(hostId)`
+- `listWorktrees(projectId)` -> `Vec<FfiWorktreeInfo>`
+
+---
+
+### 6. Task detail screen with approve/deny
+
+**Problem:** `TaskListScreen` shows tasks but there's no detail view. The original RFC P0 scope includes approve/deny for tool call permissions, which requires a task detail screen.
+
+**Files to create:**
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailScreen.kt`
+- `android/app/src/main/java/com/zremote/ui/screens/tasks/TaskDetailViewModel.kt`
+
+**Features:**
+- Task metadata: model, prompt, cost, tokens, duration
+- Loop association (link to loop detail)
+- Summary display when completed
+- Approve/deny buttons for pending permission requests
+
+**Dependency:** Server-side permission forwarding API. Currently no endpoint exists to approve/deny tool calls from mobile. Needs:
+- `POST /api/loops/{loop_id}/approve` -- approve pending tool call
+- `POST /api/loops/{loop_id}/deny` -- deny pending tool call
+- `GET /api/loops/{loop_id}/pending-permissions` -- list pending permissions
+
+This is a **server-side prerequisite** -- must be implemented in `zremote-server` and `zremote-agent` before the mobile approve/deny UI works.
+
+---
+
+### 7. Server-driven push notifications (FCM)
+
+**Problem:** Current implementation uses a foreground service (Option A) which:
+- Drains battery (keeps WebSocket + CPU active)
+- Shows persistent notification bar icon
+- Android may kill the service after extended background time
+- Doesn't work when app is force-closed
+
+**Current state:**
+- `ZRemoteEventService` (foreground service) -- works but battery-intensive
+- `NotificationEventListener` -- fires local notifications
+
+**Target architecture (Option B):**
+```
+Server --> FCM --> Android device --> notification
+```
+
+**Server-side changes needed:**
+1. New endpoint: `POST /api/notifications/register`
+   - Body: `{ device_token: String, platform: "android"|"ios", preferences: {...} }`
+2. New table: `notification_registrations`
+   - Fields: `id, device_token, platform, preferences_json, created_at, updated_at`
+3. New module: FCM dispatch
+   - On relevant ServerEvent, check registered devices, send via FCM HTTP v1 API
+   - Rate limiting to avoid notification spam
+
+**Android-side changes:**
+1. Add Firebase Cloud Messaging dependency
+2. `FirebaseMessagingService` to receive FCM tokens and messages
+3. Token registration on connect (call new server endpoint)
+4. Notification preferences screen (which events to notify about)
+5. Remove foreground service (or make it optional for real-time updates)
+
+**Firebase project setup:**
+- Create Firebase project at console.firebase.google.com
+- Download `google-services.json` to `android/app/`
+- Add Firebase BOM to dependencies
+
+**Effort:** ~2 weeks (server + mobile)
+
+---
+
+### 8. Reusable UI component library
+
+**Problem:** Common UI patterns are duplicated across screens (status dots, card layouts, detail rows). No shared component library.
+
+**Solution:** Create `android/app/src/main/java/com/zremote/ui/components/`:
+
+| Component | Used by | Description |
+|-----------|---------|-------------|
+| `StatusDot` | HostCard, SessionCard, LoopCard | Colored circle for online/offline/status |
+| `EmptyState` | All list screens | Icon + message + hint centered |
+| `ErrorState` | All list screens | Error message + retry button |
+| `LoadingState` | All screens | Centered progress indicator |
+| `DetailRow` | LoopDetail, TaskDetail | Label + value pair |
+| `RefreshableList` | All list screens | LazyColumn + PullToRefreshBox wrapper |
+
+---
+
+## P2: Nice to Have (polish and advanced features)
+
+### 9. VT100 terminal emulation
+
+**Problem:** Current terminal viewer only parses ANSI SGR (color/bold) escape sequences. No cursor positioning, no scrollback region, no alternate screen buffer.
+
+**Current state:** `AnsiParser.kt` handles:
+- SGR codes 0-107 (reset, bold, 8-color, 256-color)
+- Text output with styled characters
+
+**Missing:**
+- Cursor movement (CUP, CUU, CUD, CUF, CUB)
+- Erase in display/line (ED, EL)
+- Scroll regions (DECSTBM)
+- Alternate screen buffer (DECSET 1049)
+- Character set switching (SCS)
+- Window title (OSC)
+
+**Options:**
+1. **Integrate termux terminal-emulator** -- mature Android terminal library, handles full VT100+
+2. **Port alacritty_terminal to Kotlin** -- complex but consistent with desktop
+3. **Use a WASM-compiled terminal** -- run xterm.js in a WebView for the terminal area only
+
+**Recommendation:** Option 1 (termux) for production quality. Current ANSI parser is sufficient for read-only log viewing.
+
+---
+
+### 10. Session creation from mobile
+
+**Problem:** Users can't create new terminal sessions from the mobile app. They must create sessions from the desktop client or CLI.
+
+**Files to create:**
+- Dialog or bottom sheet in `SessionListScreen`
+- Uses `client.createSession(hostId, FfiCreateSessionRequest(...))`
+
+**UI:** Floating action button on session list -> bottom sheet with:
+- Shell selection (optional)
+- Working directory (optional, with `browseDirectory` API)
+- Terminal dimensions (auto-detect from screen size)
+
+---
+
+### 11. Gradle wrapper
+
+**Problem:** No `gradle-wrapper.jar` or `gradle-wrapper.properties` checked in. Developers need Gradle pre-installed.
+
+**Solution:** Run `gradle wrapper --gradle-version 8.11` in the `android/` directory to generate:
+- `gradle/wrapper/gradle-wrapper.jar`
+- `gradle/wrapper/gradle-wrapper.properties`
+- `gradlew` (Unix)
+- `gradlew.bat` (Windows)
+
+Check these into git. Add `gradle-wrapper.jar` exception to `.gitignore`.
+
+---
+
+### 12. ProGuard rules
+
+**Problem:** Current ProGuard rules only keep `com.zremote.sdk.**`. Release builds may strip:
+- Hilt-generated classes
+- Kotlin serialization metadata
+- Compose-related reflection targets
+
+**File to modify:** `android/app/proguard-rules.pro`
+
+**Additional rules needed:**
+```proguard
+# Kotlin serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.zremote.**$$serializer { *; }
+-keepclassmembers class com.zremote.** {
+    *** Companion;
+}
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class * extends dagger.hilt.android.internal.managers.ViewComponentManager$FragmentContextWrapper { *; }
+```
+
+---
+
+### 13. Notification preferences screen
+
+**Problem:** Users can't control which events trigger notifications. All events notify at hardcoded priorities.
+
+**Solution:** Settings screen section with toggles per notification channel:
+- Loop completions (on/off)
+- Loop errors (on/off)
+- Permission requests (on/off, always recommended on)
+- Task completions (on/off)
+- Task errors (on/off)
+- Host disconnections (on/off)
+
+Store in DataStore preferences, check before sending notification.
+
+---
+
+### 14. Offline mode / caching
+
+**Problem:** App shows nothing when offline. No cached data from previous sessions.
+
+**Solution:** Add Room database for local caching:
+- Cache last-known host list, session list, loop list
+- Show stale data with "last updated X ago" badge when disconnected
+- Sync on reconnect
+
+**Effort:** ~1 week
+
+---
+
+### 15. QR code pairing
+
+**Problem:** Users must manually type the server URL. Error-prone, especially for IP addresses.
+
+**Solution:** Server generates a QR code (via web UI or CLI) containing:
+```json
+{"url": "http://192.168.1.100:3000", "token": "optional-auth-token"}
+```
+
+Mobile app scans QR code via `CameraX` + ML Kit barcode scanner, auto-fills settings.
+
+**Effort:** ~3 days (mobile) + QR generation on server side
+
+---
+
+## Implementation Priority
+
+| Phase | Items | Effort |
+|-------|-------|--------|
+| **Next sprint** | #1 Empty states, #2 Error handling, #3 Pull-to-refresh, #4 Loading states | 2-3 days |
+| **Sprint +1** | #5 Projects screen, #8 Component library, #11 Gradle wrapper, #12 ProGuard | 3-4 days |
+| **Sprint +2** | #6 Task detail + approve/deny (requires server API), #10 Session creation | 1-2 weeks |
+| **Later** | #7 FCM push, #9 VT100 emulation, #13 Notification prefs, #14 Offline cache, #15 QR pairing | 3-5 weeks |

--- a/docs/rfc/rfc-mobile-app.md
+++ b/docs/rfc/rfc-mobile-app.md
@@ -774,7 +774,16 @@ class ZRemoteEventRepository @Inject constructor(
 
 ---
 
-## Phase 4: Terminal Viewer + Push Notifications
+## Phase 4: Terminal Viewer + Push Notifications [COMPLETED]
+
+> **Implementation notes:**
+> - Terminal uses ANSI SGR parser (8-color, 256-color, bold) with AnnotatedString rendering
+> - Quick-command bar with Ctrl+C, Tab, Esc, Up, Down buttons + text input field
+> - Push notifications use Option A (client-driven via foreground service)
+> - 7 notification channels matching RFC priority spec
+> - `NotificationEventListener` fires notifications for loop end/error, permission requests, task end/error, host disconnect
+> - `ZRemoteEventService` foreground service keeps WebSocket alive in background
+> - Full VT100 emulation deferred (ANSI color parsing sufficient for MVP log viewing)
 
 ### Read-Only Terminal Viewer (P1)
 

--- a/docs/rfc/rfc-mobile-app.md
+++ b/docs/rfc/rfc-mobile-app.md
@@ -576,7 +576,16 @@ Expected size per ABI: ~5-8MB for the `.so` file. For MVP, `aarch64` only is suf
 
 ---
 
-## Phase 3: Android MVP App (Jetpack Compose)
+## Phase 3: Android MVP App (Jetpack Compose) [COMPLETED]
+
+> **Implementation notes:**
+> - Gradle project uses version catalog (`libs.versions.toml`) instead of inline versions
+> - DI via Hilt with `ConnectionManager` singleton (wraps `ZRemoteClient` + `ZRemoteEventRepository`)
+> - Settings persistence via DataStore Preferences (server URL)
+> - Bottom navigation: Hosts, Loops, Tasks, Settings
+> - Type-safe navigation with `@Serializable` route objects (Navigation Compose 2.8+)
+> - Loop transcript viewer shows detail info (full transcript requires server-side API extension)
+> - Approve/deny deferred to Phase 4 (requires server-side permission forwarding endpoint)
 
 ### Project Structure
 

--- a/docs/rfc/rfc-mobile-app.md
+++ b/docs/rfc/rfc-mobile-app.md
@@ -1,6 +1,6 @@
 # RFC: ZRemote Mobile App
 
-## Status: Idea / Exploration
+## Status: In Progress (Phase 0 complete)
 
 ## Context & Motivation
 
@@ -13,76 +13,42 @@ ZRemote currently has a native GPUI desktop client and a web-accessible server. 
 
 The existing codebase is written entirely in Rust. The key question is: **how much code can be reused for mobile, and what's the best architecture?**
 
-## Prerequisite: `zremote-client` SDK Crate
+## Phase 0: `zremote-client` SDK Crate [COMPLETED]
 
-Before building any mobile app, extract a shared **`zremote-client`** SDK crate that all GUI clients (desktop GPUI, mobile, future CLI tools) depend on. This eliminates code duplication and ensures consistent API behavior across all frontends.
+The shared **`zremote-client`** SDK crate has been extracted from `zremote-gui`. All GUI clients (desktop GPUI, mobile, future CLI tools) depend on it. This eliminates code duplication and ensures consistent API behavior across all frontends.
 
-### What to Extract from `zremote-gui`
-
-The desktop GUI currently contains platform-independent networking code that belongs in a shared crate:
-
-| Source file | What to extract | Notes |
-|---|---|---|
-| `zremote-gui/src/api.rs` | `ApiClient` (REST client) | 178 lines. reqwest-based. Zero GPUI dependencies. Move as-is. |
-| `zremote-gui/src/types.rs` | All API types (`Host`, `Session`, `Project`, `ServerEvent`, `TerminalServerMessage`, etc.) | 195 lines. Pure serde structs. Move as-is. |
-| `zremote-gui/src/events_ws.rs` | `run_events_ws()` (event stream with auto-reconnect) | 59 lines. Uses tokio-tungstenite + flume. Move as-is. |
-| `zremote-gui/src/terminal_ws.rs` | `TerminalWsHandle`, `connect()`, terminal WS protocol | 206 lines. Binary frame parsing, scrollback buffering. Move as-is. |
-
-### SDK Crate Structure
+### Current SDK Structure
 
 ```
 crates/zremote-client/
   Cargo.toml          # deps: reqwest, tokio, tokio-tungstenite, serde, serde_json,
-                      #       futures-util, flume, tracing, uuid, chrono
+                      #       futures-util, flume, tracing, uuid, chrono, url,
+                      #       percent-encoding, rand, tokio-util
                       # depends on: zremote-protocol
   src/
-    lib.rs            # Re-exports
-    api.rs            # ApiClient - REST endpoints
-    types.rs          # Host, Session, Project, ServerEvent, Terminal messages
-    events.rs         # run_events_ws() - event stream with reconnect
-    terminal.rs       # TerminalWsHandle, connect() - terminal WS I/O
-    error.rs          # ApiError (currently in api.rs)
+    lib.rs            # Re-exports (74 lines)
+    client.rs         # ApiClient - 60+ REST endpoints (1,074 lines)
+    types.rs          # Host, Session, Project, ServerEvent, Terminal messages (607 lines)
+    events.rs         # EventStream - event WS with auto-reconnect + backoff (151 lines)
+    terminal.rs       # TerminalSession - terminal WS I/O, multi-pane, UTF-8 safe (546 lines)
+    error.rs          # ApiError - 6 variants, response body reader (130 lines)
 ```
 
-### Dependency Graph After Extraction
+**Total: 2,582 lines. Zero GPUI dependencies. 100% platform-independent.**
+
+### Dependency Graph
 
 ```
 zremote-protocol          (types only, no runtime)
-       │
-       ▼
+       |
+       v
 zremote-client            (SDK: REST + WS client, platform-independent)
-       │
-  ┌────┼────────┐
-  ▼    ▼        ▼
+       |
+  +----+--------+
+  v    v        v
  GUI  Mobile   CLI tools
-(GPUI) (UniFFI/  (future)
-       Dioxus/
-       etc.)
+(GPUI) (UniFFI)  (future)
 ```
-
-### Migration Plan
-
-1. Create `crates/zremote-client/` with dependencies from above
-2. Move `api.rs`, `types.rs`, `events_ws.rs`, `terminal_ws.rs` from GUI to SDK
-3. GUI becomes a thin presentation layer: `zremote-gui` depends on `zremote-client`
-4. All `use crate::types::*` in GUI views change to `use zremote_client::*`
-5. No behavior change — purely structural refactor
-
-### Channel Abstraction
-
-Currently the code uses `flume` channels for tokio-to-GUI communication. The SDK should keep `flume` as the default (it works on all platforms including mobile), but the channel types are part of the public API:
-
-```rust
-// zremote-client/src/terminal.rs
-pub struct TerminalWsHandle {
-    pub input_tx: flume::Sender<Vec<u8>>,
-    pub output_rx: flume::Receiver<TerminalEvent>,
-    pub resize_tx: flume::Sender<(u16, u16)>,
-    pub image_paste_tx: flume::Sender<String>,
-}
-```
-
-This works for both GPUI (current) and mobile frameworks (Dioxus reads from flume, UniFFI can wrap in callback). If a future client needs `tokio::sync::mpsc` instead, a feature flag or generic channel trait can be added later.
 
 ### What Stays in GUI
 
@@ -95,13 +61,35 @@ This works for both GPUI (current) and mobile frameworks (Dioxus reads from flum
 | `assets.rs` | rust-embed AssetSource for GPUI |
 | `views/` | All GPUI views (sidebar, terminal panel, terminal element) |
 
-### Benefits
+### SDK Public API Summary
 
-- **Single source of truth** for API interactions — bug fixes propagate to all clients
-- **Mobile app starts with a working SDK** — no need to rewrite networking
-- **Testable independently** — SDK can have integration tests against a real server
-- **UniFFI-ready** — SDK types are simple serde structs, trivial to annotate with `#[uniffi::export]`
-- **Future-proof** — CLI tools, TUI clients, or web frontends can all use the same SDK
+**ApiClient** (60+ async methods, all return `Result<T, ApiError>`):
+
+| Domain | Methods |
+|---|---|
+| Health | `health()`, `get_mode()`, `get_mode_info()` |
+| Hosts | `list_hosts()`, `get_host()`, `update_host()`, `delete_host()` |
+| Sessions | `list_sessions()`, `create_session()`, `get_session()`, `update_session()`, `close_session()`, `purge_session()` |
+| Projects | `list_projects()`, `get_project()`, `update_project()`, `delete_project()`, `add_project()`, `trigger_scan()`, `trigger_git_refresh()`, `list_project_sessions()` |
+| Worktrees | `list_worktrees()`, `create_worktree()`, `delete_worktree()` |
+| Settings | `get_settings()`, `save_settings()` |
+| Actions | `list_actions()`, `run_action()`, `resolve_action_inputs()`, `resolve_prompt()`, `configure_with_claude()` |
+| Loops | `list_loops()`, `get_loop()` |
+| Config | `get_global_config()`, `set_global_config()`, `get_host_config()`, `set_host_config()` |
+| Knowledge | `get_knowledge_status()`, `trigger_index()`, `search_knowledge()`, `list_memories()`, `update_memory()`, `delete_memory()`, `extract_memories()`, `generate_instructions()`, `write_claude_md()`, `bootstrap_project()`, `control_knowledge_service()` |
+| Claude Tasks | `list_claude_tasks()`, `create_claude_task()`, `get_claude_task()`, `resume_claude_task()`, `discover_claude_sessions()` |
+| Directory | `browse_directory()` |
+| Terminal | `open_terminal()` (convenience: create session + connect WS) |
+
+**EventStream** (auto-reconnect WebSocket):
+- `connect(url, tokio_handle) -> Self` with `flume::Receiver<ClientEvent>`
+- `ClientEvent::Connected`, `Disconnected`, `Server(Box<ServerEvent>)`
+- Exponential backoff 1s-30s with 25% jitter
+
+**TerminalSession** (bidirectional terminal WS):
+- `connect(url, handle)` (blocking) / `connect_spawned(url, handle)` (non-blocking)
+- 4 channels: `input_tx`, `output_rx`, `resize_tx`, `image_paste_tx`
+- Binary frame optimization, multi-pane support, 100MB scrollback cap
 
 ---
 
@@ -109,13 +97,11 @@ This works for both GPUI (current) and mobile frameworks (Dioxus reads from flum
 
 ### Directly Reusable (platform-independent)
 
-| Crate / Module | Reuse | Dependencies | Notes |
-|---|---|---|---|
-| `zremote-protocol` | **100%** | serde, uuid, chrono | All message types, enums, IDs. Zero platform assumptions. |
-| `zremote-gui/api.rs` | **95%** | reqwest, tokio | REST client (ApiClient). Thin wrapper, directly extractable. |
-| `zremote-gui/types.rs` | **95%** | serde | Host, Session, Project, ServerEvent structs. Plain data types. |
-| `zremote-core/queries/` | **50-80%** | sqlx (SQLite) | SQL queries are portable. sqlx works on mobile with SQLite. |
-| `zremote-core/state.rs` | **70%** | serde, tokio | SessionState, AgenticLoopState types. Drop DashMap/Axum parts. |
+| Crate / Module | Reuse | Notes |
+|---|---|---|
+| `zremote-protocol` | **100%** | All message types, enums, IDs. Zero platform assumptions. |
+| `zremote-client` | **100%** | Full SDK already extracted. REST + WS client. |
+| `zremote-core/queries/` | **50-80%** | SQL queries are portable. sqlx works on mobile with SQLite. |
 
 ### Not Reusable
 
@@ -123,455 +109,11 @@ This works for both GPUI (current) and mobile frameworks (Dioxus reads from flum
 |---|---|
 | `zremote-gui` (GPUI views) | GPUI is desktop-only. Complete UI rebuild needed. |
 | `zremote-core/error.rs` | Axum-specific (IntoResponse). Needs decoupling. |
-| `zremote-agent` | PTY/tmux, process tree BFS, hooks. Platform-specific binary. |
-
-### Extraction Strategy
-
-Create a new **`zremote-client`** crate:
-- Extract `api.rs` + `types.rs` from `zremote-gui`
-- Add WebSocket client for events stream and terminal I/O
-- Depends on: `zremote-protocol`, `reqwest`, `tokio`, `serde`
-- Platform-independent, usable by desktop GUI, mobile, and CLI tools
+| `zremote-agent` | PTY, process tree BFS, hooks. Platform-specific binary. |
 
 ---
 
-## Option 1: Shared Rust Core + Native UI (UniFFI)
-
-### Architecture
-
-```
-┌─────────────────────────────────────────────┐
-│  Rust Core (zremote-client + zremote-protocol) │
-│  - REST API client                            │
-│  - WebSocket event stream                     │
-│  - WebSocket terminal I/O                     │
-│  - Local state / caching (SQLite optional)    │
-│  - Business logic (session mgmt, loop state)  │
-└──────────┬──────────────────┬────────────────┘
-           │ UniFFI           │ UniFFI
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Kotlin      │    │  Swift       │
-    │  Jetpack     │    │  SwiftUI     │
-    │  Compose     │    │              │
-    └─────────────┘    └──────────────┘
-```
-
-### How It Works
-
-[UniFFI](https://github.com/mozilla/uniffi-rs) (Mozilla) auto-generates Kotlin and Swift bindings from Rust. You annotate Rust functions/types with `#[uniffi::export]` and get type-safe foreign bindings.
-
-```rust
-// zremote-client/src/lib.rs
-#[uniffi::export]
-pub async fn list_hosts(server_url: String) -> Result<Vec<Host>, ClientError> {
-    let client = ApiClient::new(&server_url);
-    client.list_hosts().await
-}
-
-#[derive(uniffi::Record)]
-pub struct Host {
-    pub id: String,
-    pub hostname: String,
-    pub status: String,
-    pub agent_version: Option<String>,
-}
-```
-
-Kotlin side (auto-generated):
-```kotlin
-val hosts = listHosts("http://myserver:3000")
-hosts.forEach { host ->
-    Text("${host.hostname}: ${host.status}")
-}
-```
-
-### Pros
-
-- **Production-proven**: Used by Firefox on all platforms, Bitwarden, several fintech apps
-- **Maximum native UX**: Full access to platform APIs, gestures, notifications, widgets
-- **Type-safe FFI**: No manual JNI/C bridging. Types auto-generated
-- **60-80% Rust code reuse**: All business logic, networking, state in Rust
-- **Independent platform evolution**: iOS and Android UI can diverge where needed
-- **Mature ecosystem**: UniFFI is stable (v0.28+), well-documented, actively maintained
-
-### Cons
-
-- **Two UI codebases**: Jetpack Compose (Android) + SwiftUI (iOS)
-- **Build complexity**: Cross-compilation targets (aarch64-linux-android, aarch64-apple-ios)
-- **Learning curve**: Need Kotlin/Swift knowledge alongside Rust
-- **Sync overhead**: Keeping both UIs in sync with Rust API changes
-
-### Effort Estimate
-
-- `zremote-client` extraction: 1-2 weeks
-- UniFFI bindings setup: 1 week
-- Android UI (Jetpack Compose): 3-5 weeks
-- iOS UI (SwiftUI): 3-5 weeks (if desired)
-- **Total (Android only): 5-8 weeks**
-- **Total (both platforms): 8-13 weeks**
-
-### When to Choose
-
-- You want polished, native-feeling apps
-- You plan to ship to both platforms eventually
-- You have (or will hire) Kotlin/Swift expertise
-- Long-term maintenance is a priority
-
----
-
-## Option 2: Shared Rust Core + Native UI (Crux)
-
-### Architecture
-
-```
-┌──────────────────────────────────────────────┐
-│  Crux App Core (Rust)                         │
-│  - Pure state machine (no side effects)       │
-│  - update(event, model) -> (model, effects)   │
-│  - Effects: Http, WebSocket, Notifications    │
-│  - Depends on: zremote-protocol, zremote-client│
-└──────────┬──────────────────┬────────────────┘
-           │ crux_core FFI    │ crux_core FFI
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Kotlin      │    │  Swift       │
-    │  Jetpack     │    │  SwiftUI     │
-    │  Compose     │    │              │
-    │  (Shell)     │    │  (Shell)     │
-    └─────────────┘    └──────────────┘
-```
-
-### How It Works
-
-[Crux](https://github.com/redbadger/crux) enforces a strict architecture: the Rust core is a **pure function** (no I/O, no async). Side effects are described as data and executed by the platform shell.
-
-```rust
-// Crux app definition
-pub struct App;
-
-#[derive(Default)]
-pub struct Model {
-    hosts: Vec<Host>,
-    sessions: Vec<Session>,
-    active_loops: Vec<LoopInfo>,
-}
-
-pub enum Event {
-    LoadHosts,
-    HostsLoaded(Vec<Host>),
-    SelectSession(SessionId),
-    LoopStatusChanged(AgenticLoopId, AgenticStatus),
-}
-
-pub enum Effect {
-    Http(HttpRequest),
-    WebSocket(WsMessage),
-    Notification(String),
-}
-
-impl crux_core::App for App {
-    fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
-        match event {
-            Event::LoadHosts => {
-                caps.http.get("/api/hosts").send(Event::HostsLoaded);
-            }
-            Event::HostsLoaded(hosts) => {
-                model.hosts = hosts;
-            }
-            // ...
-        }
-    }
-}
-```
-
-### Pros
-
-- **Testable by design**: Core is pure Rust, test without emulators or mocks
-- **Strong architecture**: Elm-like, prevents spaghetti state management
-- **Auto-generated bindings**: Swift and Kotlin types from Rust (like UniFFI)
-- **Consistent behavior**: Same logic on all platforms, guaranteed
-- **Good for ZRemote**: Event-driven nature maps well to WebSocket events
-
-### Cons
-
-- **Pre-1.0**: API may change. Smaller community than UniFFI
-- **Opinionated**: Forces functional architecture; not everyone's style
-- **Effect overhead**: Every I/O operation goes through the shell (extra indirection)
-- **Learning curve**: Crux-specific patterns on top of Rust + native UI
-- **Two UI codebases**: Still need Kotlin + Swift shells
-
-### Effort Estimate
-
-- Crux app core setup: 2 weeks
-- Integration with zremote-protocol: 1 week
-- Android shell (Jetpack Compose): 3-5 weeks
-- iOS shell (SwiftUI): 3-5 weeks
-- **Total (Android only): 6-8 weeks**
-- **Total (both platforms): 9-13 weeks**
-
-### When to Choose
-
-- You value strong architectural guarantees and testability
-- You like Elm/Redux-style state management
-- You want the core to be extremely easy to unit test
-- You're OK with a pre-1.0 framework
-
----
-
-## Option 3: Full Rust UI with Dioxus
-
-### Architecture
-
-```
-┌─────────────────────────────────────────┐
-│  Dioxus App (Rust)                       │
-│  - React-like declarative UI             │
-│  - Uses zremote-protocol directly        │
-│  - Uses zremote-client directly          │
-│  - Single codebase for all platforms     │
-└──────────┬──────────────────┬───────────┘
-           │ cargo-mobile2    │ cargo-mobile2
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Android     │    │  iOS         │
-    │  (WebView    │    │  (WebView    │
-    │   or native) │    │   or native) │
-    └─────────────┘    └──────────────┘
-```
-
-### How It Works
-
-[Dioxus](https://github.com/DioxusLabs/dioxus) (v0.6.x) provides a React-like API in Rust. Components are functions with hooks.
-
-```rust
-fn HostList() -> Element {
-    let hosts = use_resource(|| async {
-        let client = ApiClient::new("http://server:3000");
-        client.list_hosts().await
-    });
-
-    rsx! {
-        for host in hosts.read().iter().flatten() {
-            div { class: "host-card",
-                h3 { "{host.hostname}" }
-                span { class: "status", "{host.status}" }
-            }
-        }
-    }
-}
-
-fn App() -> Element {
-    rsx! {
-        Router::<Route> {}
-    }
-}
-```
-
-### Pros
-
-- **Single codebase**: One Rust project for Android, iOS, desktop, and web
-- **100% Rust**: No Kotlin/Swift needed. All team expertise stays in Rust
-- **Direct crate reuse**: `use zremote_protocol::*` — no FFI layer
-- **Fast prototyping**: Ship a working app quickly
-- **Hot reload**: `dx serve` for rapid iteration
-- **Web target**: Same code compiles to WASM for a web client bonus
-
-### Cons
-
-- **Mobile is experimental**: Android support works but tooling is rough
-- **Not native UI**: Custom rendering, doesn't look like native Android/iOS
-- **Platform integration gaps**: Notifications, background services, deep links need workarounds
-- **Framework risk**: If Dioxus mobile stalls, you're stuck
-- **Performance**: WebView-based mobile rendering is slower than native
-- **Android build issues**: NDK configuration, signing, and deployment are manual
-
-### Effort Estimate
-
-- Dioxus project setup + mobile targets: 1 week
-- UI implementation: 3-5 weeks
-- Platform-specific workarounds (notifications, etc.): 2-3 weeks
-- **Total: 6-9 weeks**
-
-### When to Choose
-
-- Android-only or prototype/MVP
-- Team is Rust-only, no Kotlin/Swift expertise
-- You accept non-native look and feel
-- Speed of initial delivery matters more than polish
-
----
-
-## Option 4: Full Rust UI with Makepad
-
-### Architecture
-
-```
-┌─────────────────────────────────────────┐
-│  Makepad App (Rust)                      │
-│  - GPU-accelerated rendering             │
-│  - Custom DSL for layouts                │
-│  - Uses zremote-protocol directly        │
-│  - Single codebase                       │
-└──────────┬──────────────────┬───────────┘
-           │                  │
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Android     │    │  iOS         │
-    │  (GPU)       │    │  (GPU)       │
-    └─────────────┘    └──────────────┘
-```
-
-### How It Works
-
-[Makepad](https://github.com/makepad/makepad) (v1.0, May 2025) uses GPU shaders for rendering and has its own DSL.
-
-```rust
-live_design! {
-    HostCard = <View> {
-        flow: Down,
-        padding: 10,
-        <Label> { text: "hostname" }
-        <Label> { text: "status", draw_text: { color: #4ade80 } }
-    }
-
-    HostList = <PortalList> {
-        HostCard = <HostCard> {}
-    }
-}
-```
-
-### Pros
-
-- **GPU-accelerated**: Smooth animations, 120fps capable
-- **Single codebase**: Rust everywhere, all platforms
-- **Live design**: Edit DSL and see changes instantly
-- **Good for terminal rendering**: GPU rendering could handle terminal grid efficiently
-- **v1.0 released**: First stable release (May 2025)
-
-### Cons
-
-- **Very small community**: Few production apps, limited documentation
-- **Custom DSL**: Another thing to learn, not standard Rust
-- **Unproven at scale**: v1.0 is recent, unknown production reliability
-- **No ecosystem**: No component libraries, no established patterns
-- **Platform integration**: Same gaps as Dioxus (notifications, etc.)
-- **Risk**: Single-maintainer project vibes
-
-### Effort Estimate
-
-- Makepad setup + learning DSL: 2 weeks
-- UI implementation: 4-6 weeks
-- Platform workarounds: 2-3 weeks
-- **Total: 8-11 weeks**
-
-### When to Choose
-
-- You want to experiment with cutting-edge Rust UI
-- GPU rendering is important (terminal grid rendering)
-- You're OK with high risk and small community
-- Research/exploration project, not production deadline
-
----
-
-## Option 5: Tauri Mobile
-
-### Architecture
-
-```
-┌─────────────────────────────────────────┐
-│  Web Frontend (HTML/CSS/JS or WASM)      │
-│  - Could reuse existing server web UI    │
-│  - Or build new with React/Svelte/Leptos │
-└──────────────────┬──────────────────────┘
-                   │ WebView
-┌──────────────────▼──────────────────────┐
-│  Tauri Rust Backend                      │
-│  - Uses zremote-client directly          │
-│  - Native API access via plugins         │
-│  - Push notifications, background tasks  │
-└──────────┬──────────────────┬───────────┘
-           │                  │
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Android     │    │  iOS         │
-    │  (WebView)   │    │  (WKWebView) │
-    └─────────────┘    └──────────────┘
-```
-
-### Pros
-
-- **Web skills reusable**: If you build a web frontend, it works on mobile too
-- **Rust backend**: Tauri's backend is Rust, direct crate reuse
-- **Plugin ecosystem**: Camera, notifications, biometrics via Tauri plugins
-- **Tauri v2**: Mobile support improved significantly
-
-### Cons
-
-- **WebView performance**: Not suitable for terminal rendering at 60fps
-- **Not native feel**: Web UI in a wrapper
-- **Bundle size**: Includes WebView runtime
-- **ZRemote has no web frontend**: Would need to build one from scratch
-- **Limited for terminal**: WebView is wrong tool for real-time terminal I/O
-
-### Effort Estimate
-
-- Web frontend (if none exists): 4-6 weeks
-- Tauri mobile setup: 1-2 weeks
-- Platform integration: 2-3 weeks
-- **Total: 7-11 weeks**
-
-### When to Choose
-
-- You also want a web client
-- Terminal rendering is not needed (monitoring/status only)
-- Team has web development experience
-
----
-
-## Option 6: Kotlin Multiplatform + Rust Core
-
-### Architecture
-
-```
-┌─────────────────────────────────────────┐
-│  Rust Core (via UniFFI)                  │
-│  - zremote-client, zremote-protocol      │
-└──────────────────┬──────────────────────┘
-                   │ UniFFI bindings
-┌──────────────────▼──────────────────────┐
-│  Kotlin Multiplatform (KMP)              │
-│  - Shared Kotlin layer (viewmodels)      │
-│  - expect/actual for platform specifics  │
-└──────────┬──────────────────┬───────────┘
-           │                  │
-    ┌──────▼──────┐    ┌─────▼───────┐
-    │  Android     │    │  iOS         │
-    │  Jetpack     │    │  SwiftUI     │
-    │  Compose     │    │  (via KMP)   │
-    └─────────────┘    └──────────────┘
-```
-
-### Pros
-
-- **KMP is mainstream**: Google-backed, large community, production-ready
-- **Shared viewmodels**: Business logic in Kotlin shared across platforms
-- **Best Android story**: Jetpack Compose is the standard
-- **Rust where it matters**: Core protocol/networking in Rust via UniFFI
-
-### Cons
-
-- **Three languages**: Rust + Kotlin + Swift (unless iOS uses KMP Compose)
-- **KMP iOS**: Compose Multiplatform for iOS is less mature
-- **Extra layer**: Kotlin sits between Rust and UI, more indirection
-- **Build complexity**: Gradle + Cargo + Xcode
-
-### Effort Estimate
-
-- UniFFI Rust bindings: 1-2 weeks
-- KMP shared module: 2-3 weeks
-- Android UI: 3-4 weeks
-- iOS UI: 3-5 weeks
-- **Total (Android only): 6-9 weeks**
-
----
-
-## Comparison Matrix
+## Option Comparison (Chosen: Option 1 - UniFFI + Native UI)
 
 | Criteria | UniFFI + Native | Crux + Native | Dioxus | Makepad | Tauri | KMP + Rust |
 |---|---|---|---|---|---|---|
@@ -581,14 +123,14 @@ live_design! {
 | **Android effort** | 5-8w | 6-8w | 6-9w | 8-11w | 7-11w | 6-9w |
 | **Both platforms** | 8-13w | 9-13w | 6-9w | 8-11w | 7-11w | 9-14w |
 | **Terminal rendering** | Native perf | Native perf | WebView/limited | GPU/good | WebView/bad | Native perf |
-| **Team skills needed** | Rust+Kotlin+Swift | Rust+Kotlin+Swift | Rust only | Rust only | Rust+Web | Rust+Kotlin |
 | **Risk level** | Low | Medium | High | Very High | Medium | Low |
-| **Community size** | Large | Small | Medium | Very Small | Large | Very Large |
 | **Push notifications** | Native | Native | Manual | Manual | Plugin | Native |
 
-## Feature Scope (MVP)
+**Decision: Option 1 (UniFFI + Native UI)** -- lowest risk, best UX, battle-tested (Firefox, Bitwarden). See [Options appendix](#options-appendix) for detailed analysis of all options.
 
-Regardless of approach, the mobile MVP should include:
+---
+
+## Feature Scope (MVP)
 
 ### Must Have (P0)
 - Host list with online/offline status
@@ -610,33 +152,886 @@ Regardless of approach, the mobile MVP should include:
 - Analytics dashboard
 - Telegram-like notification preferences
 
-## Recommendation
+---
 
-### Step 1: Extract `zremote-client` SDK (regardless of mobile approach)
+## Phase 1: `zremote-ffi` Crate + UniFFI Bindings
 
-This is a prerequisite for any mobile option and improves the codebase independently:
-- Clean separation of concerns in the desktop GUI
-- SDK is testable, reusable, and UniFFI-ready
-- Effort: ~1-2 days (pure structural refactor, no behavior change)
+### Architecture Decision: Separate FFI Crate
 
-### Step 2: Choose mobile framework
+Do NOT annotate `zremote-client` directly. Create a new `crates/zremote-ffi/` crate that wraps the SDK with FFI-safe types.
 
-**Option 1 (UniFFI + Native UI)** is the recommended production path:
-
-1. **Lowest risk**: UniFFI is battle-tested (Firefox ships with it on all platforms)
-2. **Best UX**: Native Jetpack Compose / SwiftUI gives platform-appropriate experience
-3. **Terminal rendering**: Native Android Canvas / iOS CoreText can handle terminal grid efficiently
-4. **Notification support**: Direct access to FCM (Android) / APNs (iOS)
-5. **SDK types map 1:1**: `Host`, `Session`, `ServerEvent` become Kotlin/Swift data classes automatically
-
-**Alternative: Dioxus (Option 3)** for Android-only prototype — faster to ship, but may need rewrite for production quality.
-
-### Implementation Order
+**Why a separate crate:**
+- SDK types use `#[serde(tag = "type")]` tagged enums -- not UniFFI-compatible
+- `reqwest::StatusCode`, `flume` channels, `reqwest::Error` can't cross FFI
+- `ServerEvent` (20 variants) and `TerminalEvent` (11 variants) map better to callback interfaces than FFI enums
+- Keeps core SDK clean for the desktop client -- no `uniffi` dependency in `zremote-client`
 
 ```
-Phase 0: Extract zremote-client SDK from zremote-gui
-Phase 1: Add UniFFI annotations to SDK types + build Android .aar
-Phase 2: Android MVP (Jetpack Compose) — host list, session list, loop monitoring
-Phase 3: Terminal viewer (read-only) + push notifications
-Phase 4: (Optional) iOS app using same SDK
+crates/zremote-ffi/
+  Cargo.toml          # deps: zremote-client, uniffi, tokio
+  uniffi.toml         # Kotlin binding config (package: com.zremote.sdk)
+  src/
+    lib.rs            # uniffi::setup_scaffolding!() + re-exports
+    types.rs          # FFI-safe record types + From impls
+    client.rs         # ZRemoteClient object (wraps ApiClient + Tokio runtime)
+    events.rs         # EventListener callback + ZRemoteEventStream handle
+    terminal.rs       # TerminalListener callback + ZRemoteTerminal handle
+    error.rs          # FfiError enum
 ```
+
+### FFI Type Mappings
+
+#### Direct mappings (`#[derive(uniffi::Record)]`)
+
+These SDK types are all `String`/`Option<String>`/primitives and map 1:1:
+
+| SDK Type | FFI Record | Fields |
+|---|---|---|
+| `Host` | `FfiHost` | id, name, hostname, status, last_seen_at, agent_version, os, arch, created_at, updated_at |
+| `Session` | `FfiSession` | id, host_id, name, shell, status, working_dir, project_id, pid, exit_code, created_at, closed_at |
+| `Project` | `FfiProject` | id, host_id, path, name, has_claude_config, has_zremote_config, project_type, created_at, parent_project_id, git_branch, git_commit_hash, git_commit_message, git_is_dirty, git_ahead, git_behind, git_remotes (as `Option<String>` JSON), git_updated_at, pinned |
+| `AgenticLoop` | `FfiAgenticLoop` | id, session_id, project_path, tool_name, status (FfiAgenticStatus), started_at, ended_at, end_reason, task_name |
+| `ConfigValue` | `FfiConfigValue` | key, value, updated_at |
+| `ModeInfo` | `FfiModeInfo` | mode, version |
+| `CreateSessionResponse` | `FfiCreateSessionResponse` | id, status |
+| `ClaudeTask` | `FfiClaudeTask` | id, session_id, host_id, project_path, project_id, model, initial_prompt, claude_session_id, resume_from, status (FfiClaudeTaskStatus), options_json, loop_id, started_at, ended_at, total_cost_usd, total_tokens_in, total_tokens_out, summary, task_name, created_at |
+| `KnowledgeBase` | `FfiKnowledgeBase` | id, host_id, status (FfiKnowledgeServiceStatus), openviking_version, last_error, started_at, updated_at |
+| `Memory` | `FfiMemory` | id, project_id, loop_id, key, content, category (FfiMemoryCategory), confidence, created_at, updated_at |
+| `DirectoryEntry` | `FfiDirectoryEntry` | name, is_dir, size |
+| `WorktreeInfo` | `FfiWorktreeInfo` | id, path, branch, is_main, commit_hash, is_dirty, ahead, behind |
+| `GitInfo` | `FfiGitInfo` | branch, commit_hash, commit_message, is_dirty, ahead, behind, remotes (Vec<FfiGitRemote>), updated_at |
+| `GitRemote` | `FfiGitRemote` | name, url |
+| `SearchResult` | `FfiSearchResult` | id, content, score, tier (FfiSearchTier), source |
+| `LoopInfo` | `FfiLoopInfo` | id, session_id, project_path, tool_name, status (FfiAgenticStatus), started_at, ended_at, end_reason, task_name |
+| `HostInfo` | `FfiHostInfo` | id, hostname, status, agent_version, os, arch |
+| `SessionInfo` | `FfiSessionInfo` | id, host_id, shell, status |
+
+#### FFI Enums (`#[derive(uniffi::Enum)]`)
+
+| Protocol Enum | FFI Enum | Variants |
+|---|---|---|
+| `AgenticStatus` | `FfiAgenticStatus` | Working, WaitingForInput, Error, Completed, Unknown |
+| `ClaudeTaskStatus` | `FfiClaudeTaskStatus` | Starting, Active, Completed, Error |
+| `KnowledgeServiceStatus` | `FfiKnowledgeServiceStatus` | Starting, Ready, Indexing, Error, Stopped |
+| `MemoryCategory` | `FfiMemoryCategory` | Pattern, Decision, Pitfall, Preference, Architecture, Convention |
+| `SearchTier` | `FfiSearchTier` | L0, L1, L2 |
+
+#### Request Records (`#[derive(uniffi::Record)]`)
+
+| SDK Request | FFI Record | Fields |
+|---|---|---|
+| `CreateSessionRequest` | `FfiCreateSessionRequest` | name: Option<String>, shell: Option<String>, cols: u16, rows: u16, working_dir: Option<String> |
+| `UpdateHostRequest` | `FfiUpdateHostRequest` | name: String |
+| `UpdateProjectRequest` | `FfiUpdateProjectRequest` | pinned: Option<bool> |
+| `AddProjectRequest` | `FfiAddProjectRequest` | path: String |
+| `CreateWorktreeRequest` | `FfiCreateWorktreeRequest` | branch: String, path: Option<String>, new_branch: bool |
+| `ListLoopsFilter` | `FfiListLoopsFilter` | status: Option<String>, host_id: Option<String>, session_id: Option<String>, project_id: Option<String> |
+| `ListClaudeTasksFilter` | `FfiListClaudeTasksFilter` | host_id: Option<String>, status: Option<String>, project_id: Option<String> |
+| `CreateClaudeTaskRequest` | `FfiCreateClaudeTaskRequest` | host_id: String, project_path: String, project_id: Option<String>, model: Option<String>, initial_prompt: Option<String>, allowed_tools: Vec<String>, skip_permissions: Option<bool>, output_format: Option<String>, custom_flags: Option<String> |
+| `SearchRequest` | `FfiSearchRequest` | query: String, tier: Option<FfiSearchTier>, max_results: Option<u32> |
+
+#### Types that CANNOT cross FFI directly
+
+| Type | Problem | Solution |
+|---|---|---|
+| `ServerEvent` (20-variant tagged enum) | `#[serde(tag = "type")]`, complex payloads | `EventListener` callback interface |
+| `TerminalEvent` (11-variant enum) | `Vec<u8>` data fields | `TerminalListener` callback interface |
+| `ApiError` | Contains `reqwest::StatusCode`, `reqwest::Error` | `FfiError` with code + message strings |
+| `ProjectSettings` | Deeply nested (contains `HashMap`, `Vec<ProjectAction>`, etc.) | Serialize as JSON string across FFI |
+| `EventStream` | Has `flume::Receiver` | `ZRemoteEventStream` handle object |
+| `TerminalSession` | Has 4 `flume` channels | `ZRemoteTerminal` handle object |
+
+### FFI Error Type
+
+```rust
+#[derive(Debug, uniffi::Error)]
+pub enum FfiError {
+    Http { message: String },
+    Server { status_code: u16, message: String },
+    Serialization { message: String },
+    InvalidUrl { message: String },
+    ChannelClosed { message: String },
+    Disconnected { message: String },
+}
+
+// Conversion: reqwest::StatusCode -> u16, inner errors -> .to_string()
+impl From<ApiError> for FfiError { ... }
+```
+
+### ZRemoteClient Object
+
+```rust
+#[derive(uniffi::Object)]
+pub struct ZRemoteClient {
+    inner: ApiClient,
+    runtime: tokio::runtime::Runtime,  // Owns Tokio runtime for async bridging
+}
+
+#[uniffi::export]
+impl ZRemoteClient {
+    #[uniffi::constructor]
+    fn new(base_url: String) -> Result<Arc<Self>, FfiError>;
+
+    // All async methods become Kotlin suspend functions via UniFFI 0.28
+    async fn health(&self) -> Result<(), FfiError>;
+    async fn get_mode(&self) -> Result<String, FfiError>;
+    async fn get_mode_info(&self) -> Result<FfiModeInfo, FfiError>;
+
+    // Hosts
+    async fn list_hosts(&self) -> Result<Vec<FfiHost>, FfiError>;
+    async fn get_host(&self, host_id: String) -> Result<FfiHost, FfiError>;
+    async fn update_host(&self, host_id: String, req: FfiUpdateHostRequest) -> Result<FfiHost, FfiError>;
+    async fn delete_host(&self, host_id: String) -> Result<(), FfiError>;
+
+    // Sessions
+    async fn list_sessions(&self, host_id: String) -> Result<Vec<FfiSession>, FfiError>;
+    async fn create_session(&self, host_id: String, req: FfiCreateSessionRequest) -> Result<FfiCreateSessionResponse, FfiError>;
+    async fn get_session(&self, session_id: String) -> Result<FfiSession, FfiError>;
+    async fn close_session(&self, session_id: String) -> Result<(), FfiError>;
+
+    // Projects
+    async fn list_projects(&self, host_id: String) -> Result<Vec<FfiProject>, FfiError>;
+    async fn get_project(&self, project_id: String) -> Result<FfiProject, FfiError>;
+    async fn list_project_sessions(&self, project_id: String) -> Result<Vec<FfiSession>, FfiError>;
+
+    // Loops
+    async fn list_loops(&self, filter: FfiListLoopsFilter) -> Result<Vec<FfiAgenticLoop>, FfiError>;
+    async fn get_loop(&self, loop_id: String) -> Result<FfiAgenticLoop, FfiError>;
+
+    // Claude Tasks
+    async fn list_claude_tasks(&self, filter: FfiListClaudeTasksFilter) -> Result<Vec<FfiClaudeTask>, FfiError>;
+    async fn create_claude_task(&self, req: FfiCreateClaudeTaskRequest) -> Result<FfiClaudeTask, FfiError>;
+    async fn get_claude_task(&self, task_id: String) -> Result<FfiClaudeTask, FfiError>;
+
+    // ... remaining 40+ methods follow the same pattern:
+    // self.inner.method(args).await.map(Into::into).map_err(Into::into)
+
+    // WebSocket handle factories
+    fn connect_events(&self, listener: Box<dyn EventListener>) -> Result<Arc<ZRemoteEventStream>, FfiError>;
+    fn connect_terminal(&self, session_id: String, listener: Box<dyn TerminalListener>) -> Result<Arc<ZRemoteTerminal>, FfiError>;
+}
+```
+
+### EventListener Callback Interface
+
+Each `ServerEvent` variant maps to one callback method. The internal implementation spawns a tokio task that reads from `EventStream.rx` and dispatches to the appropriate callback.
+
+```rust
+#[uniffi::export(callback_interface)]
+pub trait EventListener: Send + Sync {
+    // Connection lifecycle
+    fn on_connected(&self);
+    fn on_disconnected(&self);
+
+    // Hosts
+    fn on_host_connected(&self, host: FfiHostInfo);
+    fn on_host_disconnected(&self, host_id: String);
+    fn on_host_status_changed(&self, host_id: String, status: String);
+
+    // Sessions
+    fn on_session_created(&self, session: FfiSessionInfo);
+    fn on_session_closed(&self, session_id: String, exit_code: Option<i32>);
+    fn on_session_updated(&self, session_id: String);
+    fn on_session_suspended(&self, session_id: String);
+    fn on_session_resumed(&self, session_id: String);
+
+    // Projects
+    fn on_projects_updated(&self, host_id: String);
+
+    // Agentic loops
+    fn on_loop_detected(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+    fn on_loop_status_changed(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+    fn on_loop_ended(&self, loop_info: FfiLoopInfo, host_id: String, hostname: String);
+
+    // Claude tasks
+    fn on_claude_task_started(&self, task_id: String, session_id: String, host_id: String, project_path: String);
+    fn on_claude_task_updated(&self, task_id: String, status: String, loop_id: Option<String>);
+    fn on_claude_task_ended(&self, task_id: String, status: String, summary: Option<String>);
+
+    // Claude session metrics
+    fn on_claude_session_metrics(&self, session_id: String, model: Option<String>,
+        context_used_pct: Option<f64>, cost_usd: Option<f64>,
+        tokens_in: Option<u64>, tokens_out: Option<u64>);
+
+    // Knowledge
+    fn on_knowledge_status_changed(&self, host_id: String, status: String, error: Option<String>);
+    fn on_indexing_progress(&self, project_id: String, project_path: String, status: String, files_processed: u64, files_total: u64);
+    fn on_memory_extracted(&self, project_id: String, loop_id: String, memory_count: u32);
+
+    // Worktrees
+    fn on_worktree_error(&self, host_id: String, project_path: String, message: String);
+}
+```
+
+```rust
+#[derive(uniffi::Object)]
+pub struct ZRemoteEventStream {
+    cancel: CancellationToken,
+}
+
+#[uniffi::export]
+impl ZRemoteEventStream {
+    fn disconnect(&self);  // Cancels the background task
+}
+// Also auto-disconnects on Drop
+```
+
+**Kotlin usage:**
+
+```kotlin
+val events = client.connectEvents(object : EventListener {
+    override fun onConnected() { Log.d("ZRemote", "Connected") }
+    override fun onDisconnected() { Log.d("ZRemote", "Disconnected") }
+
+    override fun onHostConnected(host: FfiHostInfo) {
+        viewModelScope.launch { _hosts.value += host.toUiModel() }
+    }
+    override fun onLoopStatusChanged(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+        viewModelScope.launch { _loops.update { it.replace(loopInfo) } }
+    }
+    override fun onClaudeTaskEnded(taskId: String, status: String, summary: String?) {
+        notificationManager.showTaskComplete(taskId, summary)
+    }
+    // ... other callbacks (default no-op implementations via interface defaults)
+})
+
+// Later:
+events.disconnect()
+```
+
+### TerminalListener Callback Interface
+
+```rust
+#[uniffi::export(callback_interface)]
+pub trait TerminalListener: Send + Sync {
+    fn on_output(&self, data: Vec<u8>);
+    fn on_pane_output(&self, pane_id: String, data: Vec<u8>);
+    fn on_pane_added(&self, pane_id: String, index: u16);
+    fn on_pane_removed(&self, pane_id: String);
+    fn on_session_closed(&self, exit_code: Option<i32>);
+    fn on_scrollback_start(&self, cols: u16, rows: u16);
+    fn on_scrollback_end(&self, truncated: bool);
+    fn on_session_suspended(&self);
+    fn on_session_resumed(&self);
+    fn on_error(&self, message: String);
+    fn on_disconnected(&self);
+}
+
+#[derive(uniffi::Object)]
+pub struct ZRemoteTerminal {
+    input_tx: flume::Sender<TerminalInput>,
+    resize_tx: flume::Sender<(u16, u16)>,
+    image_paste_tx: flume::Sender<String>,
+    cancel: CancellationToken,
+}
+
+#[uniffi::export]
+impl ZRemoteTerminal {
+    fn send_input(&self, data: Vec<u8>) -> Result<(), FfiError>;
+    fn send_pane_input(&self, pane_id: String, data: Vec<u8>) -> Result<(), FfiError>;
+    fn resize(&self, cols: u16, rows: u16) -> Result<(), FfiError>;
+    fn paste_image(&self, base64_data: String) -> Result<(), FfiError>;
+    fn disconnect(&self);
+}
+```
+
+**Kotlin usage:**
+
+```kotlin
+// Connect terminal
+val session = client.createSession(hostId, FfiCreateSessionRequest(
+    cols = 80u, rows = 24u, name = null, shell = null, workingDir = null
+))
+
+val terminal = client.connectTerminal(session.id, object : TerminalListener {
+    override fun onOutput(data: ByteArray) {
+        terminalEmulator.processInput(data)
+        invalidateView()
+    }
+    override fun onSessionClosed(exitCode: Int?) {
+        navigateBack()
+    }
+    override fun onScrollbackStart(cols: UShort, rows: UShort) { /* prepare buffer */ }
+    override fun onScrollbackEnd(truncated: Boolean) { /* flush buffer */ }
+    // ...
+})
+
+// Send user input
+terminal.sendInput("ls -la\n".toByteArray())
+terminal.resize(cols = 120u, rows = 40u)
+
+// Cleanup
+terminal.disconnect()
+```
+
+### Implementation Steps
+
+1. Create `crates/zremote-ffi/Cargo.toml` + `src/lib.rs` with `uniffi::setup_scaffolding!()`
+2. Add to workspace `Cargo.toml` members
+3. Define FFI enums + `From` impls
+4. Define FFI record types + `From` impls
+5. Define FFI request records
+6. Define `FfiError` + `From<ApiError>`
+7. Implement `ZRemoteClient` with constructor + core methods (health, hosts, sessions, loops)
+8. Implement `EventListener` callback + `ZRemoteEventStream` handle
+9. Implement `TerminalListener` callback + `ZRemoteTerminal` handle
+10. Add remaining ApiClient methods
+11. Verify `cargo build -p zremote-ffi` compiles
+
+### Key Technical Notes
+
+- **UniFFI `Vec<u8>` -> Kotlin `ByteArray`**: Works natively in UniFFI 0.28+
+- **UniFFI `HashMap<String, String>`**: Supported but avoided for deeply nested `ProjectSettings` -- use JSON string instead
+- **Async bridging**: UniFFI 0.28 `async` annotation makes Kotlin see `suspend fun` -- bridges to internal Tokio runtime automatically
+- **Callback thread safety**: `Send + Sync` required. Kotlin implementations dispatch to main thread via `viewModelScope.launch`
+- **reqwest on Android**: Works with `rustls-tls` feature (already in workspace). Uses Android CA bundle via `rustls-native-certs`
+- **tokio-tungstenite on Android**: `connect` + `rustls-tls-native-roots` works without issues
+
+---
+
+## Phase 2: Android Build Pipeline
+
+### Toolchain Setup
+
+```bash
+# Install cargo-ndk for Android cross-compilation
+cargo install cargo-ndk
+
+# Add Android targets
+rustup target add aarch64-linux-android    # arm64-v8a (modern phones)
+rustup target add armv7-linux-androideabi  # armeabi-v7a (older phones)
+rustup target add x86_64-linux-android     # x86_64 (emulator)
+rustup target add i686-linux-android       # x86 (old emulator)
+
+# Requires: ANDROID_NDK_HOME environment variable
+```
+
+### Build Script (`scripts/build-android.sh`)
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Build native libraries for all Android ABIs
+cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 \
+    -o ./android/app/src/main/jniLibs \
+    build --release -p zremote-ffi
+
+# Generate Kotlin bindings from the compiled library
+cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+    --library target/release/libzremote_ffi.so \
+    --language kotlin \
+    --out-dir android/app/src/main/java/
+```
+
+### UniFFI Configuration (`crates/zremote-ffi/uniffi.toml`)
+
+```toml
+[bindings.kotlin]
+package_name = "com.zremote.sdk"
+cdylib_name = "zremote_ffi"
+```
+
+### .aar Packaging
+
+Minimal Gradle project under `android/` that:
+1. Includes JNI `.so` files from `cargo-ndk` output
+2. Includes generated Kotlin binding files
+3. Packages into `.aar` via `./gradlew assembleRelease`
+
+### Binary Size Optimization
+
+```toml
+# Cargo.toml release profile
+[profile.release]
+opt-level = "z"     # Optimize for size
+lto = true          # Link-time optimization
+strip = true        # Strip debug symbols
+codegen-units = 1   # Better optimization
+```
+
+Expected size per ABI: ~5-8MB for the `.so` file. For MVP, `aarch64` only is sufficient (covers 95%+ of modern Android devices).
+
+### CI Integration
+
+- GitHub Actions workflow: build `.aar` on each release tag
+- Cache `cargo-ndk` and Rust target directories
+- Run `cargo test -p zremote-ffi` before building
+- Upload `.aar` as release artifact
+
+---
+
+## Phase 3: Android MVP App (Jetpack Compose)
+
+### Project Structure
+
+```
+android/
+  app/
+    build.gradle.kts
+    src/main/
+      java/com/zremote/
+        sdk/                        # Generated UniFFI bindings (from build)
+        app/
+          ZRemoteApp.kt             # Application class, DI setup
+          MainActivity.kt           # Single-activity, Compose navigation
+        di/
+          AppModule.kt              # Hilt/Koin DI module (provides ZRemoteClient)
+        ui/
+          theme/
+            Theme.kt                # Material 3 dark theme (match desktop)
+            Color.kt
+            Type.kt
+          navigation/
+            NavGraph.kt             # Navigation routes
+          screens/
+            hosts/
+              HostListScreen.kt     # P0: Host list with online/offline status
+              HostListViewModel.kt
+            sessions/
+              SessionListScreen.kt  # P0: Session list per host
+              SessionListViewModel.kt
+            loops/
+              LoopListScreen.kt     # P0: Active loops with status
+              LoopDetailScreen.kt   # P0: Loop transcript viewer
+              LoopListViewModel.kt
+            tasks/
+              TaskListScreen.kt     # P0: Claude tasks list
+              TaskDetailScreen.kt   # P0: Task detail + approve/deny
+              TaskListViewModel.kt
+            projects/
+              ProjectListScreen.kt  # P1: Projects with git status
+              ProjectListViewModel.kt
+  settings.gradle.kts
+  gradle.properties
+```
+
+### Architecture
+
+```
+ZRemoteClient (Rust via UniFFI)
+       |
+       v
+Repository layer (Kotlin)          <-- Caches, combines API calls
+       |
+       v
+ViewModel (Kotlin, Hilt)           <-- UI state, business logic
+       |
+       v
+Compose Screen                     <-- Pure UI, observes StateFlow
+```
+
+### Key Dependencies
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    // Compose
+    implementation(platform("androidx.compose:compose-bom:2025.01.00"))
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+
+    // Navigation
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+
+    // Lifecycle + ViewModel
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.0")
+
+    // DI
+    implementation("com.google.dagger:hilt-android:2.51")
+    kapt("com.google.dagger:hilt-compiler:2.51")
+
+    // Our native SDK
+    implementation(files("libs/zremote-ffi.aar"))
+}
+```
+
+### Screen Details
+
+#### Host List (P0)
+
+```kotlin
+@Composable
+fun HostListScreen(viewModel: HostListViewModel = hiltViewModel()) {
+    val hosts by viewModel.hosts.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+
+    LazyColumn {
+        items(hosts) { host ->
+            HostCard(
+                hostname = host.hostname,
+                status = host.status,        // "online" / "offline"
+                agentVersion = host.agentVersion,
+                os = host.os,
+                lastSeen = host.lastSeenAt,
+                onClick = { navigateToSessions(host.id) }
+            )
+        }
+    }
+}
+```
+
+- Real-time updates via `EventListener.onHostConnected/onHostDisconnected`
+- Pull-to-refresh calls `client.listHosts()`
+- Status indicator: green dot (online), gray dot (offline)
+
+#### Agentic Loop Monitoring (P0)
+
+```kotlin
+@Composable
+fun LoopListScreen(viewModel: LoopListViewModel = hiltViewModel()) {
+    val loops by viewModel.activeLoops.collectAsStateWithLifecycle()
+    val metrics by viewModel.sessionMetrics.collectAsStateWithLifecycle()
+
+    LazyColumn {
+        items(loops) { loop ->
+            LoopCard(
+                toolName = loop.toolName,
+                status = loop.status,
+                taskName = loop.taskName,
+                projectPath = loop.projectPath,
+                startedAt = loop.startedAt,
+                metrics = metrics[loop.sessionId],  // tokens, cost, context %
+                onClick = { navigateToLoopDetail(loop.id) }
+            )
+        }
+    }
+}
+```
+
+- Real-time via `EventListener.onLoopDetected/onLoopStatusChanged/onLoopEnded`
+- Token usage from `EventListener.onClaudeSessionMetrics`
+- Status colors: Working (blue), WaitingForInput (yellow), Error (red), Completed (green)
+
+#### Loop Transcript / Approve-Deny (P0)
+
+- View loop transcript (tool calls, results)
+- Approve/deny pending tool calls (via existing API -- may need new endpoint)
+- This requires server-side support for permission request forwarding to mobile
+
+### EventListener Integration Pattern
+
+```kotlin
+class ZRemoteEventRepository @Inject constructor(
+    private val client: ZRemoteClient
+) {
+    private val _hosts = MutableStateFlow<List<FfiHost>>(emptyList())
+    val hosts: StateFlow<List<FfiHost>> = _hosts.asStateFlow()
+
+    private val _loops = MutableStateFlow<List<FfiLoopInfo>>(emptyList())
+    val loops: StateFlow<List<FfiLoopInfo>> = _loops.asStateFlow()
+
+    private var eventStream: ZRemoteEventStream? = null
+
+    fun connect() {
+        eventStream = client.connectEvents(object : EventListener {
+            override fun onHostConnected(host: FfiHostInfo) {
+                // Refresh full host list on connection event
+                CoroutineScope(Dispatchers.IO).launch {
+                    _hosts.value = client.listHosts()
+                }
+            }
+            override fun onLoopStatusChanged(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+                _loops.update { current ->
+                    current.map { if (it.id == loopInfo.id) loopInfo else it }
+                }
+            }
+            // ... other callbacks
+        })
+    }
+
+    fun disconnect() {
+        eventStream?.disconnect()
+        eventStream = null
+    }
+}
+```
+
+---
+
+## Phase 4: Terminal Viewer + Push Notifications
+
+### Read-Only Terminal Viewer (P1)
+
+**Approach: Compose Canvas rendering**
+
+Render terminal output as a character grid on Android Canvas. This avoids WebView overhead and gives native performance.
+
+```kotlin
+@Composable
+fun TerminalViewer(
+    viewModel: TerminalViewModel = hiltViewModel(),
+    sessionId: String
+) {
+    val terminalState by viewModel.terminalState.collectAsStateWithLifecycle()
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        // Render character grid with colors
+        terminalState.lines.forEachIndexed { row, line ->
+            line.cells.forEachIndexed { col, cell ->
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = cell.char.toString(),
+                    topLeft = Offset(col * cellWidth, row * cellHeight),
+                    style = TextStyle(
+                        color = cell.fgColor.toComposeColor(),
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp
+                    )
+                )
+            }
+        }
+    }
+}
+```
+
+**Terminal emulation options:**
+1. **Minimal**: Just buffer raw output bytes, render as monospace text with ANSI color parsing. Good enough for log viewing.
+2. **Full VT100**: Use an Android terminal emulation library (e.g., termux's terminal-emulator) for proper cursor positioning, scrollback, etc.
+3. **Hybrid**: Start minimal (option 1), upgrade to full emulation later.
+
+**Recommendation**: Start with option 1 (ANSI color parsing only) for the MVP read-only viewer. Full VT100 emulation is only needed for interactive terminal (P2).
+
+### Basic Terminal Input (P1)
+
+- Soft keyboard input forwarded via `terminal.sendInput(data)`
+- Quick-command bar: predefined buttons for common actions (Ctrl+C, Enter, etc.)
+- No cursor positioning or arrow keys in MVP
+
+### Push Notifications (P0)
+
+**Architecture:**
+
+```
+Server/Agent -> WebSocket ServerEvent -> Mobile EventListener -> FCM notification
+```
+
+Two approaches:
+
+**Option A: Client-driven (simpler, MVP)**
+- Mobile app keeps WebSocket connection alive via Android Foreground Service
+- `EventListener` callbacks trigger local notifications when app is backgrounded
+- Pro: No server changes needed
+- Con: Battery drain, Android may kill the service
+
+**Option B: Server-driven (production)**
+- New server endpoint: `POST /api/notifications/register` with FCM device token
+- Server sends push via FCM when events match user's notification preferences
+- New table: `notification_registrations (device_token, user_id, preferences_json)`
+- New server module: FCM/APNs dispatch
+- Pro: Works when app is killed, battery-friendly
+- Con: Requires server changes + FCM project setup
+
+**Recommendation**: Start with Option A for MVP. Migrate to Option B for production. The `EventListener` callback structure makes Option A trivial:
+
+```kotlin
+// In EventListener implementation
+override fun onLoopEnded(loopInfo: FfiLoopInfo, hostId: String, hostname: String) {
+    if (appIsBackgrounded) {
+        notificationManager.notify(
+            id = loopInfo.id.hashCode(),
+            notification = buildNotification(
+                title = "Loop completed on $hostname",
+                body = "${loopInfo.toolName}: ${loopInfo.status}",
+                channel = CHANNEL_LOOP_STATUS
+            )
+        )
+    }
+}
+```
+
+**Notification types:**
+
+| Event | Priority | Channel |
+|---|---|---|
+| Loop completed | Default | `loop_status` |
+| Loop error | High | `loop_errors` |
+| Permission request (WaitingForInput) | High | `permissions` |
+| Claude task completed | Default | `task_status` |
+| Claude task error | High | `task_errors` |
+| Host disconnected | Low | `host_status` |
+
+### Android Foreground Service
+
+```kotlin
+class ZRemoteEventService : Service() {
+    private var eventStream: ZRemoteEventStream? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIFICATION_ID, buildOngoingNotification())
+        connectToServer()
+        return START_STICKY
+    }
+
+    private fun connectToServer() {
+        val client = ZRemoteClient(serverUrl)
+        eventStream = client.connectEvents(NotificationEventListener(this))
+    }
+}
+```
+
+---
+
+## Phase 5: (Optional) iOS App
+
+The same `zremote-ffi` crate generates Swift bindings via UniFFI:
+
+```bash
+cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+    --library target/release/libzremote_ffi.dylib \
+    --language swift \
+    --out-dir ios/ZRemote/Generated/
+```
+
+### iOS-Specific Considerations
+
+- **SwiftUI shell**: Same architecture as Android -- ViewModel + StateFlow pattern maps to `@Observable` + `@State`
+- **APNs**: Replace FCM with Apple Push Notification service
+- **Build targets**: `aarch64-apple-ios`, `aarch64-apple-ios-sim`
+- **XCFramework**: Package `.a` static library into XCFramework for distribution
+- **Same callback interfaces**: `EventListener` and `TerminalListener` become Swift protocols
+
+### Swift Example
+
+```swift
+class HostListViewModel: ObservableObject {
+    @Published var hosts: [FfiHost] = []
+    private let client: ZRemoteClient
+
+    func loadHosts() async throws {
+        hosts = try await client.listHosts()
+    }
+}
+
+struct HostListView: View {
+    @StateObject var viewModel = HostListViewModel()
+
+    var body: some View {
+        List(viewModel.hosts, id: \.id) { host in
+            HStack {
+                Circle()
+                    .fill(host.status == "online" ? .green : .gray)
+                    .frame(width: 8)
+                VStack(alignment: .leading) {
+                    Text(host.hostname).font(.headline)
+                    Text(host.agentVersion ?? "unknown").font(.caption)
+                }
+            }
+        }
+        .task { try? await viewModel.loadHosts() }
+    }
+}
+```
+
+---
+
+## Implementation Timeline
+
+| Phase | Scope | Depends On | Estimated Effort |
+|---|---|---|---|
+| ~~Phase 0~~ | ~~Extract zremote-client SDK~~ | - | ~~COMPLETED~~ |
+| Phase 1 | `zremote-ffi` crate + UniFFI bindings | Phase 0 | 1-2 weeks |
+| Phase 2 | Android build pipeline + .aar | Phase 1 | 3-5 days |
+| Phase 3 | Android MVP (hosts, sessions, loops, tasks) | Phase 2 | 3-5 weeks |
+| Phase 4 | Terminal viewer + push notifications | Phase 3 | 2-3 weeks |
+| Phase 5 | iOS app (optional) | Phase 1 | 3-5 weeks |
+
+**Total (Android only, Phases 1-4): 7-11 weeks**
+**Total (both platforms, Phases 1-5): 10-16 weeks**
+
+---
+
+## Open Questions
+
+1. **Permission forwarding**: How does the mobile app approve/deny tool call permissions? Is there an existing API endpoint, or does this need a new server feature?
+2. **Authentication**: Current setup uses `ZREMOTE_TOKEN` env var. Mobile needs a way to configure this -- settings screen with token input? QR code pairing?
+3. **Server-driven notifications**: When to implement FCM/APNs? MVP with foreground service, or invest in server-side push from the start?
+4. **Terminal emulation depth**: Is ANSI color parsing sufficient for MVP, or is full VT100 emulation needed from day one?
+5. **Minimum Android version**: API 26 (Android 8.0) is typical for modern apps. Lower?
+
+---
+
+## Options Appendix
+
+<details>
+<summary>Option 1: Shared Rust Core + Native UI (UniFFI) -- CHOSEN</summary>
+
+### Architecture
+
+```
++---------------------------------------------+
+|  Rust Core (zremote-client + zremote-protocol) |
+|  - REST API client                            |
+|  - WebSocket event stream                     |
+|  - WebSocket terminal I/O                     |
+|  - Local state / caching (SQLite optional)    |
+|  - Business logic (session mgmt, loop state)  |
++----------+------------------+----------------+
+           | UniFFI           | UniFFI
+    +------v------+    +-----v-------+
+    |  Kotlin      |    |  Swift       |
+    |  Jetpack     |    |  SwiftUI     |
+    |  Compose     |    |              |
+    +-------------+    +--------------+
+```
+
+[UniFFI](https://github.com/mozilla/uniffi-rs) (Mozilla) auto-generates Kotlin and Swift bindings from Rust.
+
+**Pros:**
+- Production-proven (Firefox, Bitwarden, fintech apps)
+- Maximum native UX (full platform APIs, gestures, notifications, widgets)
+- Type-safe FFI (no manual JNI/C bridging)
+- 60-80% Rust code reuse
+- Mature ecosystem (UniFFI v0.28+)
+
+**Cons:**
+- Two UI codebases (Jetpack Compose + SwiftUI)
+- Build complexity (cross-compilation targets)
+- Need Kotlin/Swift knowledge alongside Rust
+</details>
+
+<details>
+<summary>Option 2: Shared Rust Core + Native UI (Crux)</summary>
+
+[Crux](https://github.com/redbadger/crux) enforces a strict Elm-like architecture: Rust core is a pure function (no I/O, no async). Side effects described as data, executed by platform shell.
+
+**Pros:** Testable by design, strong architecture, auto-generated bindings
+**Cons:** Pre-1.0, opinionated, effect overhead, still needs Kotlin + Swift shells
+</details>
+
+<details>
+<summary>Option 3: Full Rust UI with Dioxus</summary>
+
+[Dioxus](https://github.com/DioxusLabs/dioxus) (v0.6.x) provides React-like API in Rust. Single codebase for all platforms.
+
+**Pros:** 100% Rust, direct crate reuse, fast prototyping, hot reload, web target bonus
+**Cons:** Mobile is experimental, not native UI, platform integration gaps, framework risk
+</details>
+
+<details>
+<summary>Option 4: Full Rust UI with Makepad</summary>
+
+[Makepad](https://github.com/makepad/makepad) (v1.0, May 2025) uses GPU shaders for rendering with custom DSL.
+
+**Pros:** GPU-accelerated, single codebase, live design, good for terminal rendering
+**Cons:** Very small community, custom DSL, unproven at scale, no ecosystem
+</details>
+
+<details>
+<summary>Option 5: Tauri Mobile</summary>
+
+Web frontend in Tauri WebView wrapper with Rust backend.
+
+**Pros:** Web skills reusable, Rust backend, plugin ecosystem
+**Cons:** WebView performance (bad for terminal), not native feel, ZRemote has no web frontend
+</details>
+
+<details>
+<summary>Option 6: Kotlin Multiplatform + Rust Core</summary>
+
+KMP shared Kotlin layer with UniFFI Rust core underneath.
+
+**Pros:** KMP is mainstream (Google-backed), shared viewmodels, best Android story
+**Cons:** Three languages (Rust + Kotlin + Swift), extra indirection, build complexity (Gradle + Cargo + Xcode)
+</details>

--- a/docs/rfc/rfc-mobile-app.md
+++ b/docs/rfc/rfc-mobile-app.md
@@ -154,7 +154,15 @@ zremote-client            (SDK: REST + WS client, platform-independent)
 
 ---
 
-## Phase 1: `zremote-ffi` Crate + UniFFI Bindings
+## Phase 1: `zremote-ffi` Crate + UniFFI Bindings [COMPLETED]
+
+> **Implementation notes (vs original RFC):**
+> - `FfiGitInfo`/`FfiGitRemote` omitted -- not needed (GitInfo is nested in ProjectSettings which crosses FFI as JSON string)
+> - `FfiWorktreeInfo`/`FfiDirectoryEntry` fields match actual protocol types (RFC had placeholders)
+> - `on_claude_session_metrics` uses `FfiClaudeSessionMetrics` record instead of 12 parameters
+> - `FfiError::WebSocket` variant instead of `Disconnected` (more specific)
+> - Foreign callback dispatch uses `spawn_blocking` to avoid blocking tokio worker threads
+> - `Arc<Runtime>` shared between client and stream handles for safe lifetime management
 
 ### Architecture Decision: Separate FFI Crate
 
@@ -489,7 +497,14 @@ terminal.disconnect()
 
 ---
 
-## Phase 2: Android Build Pipeline
+## Phase 2: Android Build Pipeline [COMPLETED]
+
+> **Implementation notes:**
+> - `scripts/build-android.sh` supports `--all-abis` and `--generate-only` flags
+> - `[profile.release-android]` inherits from release with `opt-level = "z"`, full LTO, `codegen-units = 1`
+> - CI workflow in `.github/workflows/android-build.yml` triggers on release tags + manual dispatch
+> - arm64-v8a only for MVP (covers 95%+ modern Android devices)
+> - .aar packaging deferred to Phase 3 (when Gradle project exists)
 
 ### Toolchain Setup
 

--- a/scripts/build-android-apk.sh
+++ b/scripts/build-android-apk.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build ZRemote Android APK from scratch on NixOS.
+#
+# This script handles the full pipeline:
+#   1. Cross-compile Rust FFI library for arm64 (via cargo-ndk)
+#   2. Generate Kotlin bindings from host debug build (uniffi-bindgen)
+#   3. Fix known UniFFI Kotlin codegen issues (Exception.message conflict)
+#   4. Build debug APK (via Gradle)
+#   5. Optionally install on connected device (via adb)
+#
+# All tools come from `nix develop` -- no manual SDK/NDK installation needed.
+#
+# Prerequisites:
+#   - NixOS with programs.nix-ld enabled (for Android SDK pre-built binaries)
+#   - nix develop shell (provides: cargo-ndk, gradle, Android SDK/NDK, Rust aarch64 target)
+#   - For install: USB-connected Android device with USB debugging enabled
+#
+# Usage:
+#   nix develop --command bash scripts/build-android-apk.sh          # build only
+#   nix develop --command bash scripts/build-android-apk.sh --install  # build + install
+#   nix develop --command bash scripts/build-android-apk.sh --clean    # clean + build
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANDROID_DIR="${ROOT_DIR}/android"
+JNILIBS_DIR="${ANDROID_DIR}/app/src/main/jniLibs"
+BINDINGS_DIR="${ANDROID_DIR}/app/src/main/java"
+SDK_DIR="${BINDINGS_DIR}/com/zremote/sdk"
+PROFILE="release-android"
+
+DO_INSTALL=false
+DO_CLEAN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --install) DO_INSTALL=true ;;
+        --clean) DO_CLEAN=true ;;
+        --help|-h)
+            echo "Usage: nix develop --command bash $0 [--install] [--clean]"
+            echo ""
+            echo "Options:"
+            echo "  --install    Install APK on connected device after build"
+            echo "  --clean      Clean build directory before building"
+            exit 0
+            ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if [ -z "${ANDROID_HOME:-}" ]; then
+    echo "Error: ANDROID_HOME not set. Run inside: nix develop --command bash $0"
+    exit 1
+fi
+
+if ! command -v cargo-ndk &> /dev/null; then
+    echo "Error: cargo-ndk not found. Run inside: nix develop --command bash $0"
+    exit 1
+fi
+
+if ! command -v gradle &> /dev/null; then
+    echo "Error: gradle not found. Run inside: nix develop --command bash $0"
+    exit 1
+fi
+
+# Check nix-ld is active (not stub-ld) -- required for aapt2 and other SDK binaries
+if readlink /lib64/ld-linux-x86-64.so.2 2>/dev/null | grep -q "stub-ld"; then
+    echo "Error: nix-ld is not configured. Android SDK binaries won't run."
+    echo ""
+    echo "Add to your NixOS config:"
+    echo "  programs.nix-ld.enable = true;"
+    echo "  programs.nix-ld.libraries = with pkgs; [ zlib stdenv.cc.cc.lib ];"
+    echo ""
+    echo "Then: sudo nixos-rebuild switch"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: Cross-compile native library
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Step 1: Building native library (arm64-v8a) ==="
+mkdir -p "$JNILIBS_DIR"
+cargo ndk -t arm64-v8a \
+    -o "$JNILIBS_DIR" \
+    build --profile "$PROFILE" -p zremote-ffi
+
+SO_FILE=$(find "$JNILIBS_DIR" -name "libzremote_ffi.so" -print -quit)
+echo "Built: $SO_FILE ($(du -h "$SO_FILE" | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Step 2: Generate Kotlin bindings
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Step 2: Generating Kotlin bindings ==="
+
+# UniFFI --library mode needs to read metadata from the .so.
+# Cross-compiled .so can't be dlopen'd on the host, so we build a host debug
+# library and generate bindings from that instead.
+cargo build -p zremote-ffi 2>&1 | tail -3
+
+HOST_LIB="${ROOT_DIR}/target/debug/libzremote_ffi.so"
+if [ ! -f "$HOST_LIB" ]; then
+    echo "Error: Host debug library not found at $HOST_LIB"
+    exit 1
+fi
+
+mkdir -p "$SDK_DIR"
+cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+    --library "$HOST_LIB" \
+    --language kotlin \
+    --no-format \
+    --out-dir "$BINDINGS_DIR" 2>&1
+
+if [ ! -f "${SDK_DIR}/zremote_ffi.kt" ]; then
+    echo "Error: Kotlin bindings were not generated"
+    exit 1
+fi
+
+echo "Generated: ${SDK_DIR}/zremote_ffi.kt ($(wc -l < "${SDK_DIR}/zremote_ffi.kt") lines)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Fix UniFFI codegen issues
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Step 3: Patching UniFFI codegen issues ==="
+
+# Issue: UniFFI 0.29 generates `val message: String` in Exception subclass
+# constructors, which conflicts with `Throwable.message`. The generated code
+# also adds a redundant `override val message` getter. Fix: make the
+# constructor parameter `override val` and remove the duplicate getter.
+python3 - "${SDK_DIR}/zremote_ffi.kt" << 'PYEOF'
+import sys
+
+path = sys.argv[1]
+with open(path, 'r') as f:
+    lines = f.readlines()
+
+result = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    # Match: val `message`: kotlin.String inside FfiException subclass
+    if 'val `message`: kotlin.String' in line:
+        context = ''.join(lines[max(0, i-5):min(len(lines), i+10)])
+        if 'FfiException()' in context:
+            line = line.replace('val `message`', 'override val `message`')
+            result.append(line)
+            i += 1
+            # Skip the duplicate override getter that follows
+            while i < len(lines):
+                cur = lines[i].strip()
+                if cur == 'override val message':
+                    # skip this line and the get() = ... line
+                    i += 1
+                    if i < len(lines) and 'get()' in lines[i]:
+                        i += 1
+                    break
+                else:
+                    result.append(lines[i])
+                    i += 1
+            continue
+    result.append(line)
+    i += 1
+
+with open(path, 'w') as f:
+    f.writelines(result)
+
+print("Patched FfiException.message conflicts")
+PYEOF
+
+# Add OVERLOAD_RESOLUTION_AMBIGUITY suppress (safety net for edge cases)
+if ! grep -q "OVERLOAD_RESOLUTION_AMBIGUITY" "${SDK_DIR}/zremote_ffi.kt"; then
+    sed -i 's/@file:Suppress("NAME_SHADOWING")/@file:Suppress("NAME_SHADOWING", "OVERLOAD_RESOLUTION_AMBIGUITY")/' \
+        "${SDK_DIR}/zremote_ffi.kt"
+    echo "Added OVERLOAD_RESOLUTION_AMBIGUITY suppress"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Build APK
+# ---------------------------------------------------------------------------
+
+if [ "$DO_CLEAN" = true ]; then
+    echo ""
+    echo "=== Cleaning build directory ==="
+    rm -rf "${ANDROID_DIR}/app/build"
+fi
+
+echo ""
+echo "=== Step 4: Building debug APK ==="
+cd "$ANDROID_DIR"
+gradle assembleDebug --no-daemon --console=plain 2>&1
+
+APK="${ANDROID_DIR}/app/build/outputs/apk/debug/app-debug.apk"
+if [ ! -f "$APK" ]; then
+    echo "Error: APK not found at $APK"
+    exit 1
+fi
+
+echo ""
+echo "APK built: $APK ($(du -h "$APK" | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Step 5: Install (optional)
+# ---------------------------------------------------------------------------
+
+if [ "$DO_INSTALL" = true ]; then
+    echo ""
+    echo "=== Step 5: Installing on device ==="
+    if ! adb devices 2>/dev/null | grep -q "device$"; then
+        echo "Error: No Android device connected. Connect via USB and enable USB debugging."
+        exit 1
+    fi
+    adb install -r "$APK"
+    echo ""
+    echo "Installed. Launch ZRemote from the app drawer."
+fi
+
+echo ""
+echo "=== Done ==="

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build zremote-ffi native library for Android and generate Kotlin bindings.
+#
+# Prerequisites:
+#   - cargo-ndk: cargo install cargo-ndk
+#   - Android NDK: set ANDROID_NDK_HOME
+#   - Rust targets: rustup target add aarch64-linux-android
+#
+# Usage:
+#   ./scripts/build-android.sh                    # arm64-v8a only (default)
+#   ./scripts/build-android.sh --all-abis         # all 4 ABIs
+#   ./scripts/build-android.sh --generate-only    # Kotlin bindings only (skip native build)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${ROOT_DIR}/android/app/src/main/jniLibs"
+BINDINGS_DIR="${ROOT_DIR}/android/app/src/main/java"
+PROFILE="release-android"
+
+ALL_ABIS=false
+GENERATE_ONLY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --all-abis) ALL_ABIS=true ;;
+        --generate-only) GENERATE_ONLY=true ;;
+        --help|-h)
+            echo "Usage: $0 [--all-abis] [--generate-only]"
+            echo ""
+            echo "Options:"
+            echo "  --all-abis         Build for all Android ABIs (arm64-v8a, armeabi-v7a, x86_64, x86)"
+            echo "  --generate-only    Only generate Kotlin bindings, skip native build"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$GENERATE_ONLY" = false ]; then
+    # Validate environment
+    if [ -z "${ANDROID_NDK_HOME:-}" ]; then
+        echo "Error: ANDROID_NDK_HOME is not set."
+        echo "Install Android NDK and set: export ANDROID_NDK_HOME=/path/to/ndk"
+        exit 1
+    fi
+
+    if ! command -v cargo-ndk &> /dev/null; then
+        echo "Error: cargo-ndk not found."
+        echo "Install with: cargo install cargo-ndk"
+        exit 1
+    fi
+
+    # Determine targets
+    if [ "$ALL_ABIS" = true ]; then
+        TARGETS="-t arm64-v8a -t armeabi-v7a -t x86_64 -t x86"
+        echo "Building for all ABIs: arm64-v8a, armeabi-v7a, x86_64, x86"
+    else
+        TARGETS="-t arm64-v8a"
+        echo "Building for arm64-v8a only (use --all-abis for all targets)"
+    fi
+
+    # Build native libraries
+    echo ""
+    echo "=== Building native libraries ==="
+    mkdir -p "$OUTPUT_DIR"
+    # shellcheck disable=SC2086
+    cargo ndk $TARGETS \
+        -o "$OUTPUT_DIR" \
+        build --profile "$PROFILE" -p zremote-ffi
+
+    echo ""
+    echo "Native libraries built:"
+    find "$OUTPUT_DIR" -name "*.so" -exec ls -lh {} \;
+fi
+
+# Generate Kotlin bindings
+echo ""
+echo "=== Generating Kotlin bindings ==="
+mkdir -p "$BINDINGS_DIR"
+
+# Find the built library for binding generation (any ABI works, prefer host arch)
+LIB_PATH=""
+for candidate in \
+    "target/aarch64-linux-android/${PROFILE}/libzremote_ffi.so" \
+    "target/x86_64-linux-android/${PROFILE}/libzremote_ffi.so" \
+    "target/${PROFILE}/libzremote_ffi.so"; do
+    if [ -f "${ROOT_DIR}/${candidate}" ]; then
+        LIB_PATH="${ROOT_DIR}/${candidate}"
+        break
+    fi
+done
+
+if [ -z "$LIB_PATH" ]; then
+    echo "Error: Could not find built libzremote_ffi.so"
+    echo "Run without --generate-only first to build the native library."
+    exit 1
+fi
+
+cargo run -p zremote-ffi --bin uniffi-bindgen generate \
+    --library "$LIB_PATH" \
+    --language kotlin \
+    --out-dir "$BINDINGS_DIR"
+
+echo ""
+echo "Kotlin bindings generated:"
+find "$BINDINGS_DIR" -name "*.kt" -exec ls -lh {} \;
+
+echo ""
+echo "=== Done ==="
+echo "JNI libraries: $OUTPUT_DIR"
+echo "Kotlin source: $BINDINGS_DIR"

--- a/scripts/patch-uniffi-bindings.py
+++ b/scripts/patch-uniffi-bindings.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Patch UniFFI-generated Kotlin bindings for Android compatibility.
+
+Fixes:
+1. FfiException subclasses: `val message` conflicts with Throwable.message
+   - Makes constructor param `override val message`
+   - Removes duplicate getter
+2. Adds OVERLOAD_RESOLUTION_AMBIGUITY suppress
+"""
+import sys
+
+path = sys.argv[1]
+with open(path, "r") as f:
+    lines = f.readlines()
+
+result = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    # Match: val `message`: kotlin.String inside FfiException subclass
+    if "val `message`: kotlin.String" in line:
+        context = "".join(lines[max(0, i - 5) : min(len(lines), i + 10)])
+        if "FfiException()" in context:
+            line = line.replace("val `message`", "override val `message`")
+            result.append(line)
+            i += 1
+            # Skip the duplicate override getter
+            while i < len(lines):
+                cur = lines[i].strip()
+                if cur == "override val message":
+                    i += 1  # skip "override val message"
+                    if i < len(lines) and "get()" in lines[i]:
+                        i += 1  # skip "get() = ..."
+                    break
+                else:
+                    result.append(lines[i])
+                    i += 1
+            continue
+    result.append(line)
+    i += 1
+
+# Add suppress annotation
+output = "".join(result)
+output = output.replace(
+    '@file:Suppress("NAME_SHADOWING")',
+    '@file:Suppress("NAME_SHADOWING", "OVERLOAD_RESOLUTION_AMBIGUITY")',
+)
+
+with open(path, "w") as f:
+    f.write(output)
+
+print(f"Patched {path}")


### PR DESCRIPTION
## Summary

Complete mobile app foundation for ZRemote -- from Rust FFI bindings to a working Android Jetpack Compose app.

### Phase 1: `zremote-ffi` crate (Rust)
- UniFFI bindings wrapping `zremote-client` SDK for Kotlin/Swift
- 18 FFI record types, 5 enum types, 9 request types with `From` conversions
- `ZRemoteClient` object exposing all 60+ async API methods
- `EventListener` callback interface (22 server event types)
- `TerminalListener` callback interface (11 terminal event types)
- `spawn_blocking` for all foreign callback dispatch (no tokio blocking)
- `Arc<Runtime>` shared between client and stream handles
- 11 unit tests, clippy clean

### Phase 2: Android build pipeline
- `scripts/build-android.sh` -- cross-compile via cargo-ndk + generate Kotlin bindings
- `.github/workflows/android-build.yml` -- CI on release tags
- `[profile.release-android]` -- size-optimized (opt-level=z, full LTO, codegen-units=1)

### Phase 3: Android MVP (Jetpack Compose)
- 6 screens: Hosts, Sessions, Loops, Loop Detail, Tasks, Settings
- Hilt DI, DataStore persistence, Material 3 dark theme
- Bottom navigation with type-safe routes
- `ConnectionManager` with thread-safe client lifecycle
- `ZRemoteEventRepository` for real-time event stream

### Phase 4: Terminal viewer + push notifications
- ANSI terminal viewer (SGR color parsing, 8/256 color, bold)
- Quick-command bar (Ctrl+C, Tab, Esc, arrows + text input)
- 7 notification channels (loops, tasks, permissions, hosts)
- Foreground service keeping WebSocket alive in background

### Documentation
- `android/README.md` -- build, sideload install, usage guide
- `docs/rfc/rfc-mobile-app.md` -- updated with Phase 0-4 COMPLETED
- `docs/rfc/rfc-mobile-app-improvements.md` -- 15 post-MVP improvements (P0-P2)

## Test plan

- [x] `cargo test -p zremote-ffi` -- 11 tests pass
- [x] `cargo clippy -p zremote-ffi` -- clean
- [x] `cargo test --workspace` -- 1401 tests pass (pre-commit hook)
- [ ] Android build: `./scripts/build-android.sh` + `cd android && ./gradlew assembleDebug`
- [ ] Install on device, connect to running ZRemote server
- [ ] Verify host list, session list, loop monitoring, terminal viewer