### PR TITLE
Fix no-op GUI event handlers: toast, reconnect, worktree errors, task tracking

### DIFF
--- a/crates/zremote-gui/assets/icons/alert-triangle.svg
+++ b/crates/zremote-gui/assets/icons/alert-triangle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>

--- a/crates/zremote-gui/assets/icons/check-circle.svg
+++ b/crates/zremote-gui/assets/icons/check-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>

--- a/crates/zremote-gui/assets/icons/info.svg
+++ b/crates/zremote-gui/assets/icons/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>

--- a/crates/zremote-gui/assets/icons/x-circle.svg
+++ b/crates/zremote-gui/assets/icons/x-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>

--- a/crates/zremote-gui/src/icons.rs
+++ b/crates/zremote-gui/src/icons.rs
@@ -24,6 +24,10 @@ pub enum Icon {
     MessageCircle,
     CircleHelp,
     Bot,
+    AlertTriangle,
+    CheckCircle,
+    XCircle,
+    Info,
 }
 
 impl Icon {
@@ -51,6 +55,10 @@ impl Icon {
             Self::MessageCircle => "icons/message-circle.svg",
             Self::CircleHelp => "icons/circle-help.svg",
             Self::Bot => "icons/bot.svg",
+            Self::AlertTriangle => "icons/alert-triangle.svg",
+            Self::CheckCircle => "icons/check-circle.svg",
+            Self::XCircle => "icons/x-circle.svg",
+            Self::Info => "icons/info.svg",
         }
     }
 }

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -20,6 +20,7 @@ use crate::views::help_modal::{HelpModal, HelpModalEvent};
 use crate::views::session_switcher::{SessionSwitcher, SessionSwitcherEvent};
 use crate::views::sidebar::SidebarView;
 use crate::views::terminal_panel::{TerminalPanel, TerminalPanelEvent};
+use crate::views::toast::{ToastContainer, ToastLevel};
 
 /// Root view: sidebar (fixed 250px) | content area (terminal or empty state).
 pub struct MainView {
@@ -31,6 +32,7 @@ pub struct MainView {
     session_switcher: Option<Entity<SessionSwitcher>>,
     help_modal: Option<Entity<HelpModal>>,
     double_shift: DoubleShiftDetector,
+    toasts: Entity<ToastContainer>,
     /// Whether the event WebSocket is currently connected.
     server_connected: bool,
     /// Whether the event WebSocket has ever successfully connected.
@@ -53,6 +55,11 @@ impl MainView {
         // Start periodic loop reconciliation (fallback for missed WS events)
         Self::start_loop_reconciliation(&sidebar, cx);
 
+        let toasts = cx.new(|_| ToastContainer::new());
+
+        // Start toast tick timer (removes expired toasts every second)
+        Self::start_toast_tick(&toasts, cx);
+
         let focus_handle = cx.focus_handle();
 
         Self {
@@ -64,6 +71,7 @@ impl MainView {
             session_switcher: None,
             help_modal: None,
             double_shift: DoubleShiftDetector::new(),
+            toasts,
             server_connected: true, // Assume connected until first Disconnected event
             ever_connected: false,
             current_host_id: None,
@@ -183,6 +191,37 @@ impl MainView {
         .detach();
     }
 
+    fn start_toast_tick(toasts: &Entity<ToastContainer>, cx: &mut Context<Self>) {
+        let toasts = toasts.clone();
+        cx.spawn(async move |_this: WeakEntity<Self>, cx: &mut AsyncApp| {
+            loop {
+                Timer::after(std::time::Duration::from_secs(1)).await;
+                let result = toasts.update(cx, |container, cx| {
+                    if container.tick() {
+                        cx.notify();
+                    }
+                });
+                if result.is_err() {
+                    break; // Entity dropped
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn show_toast(
+        &self,
+        message: &str,
+        level: ToastLevel,
+        toast_icon: Option<Icon>,
+        cx: &mut Context<Self>,
+    ) {
+        self.toasts.update(cx, |container, cx| {
+            container.push(message, level, toast_icon);
+            cx.notify();
+        });
+    }
+
     fn handle_server_event(&mut self, event: &ServerEvent, cx: &mut Context<Self>) {
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.handle_server_event(event, cx);
@@ -205,6 +244,46 @@ impl MainView {
                     });
                 }
             }
+        }
+
+        // WorktreeError: show error toast
+        if let ServerEvent::WorktreeError {
+            project_path,
+            message,
+            ..
+        } = event
+        {
+            let msg = format!("Worktree error ({project_path}): {message}");
+            self.show_toast(&msg, ToastLevel::Error, Some(Icon::AlertTriangle), cx);
+        }
+
+        // Claude task lifecycle: show toasts
+        match event {
+            ServerEvent::ClaudeTaskStarted { project_path, .. } => {
+                let name = project_path.rsplit('/').next().unwrap_or(project_path);
+                self.show_toast(
+                    &format!("Claude task started: {name}"),
+                    ToastLevel::Info,
+                    Some(Icon::Bot),
+                    cx,
+                );
+            }
+            ServerEvent::ClaudeTaskEnded {
+                status, summary, ..
+            } => {
+                let (level, prefix) = match status {
+                    zremote_client::ClaudeTaskStatus::Completed => {
+                        (ToastLevel::Success, "Task completed")
+                    }
+                    zremote_client::ClaudeTaskStatus::Error => (ToastLevel::Error, "Task failed"),
+                    _ => (ToastLevel::Info, "Task ended"),
+                };
+                let msg = summary
+                    .as_deref()
+                    .map_or_else(|| prefix.to_string(), |s| format!("{prefix}: {s}"));
+                self.show_toast(&msg, level, Some(Icon::Bot), cx);
+            }
+            _ => {}
         }
 
         // Forward CC metrics to terminal panel
@@ -405,7 +484,35 @@ impl MainView {
                     }
                 });
             }
-            CommandPaletteEvent::Reconnect | CommandPaletteEvent::Close => {}
+            CommandPaletteEvent::Reconnect => {
+                if let Some(terminal) = &self.terminal {
+                    let session_id = terminal.read(cx).session_id().to_string();
+                    let host_id = self.current_host_id.clone().unwrap_or_default();
+                    if let Some(handle) =
+                        connect_terminal(&self.app_state, &session_id, &host_id, false)
+                    {
+                        terminal.update(cx, |panel, cx| {
+                            panel.reconnect(handle, &self.app_state.tokio_handle, cx);
+                        });
+                        self.show_toast("Reconnected", ToastLevel::Success, Some(Icon::Wifi), cx);
+                    } else {
+                        self.show_toast(
+                            "Reconnect failed",
+                            ToastLevel::Error,
+                            Some(Icon::WifiOff),
+                            cx,
+                        );
+                    }
+                } else {
+                    self.show_toast(
+                        "No active terminal to reconnect",
+                        ToastLevel::Info,
+                        None,
+                        cx,
+                    );
+                }
+            }
+            CommandPaletteEvent::Close => {}
         }
         self.close_command_palette(cx);
     }
@@ -775,6 +882,9 @@ impl Render for MainView {
                     ),
             );
         }
+
+        // Toast overlay (bottom-right, always on top)
+        root = root.child(self.toasts.clone());
 
         root
     }

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -392,9 +392,20 @@ impl MainView {
                 self.open_session_switcher(cx);
                 return;
             }
-            CommandPaletteEvent::ToggleProjectPin { .. }
-            | CommandPaletteEvent::Reconnect
-            | CommandPaletteEvent::Close => {}
+            CommandPaletteEvent::ToggleProjectPin { project_id, pinned } => {
+                let api = self.app_state.api.clone();
+                let project_id = project_id.clone();
+                let pinned = *pinned;
+                self.app_state.tokio_handle.spawn(async move {
+                    let req = zremote_client::UpdateProjectRequest {
+                        pinned: Some(pinned),
+                    };
+                    if let Err(e) = api.update_project(&project_id, &req).await {
+                        tracing::error!("Failed to toggle project pin: {e}");
+                    }
+                });
+            }
+            CommandPaletteEvent::Reconnect | CommandPaletteEvent::Close => {}
         }
         self.close_command_palette(cx);
     }

--- a/crates/zremote-gui/src/views/mod.rs
+++ b/crates/zremote-gui/src/views/mod.rs
@@ -9,4 +9,5 @@ pub mod session_switcher;
 pub mod sidebar;
 pub mod terminal_element;
 pub mod terminal_panel;
+pub mod toast;
 pub mod url_detector;

--- a/crates/zremote-gui/src/views/sidebar.rs
+++ b/crates/zremote-gui/src/views/sidebar.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 
 use crate::views::main_view::SidebarEvent;
 use zremote_client::{
-    AgenticStatus, CreateSessionRequest, Host, HostStatus, ListLoopsFilter, Project, ServerEvent,
-    Session, SessionStatus,
+    AgenticStatus, ClaudeTaskStatus, CreateSessionRequest, Host, HostStatus, ListClaudeTasksFilter,
+    ListLoopsFilter, Project, ServerEvent, Session, SessionStatus,
 };
 
 /// Tracks the Claude Code agentic loop state for a session.
@@ -37,6 +37,18 @@ pub struct CcMetrics {
     pub lines_removed: Option<i64>,
     pub rate_limit_5h_pct: Option<u64>,
     pub rate_limit_7d_pct: Option<u64>,
+}
+
+/// Tracks a Claude task lifecycle in the sidebar.
+struct ClaudeTaskInfo {
+    task_id: String,
+    session_id: String,
+    host_id: String,
+    project_path: String,
+    status: ClaudeTaskStatus,
+    summary: Option<String>,
+    started_at: std::time::Instant,
+    ended_at: Option<std::time::Instant>,
 }
 
 /// A project with its associated sessions.
@@ -66,6 +78,8 @@ pub struct SidebarView {
     cc_metrics: HashMap<String, CcMetrics>,
     /// Terminal titles set by OSC escape sequences, per session_id.
     terminal_titles: HashMap<String, String>,
+    /// Claude task lifecycle state, keyed by task_id.
+    claude_tasks: HashMap<String, ClaudeTaskInfo>,
 }
 
 impl SidebarView {
@@ -124,6 +138,7 @@ impl SidebarView {
             cc_states: HashMap::new(),
             cc_metrics: HashMap::new(),
             terminal_titles: HashMap::new(),
+            claude_tasks: HashMap::new(),
         };
         view.load_data(cx);
         view
@@ -147,7 +162,7 @@ impl SidebarView {
                 return;
             }
 
-            let (hosts, all_sessions, all_projects) = handle
+            let (hosts, all_sessions, all_projects, active_tasks) = handle
                 .spawn(async move {
                     let hosts = api.list_hosts().await.unwrap_or_default();
                     let mut all_sessions = Vec::new();
@@ -158,7 +173,22 @@ impl SidebarView {
                         all_sessions.extend(sessions.unwrap_or_default());
                         all_projects.extend(projects.unwrap_or_default());
                     }
-                    (hosts, all_sessions, all_projects)
+                    // Fetch active + starting Claude tasks
+                    let active_filter = ListClaudeTasksFilter {
+                        status: Some("active".to_string()),
+                        ..ListClaudeTasksFilter::default()
+                    };
+                    let starting_filter = ListClaudeTasksFilter {
+                        status: Some("starting".to_string()),
+                        ..ListClaudeTasksFilter::default()
+                    };
+                    let (active, starting) = tokio::join!(
+                        api.list_claude_tasks(&active_filter),
+                        api.list_claude_tasks(&starting_filter),
+                    );
+                    let mut tasks = active.unwrap_or_default();
+                    tasks.extend(starting.unwrap_or_default());
+                    (hosts, all_sessions, all_projects, tasks)
                 })
                 .await
                 .unwrap_or_default();
@@ -173,6 +203,22 @@ impl SidebarView {
                 this.sessions = Rc::new(all_sessions);
                 this.projects = Rc::new(all_projects);
                 this.loading = false;
+
+                // Seed Claude tasks from API (only add tasks we don't already track)
+                for task in active_tasks {
+                    this.claude_tasks
+                        .entry(task.id.clone())
+                        .or_insert_with(|| ClaudeTaskInfo {
+                            task_id: task.id.clone(),
+                            session_id: task.session_id.clone(),
+                            host_id: task.host_id.clone(),
+                            project_path: task.project_path.clone(),
+                            status: task.status,
+                            summary: task.summary.clone(),
+                            started_at: std::time::Instant::now(),
+                            ended_at: None,
+                        });
+                }
 
                 // If a session was restored/selected, keep it unless it's truly gone.
                 if let Some(ref restored_id) = this.selected_session_id {
@@ -318,6 +364,51 @@ impl SidebarView {
                 );
                 cx.notify();
             }
+            ServerEvent::WorktreeError { .. } => {
+                // Handled by MainView toast -- sidebar reloads to clear stale state
+                self.load_data(cx);
+            }
+            ServerEvent::ClaudeTaskStarted {
+                task_id,
+                session_id,
+                host_id,
+                project_path,
+            } => {
+                self.claude_tasks.insert(
+                    task_id.clone(),
+                    ClaudeTaskInfo {
+                        task_id: task_id.clone(),
+                        session_id: session_id.clone(),
+                        host_id: host_id.clone(),
+                        project_path: project_path.clone(),
+                        status: ClaudeTaskStatus::Starting,
+                        summary: None,
+                        started_at: std::time::Instant::now(),
+                        ended_at: None,
+                    },
+                );
+                cx.notify();
+            }
+            ServerEvent::ClaudeTaskUpdated {
+                task_id, status, ..
+            } => {
+                if let Some(task) = self.claude_tasks.get_mut(task_id) {
+                    task.status = *status;
+                    cx.notify();
+                }
+            }
+            ServerEvent::ClaudeTaskEnded {
+                task_id,
+                status,
+                summary,
+            } => {
+                if let Some(task) = self.claude_tasks.get_mut(task_id) {
+                    task.status = *status;
+                    task.summary.clone_from(summary);
+                    task.ended_at = Some(std::time::Instant::now());
+                    cx.notify();
+                }
+            }
             _ => {}
         }
     }
@@ -402,6 +493,16 @@ impl SidebarView {
                         changed = true;
                     }
                 }
+                // Remove ended Claude tasks older than 30s
+                let tasks_before = this.claude_tasks.len();
+                this.claude_tasks.retain(|_, t| {
+                    t.ended_at
+                        .is_none_or(|ended| ended.elapsed() < Duration::from_secs(30))
+                });
+                if this.claude_tasks.len() != tasks_before {
+                    changed = true;
+                }
+
                 if changed {
                     cx.notify();
                 }
@@ -656,6 +757,34 @@ impl SidebarView {
             );
         }
 
+        // Claude tasks for this host
+        let tasks = self.active_tasks_for_host(&host_id);
+        if !tasks.is_empty() {
+            // Separator before tasks (if we have sessions above)
+            if has_projects || has_orphans {
+                children.push(
+                    div()
+                        .mx(px(12.0))
+                        .my(px(4.0))
+                        .h(px(1.0))
+                        .bg(theme::border())
+                        .into_any_element(),
+                );
+            }
+            children.push(
+                div()
+                    .px(px(16.0))
+                    .py(px(2.0))
+                    .text_color(theme::text_tertiary())
+                    .text_size(px(11.0))
+                    .child("Tasks")
+                    .into_any_element(),
+            );
+            for task in &tasks {
+                children.push(self.render_task_item(task, cx).into_any_element());
+            }
+        }
+
         let mut container = div().flex().flex_col().w_full();
 
         // Host header only in server mode
@@ -667,6 +796,97 @@ impl SidebarView {
         container = container.child(div().flex().flex_col().children(children));
 
         container
+    }
+
+    fn active_tasks_for_host(&self, host_id: &str) -> Vec<&ClaudeTaskInfo> {
+        let mut tasks: Vec<&ClaudeTaskInfo> = self
+            .claude_tasks
+            .values()
+            .filter(|t| t.host_id == host_id)
+            .collect();
+        tasks.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        tasks
+    }
+
+    fn render_task_item(&self, task: &ClaudeTaskInfo, cx: &mut Context<Self>) -> impl IntoElement {
+        let (status_icon, status_color) = match task.status {
+            ClaudeTaskStatus::Starting => (Icon::Loader, theme::text_tertiary()),
+            ClaudeTaskStatus::Active => (Icon::Bot, theme::accent()),
+            ClaudeTaskStatus::Completed => (Icon::CheckCircle, theme::success()),
+            ClaudeTaskStatus::Error => (Icon::XCircle, theme::error()),
+        };
+
+        let project_name = task
+            .project_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&task.project_path)
+            .to_string();
+
+        let elapsed = task.started_at.elapsed();
+        let elapsed_text = if elapsed.as_secs() >= 3600 {
+            format!(
+                "{}h{}m",
+                elapsed.as_secs() / 3600,
+                (elapsed.as_secs() % 3600) / 60
+            )
+        } else if elapsed.as_secs() >= 60 {
+            format!("{}m", elapsed.as_secs() / 60)
+        } else {
+            format!("{}s", elapsed.as_secs())
+        };
+
+        let session_id = task.session_id.clone();
+        let host_id = task.host_id.clone();
+        let task_id = task.task_id.clone();
+
+        div()
+            .id(SharedString::from(format!("task-{task_id}")))
+            .flex()
+            .items_center()
+            .justify_between()
+            .pl(px(20.0))
+            .pr(px(12.0))
+            .h(px(22.0))
+            .mx(px(4.0))
+            .rounded(px(4.0))
+            .cursor_pointer()
+            .hover(|s| s.bg(theme::bg_tertiary()))
+            .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                this.selected_session_id = Some(session_id.clone());
+                cx.emit(SidebarEvent::SessionSelected {
+                    session_id: session_id.clone(),
+                    host_id: host_id.clone(),
+                });
+                cx.notify();
+            }))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .min_w(px(0.0))
+                    .overflow_hidden()
+                    .child(
+                        icon(status_icon)
+                            .size(px(12.0))
+                            .flex_shrink_0()
+                            .text_color(status_color),
+                    )
+                    .child(
+                        div()
+                            .text_color(theme::text_secondary())
+                            .text_size(px(11.0))
+                            .truncate()
+                            .child(project_name),
+                    ),
+            )
+            .child(
+                div()
+                    .text_color(theme::text_tertiary())
+                    .text_size(px(10.0))
+                    .child(elapsed_text),
+            )
     }
 
     #[allow(clippy::unused_self)]

--- a/crates/zremote-gui/src/views/toast.rs
+++ b/crates/zremote-gui/src/views/toast.rs
@@ -1,0 +1,144 @@
+use std::time::{Duration, Instant};
+
+use gpui::*;
+
+use crate::icons::{Icon, icon};
+use crate::theme;
+
+/// Severity level for a toast notification.
+#[derive(Debug, Clone, Copy)]
+pub enum ToastLevel {
+    Info,
+    Success,
+    Warning,
+    Error,
+}
+
+/// A single toast notification.
+pub struct Toast {
+    pub id: u64,
+    pub message: String,
+    pub level: ToastLevel,
+    pub icon: Option<Icon>,
+    pub created_at: Instant,
+}
+
+impl Toast {
+    /// How long this toast should remain visible before auto-dismissing.
+    pub fn ttl(&self) -> Duration {
+        match self.level {
+            ToastLevel::Error | ToastLevel::Warning => Duration::from_secs(8),
+            ToastLevel::Info | ToastLevel::Success => Duration::from_secs(4),
+        }
+    }
+
+    fn border_color(&self) -> Rgba {
+        match self.level {
+            ToastLevel::Info => theme::accent(),
+            ToastLevel::Success => theme::success(),
+            ToastLevel::Warning => theme::warning(),
+            ToastLevel::Error => theme::error(),
+        }
+    }
+
+    fn default_icon(&self) -> Icon {
+        match self.level {
+            ToastLevel::Info => Icon::Info,
+            ToastLevel::Success => Icon::CheckCircle,
+            ToastLevel::Warning => Icon::AlertTriangle,
+            ToastLevel::Error => Icon::XCircle,
+        }
+    }
+}
+
+const MAX_VISIBLE: usize = 5;
+
+/// Container entity that manages a stack of toast notifications.
+pub struct ToastContainer {
+    toasts: Vec<Toast>,
+    next_id: u64,
+}
+
+impl ToastContainer {
+    pub fn new() -> Self {
+        Self {
+            toasts: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Add a new toast notification.
+    pub fn push(
+        &mut self,
+        message: impl Into<String>,
+        level: ToastLevel,
+        toast_icon: Option<Icon>,
+    ) {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.toasts.push(Toast {
+            id,
+            message: message.into(),
+            level,
+            icon: toast_icon,
+            created_at: Instant::now(),
+        });
+        // Keep only the most recent MAX_VISIBLE toasts
+        if self.toasts.len() > MAX_VISIBLE {
+            self.toasts.remove(0);
+        }
+    }
+
+    /// Remove expired toasts. Returns `true` if any were removed.
+    pub fn tick(&mut self) -> bool {
+        let before = self.toasts.len();
+        self.toasts.retain(|t| t.created_at.elapsed() < t.ttl());
+        self.toasts.len() != before
+    }
+}
+
+impl Render for ToastContainer {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let mut container = div()
+            .absolute()
+            .bottom(px(16.0))
+            .right(px(16.0))
+            .flex()
+            .flex_col()
+            .gap(px(6.0))
+            .max_w(px(360.0));
+
+        for toast in &self.toasts {
+            let icon_to_use = toast.icon.unwrap_or_else(|| toast.default_icon());
+            let border = toast.border_color();
+            let icon_color = border;
+
+            container = container.child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .px(px(12.0))
+                    .py(px(8.0))
+                    .rounded(px(6.0))
+                    .bg(theme::bg_tertiary())
+                    .border_l(px(3.0))
+                    .border_color(border)
+                    .child(
+                        icon(icon_to_use)
+                            .size(px(14.0))
+                            .flex_shrink_0()
+                            .text_color(icon_color),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(theme::text_primary())
+                            .child(toast.message.clone()),
+                    ),
+            );
+        }
+
+        container
+    }
+}


### PR DESCRIPTION
## Summary

- **Toast notification system**: New `ToastContainer` entity with auto-dismiss stack (bottom-right overlay, max 5 visible, level-based TTL and colored border)
- **Reconnect handler**: `CommandPaletteEvent::Reconnect` now reconnects the active terminal via `connect_terminal()` with success/error toast feedback
- **WorktreeError handling**: Shows error toast with project path and message; sidebar reloads to clear stale state
- **Claude task lifecycle tracking**: Sidebar tracks `ClaudeTask{Started,Updated,Ended}` events in per-host task section with status icon, project name, and elapsed time. Tasks are clickable (open terminal). Active/starting tasks fetched on initial load; ended tasks auto-cleaned after 30s
- **New icons**: AlertTriangle, CheckCircle, XCircle, Info (Lucide SVGs)

## Test plan

- [x] `cargo clippy --workspace` -- no warnings
- [x] `cargo test --workspace` -- all 1443 tests pass
- [x] Pre-commit hooks pass (fmt, clippy, test)
- [ ] Visual verification: toast rendering, reconnect flow, task section in sidebar