### PR TITLE
Make session switcher preview wider and responsive

### DIFF
--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -1211,7 +1211,7 @@ impl MainView {
 }
 
 impl Render for MainView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Build the content area (terminal or empty state) as a vertical column
         // so we can prepend the connection banner when disconnected.
         let content_area = if let Some(terminal) = &self.terminal {
@@ -1343,6 +1343,18 @@ impl Render for MainView {
 
         // Session switcher overlay (same backdrop+sibling pattern as command palette)
         if let Some(switcher) = &self.session_switcher {
+            // Responsive modal size: the preview pane shows live terminal content, so
+            // narrow windows squeeze 80+ column TUIs and make them look scrambled.
+            // Grow with the window while keeping sane bounds.
+            let viewport = window.viewport_size();
+            let viewport_w = f32::from(viewport.width);
+            let viewport_h = f32::from(viewport.height);
+            let switcher_w = px((viewport_w - 160.0).clamp(760.0, 1200.0));
+            // Use an explicit height (not just max_h) so h_full() on inner flex
+            // children resolves to a definite value, keeping the left list's
+            // overflow_y_scroll() active from the first overflowing item.
+            let switcher_h = px((viewport_h - 200.0).clamp(340.0, 640.0));
+
             root = root.child(
                 div()
                     .absolute()
@@ -1367,8 +1379,8 @@ impl Render for MainView {
                             .child(
                                 div()
                                     .id("switcher-container")
-                                    .w(px(680.0))
-                                    .max_h(px(420.0))
+                                    .w(switcher_w)
+                                    .h(switcher_h)
                                     .rounded(px(8.0))
                                     .border_1()
                                     .border_color(theme::border())

--- a/crates/zremote-gui/src/views/session_switcher.rs
+++ b/crates/zremote-gui/src/views/session_switcher.rs
@@ -296,8 +296,12 @@ impl SessionSwitcher {
             .flex()
             .flex_col()
             .flex_1()
-            .min_w(px(350.0))
-            .max_h(px(400.0))
+            // Floor matches the minimum container width (760) minus the left
+            // list (280), so the preview never overflows the container at the
+            // smallest responsive size. At larger window sizes flex_1 lets the
+            // preview grow to fit 100+ column terminals comfortably.
+            .min_w(px(480.0))
+            .h_full()
             .bg(theme::terminal_bg())
             .p(px(8.0))
             .overflow_hidden()
@@ -351,6 +355,7 @@ impl Render for SessionSwitcher {
             .flex()
             .flex_row()
             .w_full()
+            .h_full()
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
                 let key = event.keystroke.key.as_str();
                 let mods = &event.keystroke.modifiers;
@@ -388,7 +393,7 @@ impl Render for SessionSwitcher {
                     .flex()
                     .flex_col()
                     .w(px(280.0))
-                    .max_h(px(400.0))
+                    .h_full()
                     .overflow_y_scroll()
                     .track_scroll(&self.scroll_handle)
                     .border_r_1()


### PR DESCRIPTION
## Summary

- Session switcher (Ctrl+Tab) preview je širší a responzivní vůči velikosti okna (clamped 760-1200px šířka, 340-640px výška) místo fixních 680x420px
- Preview pane má `min_w(480)` odpovídající minimu kontejneru (760 - 280 list = 480), takže 80-col terminál není ořezán přes `overflow_hidden` a TUI (box-drawing) drží zarovnání
- Vnitřní panely používají `h_full()` proti explicitní výšce kontejneru, takže `overflow_y_scroll` na session listu funguje od první přetečené položky

## Test plan

- [x] `cargo clippy -p zremote-gui --all-targets` - čisté (jen preexistující warning v `toast.rs`)
- [x] `cargo test -p zremote-gui` - 60 passed
- [x] Pre-commit hook (fmt + clippy + workspace test) - vše zelené (2000+ testů)
- [x] `cargo build -p zremote` - plný binary builduje
- [ ] Manuální smoke test: `cargo run -p zremote -- gui --local`, otevřít 2+ terminály s TUI, Ctrl+Tab → preview je širší, TUI rámečky drží zarovnání, quick-switch (krátký tap) funguje beze změn
- [ ] Ověřit na malém okně (~1280x800), že modal nevyleze přes hranu (clamp min 760)
