### PR TITLE
feat(gui): batched async persistence with retry

### DIFF
--- a/crates/zremote-gui/src/lib.rs
+++ b/crates/zremote-gui/src/lib.rs
@@ -128,7 +128,13 @@ pub fn run(config: GuiConfig) {
             let _quit_sub = cx.on_app_quit({
                 move |cx: &mut App| {
                     // Try to read window bounds for persistence.
-                    if let Some(win) = cx.windows().first().copied()
+                    //
+                    // The `FlushWaiter` pattern lets us release the outer
+                    // `AppState::persistence` mutex before we block on the
+                    // background worker, so a concurrent access to the
+                    // persistence handle during quit does not stall for up
+                    // to 2 seconds behind a held guard.
+                    let waiter = if let Some(win) = cx.windows().first().copied()
                         && let Ok(bounds) = win
                             .update(cx, |_root: AnyView, window: &mut Window, _cx: &mut App| {
                                 window.bounds()
@@ -139,9 +145,14 @@ pub fn run(config: GuiConfig) {
                             s.window_width = Some(f32::from(bounds.size.width));
                             s.window_height = Some(f32::from(bounds.size.height));
                         });
-                        if let Err(e) = p.save_if_changed() {
-                            tracing::warn!(error = %e, "failed to save GUI state on quit");
-                        }
+                        Some(p.flush_waiter())
+                    } else {
+                        None
+                    };
+                    if let Some(waiter) = waiter
+                        && waiter.wait(Duration::from_secs(2)).is_err()
+                    {
+                        tracing::warn!("timed out waiting for GUI state flush on quit");
                     }
                     async {}
                 }

--- a/crates/zremote-gui/src/persistence.rs
+++ b/crates/zremote-gui/src/persistence.rs
@@ -1,21 +1,60 @@
-//! Workspace persistence: save/restore GUI state across restarts.
+//! Batched async persistence for GUI state (see `docs/rfc/rfc-004-batched-async-persistence.md`).
 //!
 //! State file: `~/.config/zremote/gui-state.json`
 //!
-//! Safety layers (inspired by Okena pattern):
-//! 1. Fallback guard: parse failure returns Default, never crash
-//! 2. Empty check: don't save fully default state
-//! 3. Rolling backup: rename existing to .bak before write
-//! 4. Atomic write: write .tmp -> fsync -> rename
+//! # Model
+//!
+//! The public [`Persistence`] handle is held by `AppState` and mutated from the
+//! GPUI main thread. Mutations are synchronous and non-blocking: `update` only
+//! touches in-memory fields, clones the current `GuiState`, drops the snapshot
+//! into a shared "pending" slot, and signals a background worker thread. The
+//! worker is the only entity that touches disk. It waits for work, debounces
+//! bursts, then performs a single atomic-with-backup write per burst.
+//!
+//! # Invariants
+//!
+//! - Exactly one background thread performs I/O. `update` is wait-free with
+//!   respect to file I/O.
+//! - `last_saved_version <= pending_version` at all times; `last_saved_version`
+//!   is monotonic.
+//! - Only one mutex (`SharedSaver::mu`) protects the saver state. The worker
+//!   never holds the mutex across a `PersistenceWriter::write` call — all disk
+//!   I/O happens outside the critical section.
+//! - Coalescing: N rapid `update` calls during a debounce window produce at
+//!   most 2 writes (one for whatever is in `pending` when the current write
+//!   started, plus at most one follow-up for everything after).
+//! - Retry on failure: if `PersistenceWriter::write` returns `Err`, the worker
+//!   re-queues the failed snapshot into `pending` (unless a newer update has
+//!   already superseded it) and retries after the next debounce window.
+//!   Callers waiting in `flush_blocking` either see a later retry succeed or
+//!   observe the deadline elapse.
+//! - `Drop::drop` flushes pending writes with a 2 s deadline, then signals
+//!   shutdown and joins the worker before returning.
+//!
+//! # Default-state guard
+//!
+//! Matches the legacy behaviour: if the snapshot about to be written compares
+//! equal to [`GuiState::default`] (via [`GuiState::is_default`]), the worker
+//! skips the disk write **but still advances `last_saved_version`** so that
+//! [`Persistence::flush_blocking`] does not spin waiting for a write that will
+//! never happen.
+//!
+//! # Testability
+//!
+//! The writer is injectable via [`PersistenceWriter`]. Tests install counting,
+//! blocking, or failing writers through [`Persistence::with_writer`] without
+//! touching the real filesystem.
 
+use std::fmt;
 use std::io::Write;
-use std::path::PathBuf;
-
-use std::time::SystemTime;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RecentSession {
     pub session_id: String,
     /// Unix timestamp in seconds.
@@ -25,7 +64,13 @@ pub struct RecentSession {
 /// Current format version.
 const FORMAT_VERSION: u32 = 1;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+/// Default debounce window for the production worker.
+const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// Default deadline used by `Drop` to flush pending writes before shutdown.
+const DROP_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct GuiState {
     #[serde(default)]
     pub version: u32,
@@ -51,41 +96,215 @@ impl GuiState {
     }
 }
 
-pub struct Persistence {
+/// Error returned by [`Persistence::flush_blocking`] / [`FlushWaiter::wait`]
+/// when the deadline elapses before all pending writes reach disk, or when
+/// the worker has already shut down with pending state.
+#[derive(Debug)]
+pub struct FlushTimeout;
+
+impl fmt::Display for FlushTimeout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("timed out waiting for persistence flush")
+    }
+}
+
+impl std::error::Error for FlushTimeout {}
+
+/// Opaque handle that lets the caller release an outer mutex around
+/// `Persistence` before blocking on a flush. Obtained via
+/// [`Persistence::flush_waiter`].
+pub struct FlushWaiter {
+    shared: Arc<SharedSaver>,
+    target: u64,
+}
+
+impl FlushWaiter {
+    /// Block until the target version is on disk or `timeout` elapses.
+    pub fn wait(self, timeout: Duration) -> Result<(), FlushTimeout> {
+        flush_shared_blocking(&self.shared, self.target, timeout)
+    }
+}
+
+/// Blocking wait on the worker's shared state. Used by
+/// [`Persistence::flush_blocking`] and [`FlushWaiter::wait`] so both paths
+/// share the same condvar logic.
+fn flush_shared_blocking(
+    shared: &Arc<SharedSaver>,
+    target: u64,
+    timeout: Duration,
+) -> Result<(), FlushTimeout> {
+    let deadline = Instant::now() + timeout;
+    // Mutex poisoning is treated as a process-fatal event — the worker is
+    // the only critical section and a poisoned lock means we already
+    // crashed somewhere upstream. Matches pre-RFC-004 behaviour.
+    let mut inner = shared.mu.lock().unwrap();
+    loop {
+        if inner.last_saved_version >= target {
+            return Ok(());
+        }
+        if inner.shutdown {
+            // Worker has exited and can no longer advance last_saved_version.
+            // Treat this as a timeout — the caller's pending data will not
+            // reach disk via this handle.
+            return Err(FlushTimeout);
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(FlushTimeout);
+        };
+        // Mutex poisoning: fatal by design.
+        let (new_inner, result) = shared.cv.wait_timeout(inner, remaining).unwrap();
+        inner = new_inner;
+        if result.timed_out() && inner.last_saved_version < target {
+            return Err(FlushTimeout);
+        }
+    }
+}
+
+/// Pluggable writer so tests can observe / inject failures without real I/O.
+pub trait PersistenceWriter: Send + Sync {
+    fn write(&self, path: &Path, state: &GuiState) -> std::io::Result<()>;
+}
+
+/// Production writer: atomic write with rolling `.bak` backup. Produces byte
+/// output identical to the pre-RFC-004 synchronous implementation.
+pub struct FileWriter;
+
+impl PersistenceWriter for FileWriter {
+    fn write(&self, path: &Path, state: &GuiState) -> std::io::Result<()> {
+        atomic_write_with_backup(path, state)
+    }
+}
+
+/// Atomic-write-with-rolling-backup routine — must stay byte-compatible with
+/// the legacy synchronous implementation.
+fn atomic_write_with_backup(path: &Path, state: &GuiState) -> std::io::Result<()> {
+    // Ensure parent directory exists.
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Rolling backup: rename existing to .bak. Tolerate `NotFound` for the
+    // first-write case; any other error is surfaced so the caller can retry.
+    // No `path.exists()` TOCTOU pre-check — `fs::rename` is the authoritative
+    // existence test.
+    let bak = path.with_extension("json.bak");
+    match std::fs::rename(path, &bak) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    // Write to .tmp first, then atomically rename over the real path.
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(state).map_err(std::io::Error::other)?;
+
+    // Write + fsync inside a block so the file handle is closed before rename.
+    let write_result: std::io::Result<()> = (|| {
+        let mut file = std::fs::File::create(&tmp)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        // Clean up the half-written tmp so we do not leak disk on repeated
+        // failures.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // Rename failed after a successful write — the tmp still holds the
+        // serialized state but will never land at the real path. Delete it
+        // so `.tmp` does not accumulate.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    tracing::debug!(path = %path.display(), "saved GUI state");
+    Ok(())
+}
+
+/// Shared state between the caller and the background worker.
+struct SharedSaver {
+    mu: Mutex<SaverInner>,
+    cv: Condvar,
+    debounce: Duration,
+    writer: Box<dyn PersistenceWriter>,
     path: PathBuf,
+}
+
+struct SaverInner {
+    /// Newest snapshot queued for writing. Overwritten on every update —
+    /// only the latest survives, which is the coalescing invariant.
+    pending: Option<GuiState>,
+    pending_version: u64,
+    last_saved_version: u64,
+    shutdown: bool,
+}
+
+/// Caller-side handle. Held inside `AppState` behind a `Mutex`.
+pub struct Persistence {
     state: GuiState,
     data_version: u64,
-    last_saved_version: u64,
+    shared: Arc<SharedSaver>,
+    worker: Option<JoinHandle<()>>,
 }
 
 impl Persistence {
-    /// Load state from disk. Returns default state on any error.
+    /// Load state from disk and spawn the background writer. Returns default
+    /// state on any parse/IO error.
     pub fn load() -> Self {
         let path = state_file_path();
+        let state = load_state_from_disk(&path);
+        Self::new_with_state(path, state, Box::new(FileWriter), DEFAULT_DEBOUNCE)
+    }
 
-        let state = if path.exists() {
-            match std::fs::read_to_string(&path) {
-                Ok(contents) => match serde_json::from_str::<GuiState>(&contents) {
-                    Ok(state) => state,
-                    Err(e) => {
-                        tracing::warn!(error = %e, path = %path.display(), "failed to parse GUI state, using defaults");
-                        GuiState::default()
-                    }
-                },
-                Err(e) => {
-                    tracing::warn!(error = %e, path = %path.display(), "failed to read GUI state file");
-                    GuiState::default()
-                }
-            }
-        } else {
-            GuiState::default()
-        };
+    /// Construct a persistence handle with an injected writer and debounce.
+    /// Used by tests to observe coalescing and failure behaviour without
+    /// touching the real filesystem. The file at `path` is NOT loaded — the
+    /// initial state is [`GuiState::default`].
+    pub fn with_writer(
+        path: PathBuf,
+        writer: Box<dyn PersistenceWriter>,
+        debounce: Duration,
+    ) -> Self {
+        Self::new_with_state(path, GuiState::default(), writer, debounce)
+    }
+
+    fn new_with_state(
+        path: PathBuf,
+        state: GuiState,
+        writer: Box<dyn PersistenceWriter>,
+        debounce: Duration,
+    ) -> Self {
+        let shared = Arc::new(SharedSaver {
+            mu: Mutex::new(SaverInner {
+                pending: None,
+                pending_version: 0,
+                last_saved_version: 0,
+                shutdown: false,
+            }),
+            cv: Condvar::new(),
+            debounce,
+            writer,
+            path,
+        });
+
+        let worker_shared = Arc::clone(&shared);
+        // Thread spawn failure is unrecoverable: without the worker, no disk
+        // I/O can ever happen, so there is no graceful degradation path.
+        // `expect` here surfaces the failure immediately rather than returning
+        // a half-initialized handle.
+        let worker = thread::Builder::new()
+            .name("zremote-persistence".to_string())
+            .spawn(move || run_worker(&worker_shared))
+            .expect("failed to spawn persistence worker thread");
 
         Self {
-            path,
             state,
             data_version: 0,
-            last_saved_version: 0,
+            shared,
+            worker: Some(worker),
         }
     }
 
@@ -93,81 +312,228 @@ impl Persistence {
         &self.state
     }
 
-    /// Mutate state and bump the data version.
+    /// Mutate state, bump the data version, and queue a save. Non-blocking:
+    /// returns after touching only in-memory fields and the saver mutex.
     pub fn update(&mut self, f: impl FnOnce(&mut GuiState)) {
         f(&mut self.state);
         self.data_version += 1;
+        self.queue_save();
     }
 
     /// Record a session access, moving it to the front of the recent list.
-    /// Keeps at most 10 entries.
+    /// Keeps at most 10 entries. Save is queued automatically via `update`.
     pub fn record_session_access(&mut self, session_id: &str) {
-        self.state
-            .recent_sessions
-            .retain(|r| r.session_id != session_id);
-        self.state.recent_sessions.insert(
-            0,
-            RecentSession {
-                session_id: session_id.to_string(),
-                timestamp: i64::try_from(
-                    SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map_or(0, |d| d.as_secs()),
-                )
-                .unwrap_or(0),
-            },
-        );
-        self.state.recent_sessions.truncate(10);
-        self.data_version += 1;
-        let _ = self.save_if_changed();
+        self.update(|state| {
+            state.recent_sessions.retain(|r| r.session_id != session_id);
+            state.recent_sessions.insert(
+                0,
+                RecentSession {
+                    session_id: session_id.to_string(),
+                    timestamp: i64::try_from(
+                        SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map_or(0, |d| d.as_secs()),
+                    )
+                    .unwrap_or(0),
+                },
+            );
+            state.recent_sessions.truncate(10);
+        });
     }
 
-    /// Save to disk if state has changed since last save.
-    /// Returns Ok(true) if saved, Ok(false) if skipped.
-    pub fn save_if_changed(&mut self) -> std::io::Result<bool> {
-        if self.data_version == self.last_saved_version {
-            return Ok(false);
-        }
+    /// Block the current thread until every mutation up to `self.data_version`
+    /// is on disk, or `timeout` elapses. Returns [`FlushTimeout`] on timeout
+    /// or if the worker has already shut down with unpersisted state.
+    ///
+    /// Note: the worker advances `last_saved_version` even when it skips a
+    /// default-state snapshot, so this method will not spin in that case.
+    ///
+    /// Holds the internal `SharedSaver::mu` lock only while waiting on the
+    /// condition variable — the worker's critical section is always short,
+    /// so the wait does not starve the I/O thread.
+    pub fn flush_blocking(&mut self, timeout: Duration) -> Result<(), FlushTimeout> {
+        flush_shared_blocking(&self.shared, self.data_version, timeout)
+    }
 
-        // Don't save fully default state (nothing meaningful to persist).
-        if self.state.is_default() {
-            return Ok(false);
+    /// Cheap snapshot of the flush target plus a shareable handle to the
+    /// worker state, so the caller can release any outer mutex around
+    /// `Persistence` before blocking on the flush. Use when `Persistence`
+    /// is itself held inside another mutex (e.g. `AppState::persistence`)
+    /// and you do not want to stall other access to that mutex for up to
+    /// `timeout`.
+    pub fn flush_waiter(&self) -> FlushWaiter {
+        FlushWaiter {
+            shared: Arc::clone(&self.shared),
+            target: self.data_version,
         }
+    }
 
+    #[cfg(test)]
+    fn last_saved_version(&self) -> u64 {
+        // Mutex poisoning: fatal by design.
+        self.shared.mu.lock().unwrap().last_saved_version
+    }
+
+    fn queue_save(&mut self) {
         self.state.version = FORMAT_VERSION;
-        self.atomic_write()?;
-        self.last_saved_version = self.data_version;
-        Ok(true)
+        let snapshot = self.state.clone();
+        let version = self.data_version;
+        // Mutex poisoning: fatal by design.
+        let mut inner = self.shared.mu.lock().unwrap();
+        inner.pending = Some(snapshot);
+        inner.pending_version = version;
+        drop(inner);
+        self.shared.cv.notify_all();
     }
+}
 
-    /// Atomic write with rolling backup.
-    fn atomic_write(&self) -> std::io::Result<()> {
-        // Ensure parent directory exists.
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Rolling backup: rename existing to .bak
-        if self.path.exists() {
-            let bak = self.path.with_extension("json.bak");
-            let _ = std::fs::rename(&self.path, &bak);
-        }
-
-        // Write to .tmp first.
-        let tmp = self.path.with_extension("json.tmp");
-        let json = serde_json::to_string_pretty(&self.state).map_err(std::io::Error::other)?;
-
+impl Drop for Persistence {
+    fn drop(&mut self) {
+        // Best-effort flush with a bounded deadline. Skips the wait entirely
+        // when `last_saved_version >= data_version` (cheap first-iteration
+        // check in `flush_shared_blocking`) so a caller that already flushed
+        // explicitly does not pay a second 2 s stall here.
+        let _ = self.flush_blocking(DROP_FLUSH_TIMEOUT);
+        // Signal shutdown and wake the worker.
         {
-            let mut file = std::fs::File::create(&tmp)?;
-            file.write_all(json.as_bytes())?;
-            file.sync_all()?;
+            // Mutex poisoning: fatal by design.
+            let mut inner = self.shared.mu.lock().unwrap();
+            inner.shutdown = true;
+        }
+        self.shared.cv.notify_all();
+        if let Some(handle) = self.worker.take()
+            && let Err(panic_payload) = handle.join()
+        {
+            // A worker panic means subsequent `update` calls are silently
+            // dropped from the retry-queue perspective. Log loudly so the
+            // failure is visible in tracing output rather than disappearing.
+            tracing::error!(
+                ?panic_payload,
+                "persistence worker thread panicked before shutdown",
+            );
+        }
+    }
+}
+
+/// Worker loop: see RFC-004 Architecture § Worker loop.
+fn run_worker(shared: &Arc<SharedSaver>) {
+    loop {
+        // Phase 1: wait for pending work or shutdown.
+        {
+            // Mutex poisoning: fatal by design.
+            let mut inner = shared.mu.lock().unwrap();
+            while inner.pending.is_none() && !inner.shutdown {
+                inner = shared.cv.wait(inner).unwrap();
+            }
+            if inner.shutdown && inner.pending.is_none() {
+                break;
+            }
         }
 
-        // Atomic rename.
-        std::fs::rename(&tmp, &self.path)?;
+        // Phase 2: debounce — release the lock, let additional updates
+        // coalesce into the same `pending` slot. Interruptible by shutdown:
+        // a shutdown signal that arrives during this wait wakes us early,
+        // so the worker can drain the latest pending snapshot and exit.
+        {
+            // Mutex poisoning: fatal by design.
+            let inner = shared.mu.lock().unwrap();
+            let _guard = shared
+                .cv
+                .wait_timeout_while(inner, shared.debounce, |st| !st.shutdown)
+                .unwrap()
+                .0;
+        }
 
-        tracing::debug!(path = %self.path.display(), "saved GUI state");
-        Ok(())
+        // Phase 3: take the latest snapshot under the lock. `snapshot` is
+        // owned by the worker from here onwards so phase 5 can re-queue it
+        // if the write in phase 4 fails.
+        let taken = {
+            // Mutex poisoning: fatal by design.
+            let mut inner = shared.mu.lock().unwrap();
+            if let Some(snapshot) = inner.pending.take() {
+                Some((snapshot, inner.pending_version))
+            } else if inner.shutdown {
+                break;
+            } else {
+                None
+            }
+        };
+        let Some((snapshot, version)) = taken else {
+            continue;
+        };
+
+        // Phase 4: write OUTSIDE the lock. Skip default-state snapshots to
+        // match the pre-RFC-004 "don't persist empty state" guard. We still
+        // advance `last_saved_version` in phase 5 so that `flush_blocking`
+        // does not spin on a write that will never happen.
+        let is_default_skip = snapshot.is_default();
+        let result: std::io::Result<()> = if is_default_skip {
+            Ok(())
+        } else {
+            shared.writer.write(&shared.path, &snapshot)
+        };
+
+        // Phase 5: publish result, notify waiters. On failure, re-queue the
+        // snapshot so the worker retries after the next phase 1 wake-up —
+        // unless a newer update has already replaced it (coalescing: newest
+        // wins). The caller-side `flush_blocking` will keep waiting until
+        // either a retry succeeds or its deadline elapses.
+        {
+            // Mutex poisoning: fatal by design.
+            let mut inner = shared.mu.lock().unwrap();
+            match result {
+                Ok(()) => {
+                    inner.last_saved_version = version;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %shared.path.display(),
+                        "persistence worker write failed; will retry",
+                    );
+                    if inner.pending.is_none() {
+                        // Nothing newer arrived while we were writing —
+                        // put the failed snapshot back so the next loop
+                        // iteration retries it.
+                        inner.pending = Some(snapshot);
+                        inner.pending_version = version;
+                    }
+                    // If `inner.pending` is already Some, a newer snapshot
+                    // superseded this one during the write — drop the
+                    // failed one on the floor; the newer write wins.
+                }
+            }
+            drop(inner);
+            shared.cv.notify_all();
+        }
+    }
+    tracing::debug!("persistence worker exiting");
+}
+
+fn load_state_from_disk(path: &Path) -> GuiState {
+    if !path.exists() {
+        return GuiState::default();
+    }
+    match std::fs::read_to_string(path) {
+        Ok(contents) => match serde_json::from_str::<GuiState>(&contents) {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "failed to parse GUI state, using defaults",
+                );
+                GuiState::default()
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "failed to read GUI state file",
+            );
+            GuiState::default()
+        }
     }
 }
 
@@ -176,4 +542,445 @@ fn state_file_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join("zremote")
         .join("gui-state.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    // -------- Test writers --------
+
+    struct CountingWriter {
+        calls: Arc<AtomicU64>,
+        last_written: Arc<Mutex<Option<GuiState>>>,
+    }
+
+    impl PersistenceWriter for CountingWriter {
+        fn write(&self, _path: &Path, state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            // Mutex poisoning: test-only, a poisoned lock would fail the test.
+            *self.last_written.lock().unwrap() = Some(state.clone());
+            Ok(())
+        }
+    }
+
+    struct BlockingWriter {
+        unblock: Arc<(Mutex<bool>, Condvar)>,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl PersistenceWriter for BlockingWriter {
+        fn write(&self, _path: &Path, _state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let (lock, cv) = &*self.unblock;
+            // Mutex poisoning: test-only.
+            let mut unblocked = lock.lock().unwrap();
+            while !*unblocked {
+                unblocked = cv.wait(unblocked).unwrap();
+            }
+            Ok(())
+        }
+    }
+
+    struct FailingWriter {
+        calls: Arc<AtomicU64>,
+    }
+
+    impl PersistenceWriter for FailingWriter {
+        fn write(&self, _path: &Path, _state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Err(std::io::Error::other("synthetic failure"))
+        }
+    }
+
+    /// Fails `fail_count` times, then returns `Ok` on subsequent calls.
+    /// Used to verify retry-to-success in `test_write_retry_on_transient_failure`.
+    struct FlakyWriter {
+        remaining_failures: Arc<AtomicU64>,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl PersistenceWriter for FlakyWriter {
+        fn write(&self, _path: &Path, _state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if self.remaining_failures.load(Ordering::Relaxed) > 0 {
+                self.remaining_failures.fetch_sub(1, Ordering::Relaxed);
+                Err(std::io::Error::other("transient synthetic failure"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    struct SleepingWriter {
+        sleep: Duration,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl PersistenceWriter for SleepingWriter {
+        fn write(&self, _path: &Path, _state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            thread::sleep(self.sleep);
+            Ok(())
+        }
+    }
+
+    /// Writer that signals a `Drop` sentinel when the worker releases it.
+    /// Used by `test_worker_terminates_on_drop` to prove the worker thread
+    /// has released its `Arc<SharedSaver>` (which holds the writer) after
+    /// the caller drops the `Persistence`.
+    struct SentinelWriter {
+        calls: Arc<AtomicU64>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl PersistenceWriter for SentinelWriter {
+        fn write(&self, _path: &Path, _state: &GuiState) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    impl Drop for SentinelWriter {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Relaxed);
+        }
+    }
+
+    // -------- Helpers --------
+
+    fn temp_path(label: &str) -> PathBuf {
+        // Per-test unique directory under the system temp dir. Tests only
+        // ever write inside this directory, so it is safe to leave behind
+        // for the OS to clean up. No tempdir guard is created — which means
+        // no leaked drop logic.
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir()
+            .join("zremote-persist-tests")
+            .join(format!("{}-{label}-{n}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create test temp dir");
+        dir.join(format!("{label}.json"))
+    }
+
+    fn counting_writer() -> (
+        Box<CountingWriter>,
+        Arc<AtomicU64>,
+        Arc<Mutex<Option<GuiState>>>,
+    ) {
+        let calls = Arc::new(AtomicU64::new(0));
+        let last = Arc::new(Mutex::new(None));
+        let writer = Box::new(CountingWriter {
+            calls: Arc::clone(&calls),
+            last_written: Arc::clone(&last),
+        });
+        (writer, calls, last)
+    }
+
+    fn non_default_mutation(state: &mut GuiState) {
+        // Touch a field that makes `is_default()` return false so the worker
+        // actually writes the snapshot.
+        state.server_url = Some("http://example:1234".to_string());
+    }
+
+    // -------- Tests --------
+
+    #[test]
+    fn test_update_is_nonblocking() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let writer = Box::new(SleepingWriter {
+            sleep: Duration::from_millis(100),
+            calls: Arc::clone(&calls),
+        });
+        let path = temp_path("nonblocking");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        let start = Instant::now();
+        for i in 0..20u32 {
+            p.update(|s| {
+                s.server_url = Some(format!("http://host:{i}"));
+            });
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "20 updates took {elapsed:?}, expected < 50 ms",
+        );
+        // Drop runs flush_blocking(2 s). With 20 updates coalesced, the
+        // worker performs at most 2 writes of 100 ms each, well under the
+        // drop deadline — this is intentional, just observed here.
+        drop(p);
+    }
+
+    #[test]
+    fn test_coalescing_100_updates() {
+        let (writer, calls, _) = counting_writer();
+        let path = temp_path("coalescing");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(30));
+
+        for i in 0..100u32 {
+            p.update(|s| {
+                s.server_url = Some(format!("http://host:{i}"));
+            });
+        }
+
+        p.flush_blocking(Duration::from_secs(2))
+            .expect("flush should complete within 2 s");
+
+        let n = calls.load(Ordering::Relaxed);
+        assert!(n <= 2, "expected <= 2 writes, got {n}");
+        assert!(n >= 1, "expected at least one write, got {n}");
+    }
+
+    #[test]
+    fn test_flush_blocking_returns_after_save() {
+        let (writer, calls, _) = counting_writer();
+        let path = temp_path("flush-returns");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.update(non_default_mutation);
+        p.flush_blocking(Duration::from_secs(1)).expect("flush ok");
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(p.last_saved_version(), p.data_version);
+    }
+
+    #[test]
+    fn test_flush_blocking_timeout() {
+        let unblock = Arc::new((Mutex::new(false), Condvar::new()));
+        let calls = Arc::new(AtomicU64::new(0));
+        let writer = Box::new(BlockingWriter {
+            unblock: Arc::clone(&unblock),
+            calls: Arc::clone(&calls),
+        });
+        let path = temp_path("flush-timeout");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.update(non_default_mutation);
+        let result = p.flush_blocking(Duration::from_millis(50));
+        assert!(matches!(result, Err(FlushTimeout)));
+
+        // Unblock the writer so the worker can exit cleanly on drop.
+        {
+            let (lock, cv) = &*unblock;
+            let mut v = lock.lock().unwrap();
+            *v = true;
+            cv.notify_all();
+        }
+        drop(p);
+    }
+
+    #[test]
+    fn test_drop_flushes_pending_writes() {
+        let (writer, calls, _) = counting_writer();
+        let path = temp_path("drop-flushes");
+        {
+            let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+            p.update(non_default_mutation);
+            // Drop without explicit flush — Drop should call flush_blocking(2s).
+        }
+        assert!(
+            calls.load(Ordering::Relaxed) >= 1,
+            "writer should have been called at least once",
+        );
+    }
+
+    #[test]
+    fn test_write_failure_does_not_advance_last_saved() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let writer = Box::new(FailingWriter {
+            calls: Arc::clone(&calls),
+        });
+        let path = temp_path("write-failure");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.update(non_default_mutation);
+        let result = p.flush_blocking(Duration::from_millis(100));
+        assert!(matches!(result, Err(FlushTimeout)));
+        assert!(
+            calls.load(Ordering::Relaxed) >= 1,
+            "writer should have been attempted",
+        );
+        // On permanent failure the worker keeps retrying the same snapshot
+        // indefinitely (bounded by the debounce window between attempts).
+        // We verify that by re-reading the call count after another short
+        // window: it must have grown past the initial attempt.
+        let calls_at_timeout = calls.load(Ordering::Relaxed);
+        thread::sleep(Duration::from_millis(80));
+        assert!(
+            calls.load(Ordering::Relaxed) > calls_at_timeout,
+            "worker should retry failed writes; calls={calls_at_timeout} then no growth",
+        );
+        // Drop runs flush_blocking(2 s) which will hit its own timeout —
+        // that is the intended permanent-failure contract. To keep this
+        // test fast we forget the `Persistence` instead of dropping it.
+        // The leaked worker thread exits when the process ends.
+        std::mem::forget(p);
+    }
+
+    #[test]
+    fn test_write_retry_on_transient_failure() {
+        // Writer fails the first 3 attempts then succeeds. Verifies that
+        // the worker re-queues the failed snapshot and retries without
+        // losing data, and that `flush_blocking` eventually returns Ok.
+        let calls = Arc::new(AtomicU64::new(0));
+        let remaining = Arc::new(AtomicU64::new(3));
+        let writer = Box::new(FlakyWriter {
+            remaining_failures: Arc::clone(&remaining),
+            calls: Arc::clone(&calls),
+        });
+        let path = temp_path("flaky-retry");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.update(non_default_mutation);
+        p.flush_blocking(Duration::from_secs(3))
+            .expect("flaky writer should eventually succeed");
+
+        let total_calls = calls.load(Ordering::Relaxed);
+        assert!(
+            total_calls >= 4,
+            "expected at least 3 failed attempts + 1 success, got {total_calls}",
+        );
+        assert_eq!(
+            remaining.load(Ordering::Relaxed),
+            0,
+            "all transient failures should have been consumed",
+        );
+        assert_eq!(p.last_saved_version(), p.data_version);
+    }
+
+    #[test]
+    fn test_default_state_is_not_written() {
+        // Sanity guard: if a future change to `GuiState` breaks the
+        // `is_default()` invariant (e.g. a new field whose default is
+        // treated as non-default), this assertion fails loudly instead of
+        // silently flipping the test into a meaningless pass.
+        assert!(
+            GuiState::default().is_default(),
+            "GuiState::default() must satisfy is_default() — \
+             otherwise the default-state skip guard below becomes a no-op",
+        );
+
+        let (writer, calls, _) = counting_writer();
+        let path = temp_path("default-skip");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        // Bump the version without leaving default state.
+        p.update(|_| {});
+        p.flush_blocking(Duration::from_secs(1))
+            .expect("flush should complete even when snapshot is default");
+
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "default state must not be written",
+        );
+        assert_eq!(
+            p.last_saved_version(),
+            p.data_version,
+            "last_saved_version must advance even when the write was skipped",
+        );
+    }
+
+    #[test]
+    fn test_record_session_access_queues_save() {
+        let (writer, calls, last) = counting_writer();
+        let path = temp_path("record-session");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.record_session_access("abc123");
+        p.flush_blocking(Duration::from_secs(1)).expect("flush ok");
+
+        assert!(calls.load(Ordering::Relaxed) >= 1);
+        let snapshot = last.lock().unwrap().clone().expect("snapshot");
+        assert_eq!(snapshot.recent_sessions.len(), 1);
+        assert_eq!(snapshot.recent_sessions[0].session_id, "abc123");
+    }
+
+    #[test]
+    fn test_worker_terminates_on_drop() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let writer = Box::new(SentinelWriter {
+            calls: Arc::clone(&calls),
+            dropped: Arc::clone(&dropped),
+        });
+        let path = temp_path("worker-join");
+        let start = Instant::now();
+        {
+            let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+            p.update(non_default_mutation);
+            // Drop runs flush_blocking + signal + join. If the worker hangs
+            // the test itself hangs — the time bound below catches that.
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "drop should return promptly, took {elapsed:?}",
+        );
+        assert!(
+            dropped.load(Ordering::Relaxed),
+            "SentinelWriter should have been dropped (worker released the Arc)",
+        );
+        assert!(calls.load(Ordering::Relaxed) >= 1);
+    }
+
+    #[test]
+    fn test_burst_then_idle_then_burst() {
+        let (writer, calls, _) = counting_writer();
+        let path = temp_path("burst-idle-burst");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(20));
+
+        for i in 0..50u32 {
+            p.update(|s| {
+                s.server_url = Some(format!("http://first:{i}"));
+            });
+        }
+        p.flush_blocking(Duration::from_secs(2)).expect("flush 1");
+        let after_first = calls.load(Ordering::Relaxed);
+
+        // Idle interval large enough for the worker to park on the cv.
+        thread::sleep(Duration::from_millis(100));
+
+        for i in 0..50u32 {
+            p.update(|s| {
+                s.server_url = Some(format!("http://second:{i}"));
+            });
+        }
+        p.flush_blocking(Duration::from_secs(2)).expect("flush 2");
+        let total = calls.load(Ordering::Relaxed);
+
+        assert!(
+            (1..=2).contains(&after_first),
+            "first burst writes = {after_first}"
+        );
+        assert!(
+            (2..=4).contains(&total),
+            "total writes across both bursts expected 2..=4, got {total}",
+        );
+    }
+
+    #[test]
+    fn test_file_writer_produces_same_bytes_as_reference() {
+        let path = temp_path("file-writer-bytes");
+        let state = GuiState {
+            version: 1,
+            server_url: Some("http://a:1".to_string()),
+            active_session_id: Some("s".to_string()),
+            window_width: Some(800.0),
+            window_height: Some(600.0),
+            recent_sessions: vec![RecentSession {
+                session_id: "s".to_string(),
+                timestamp: 1_700_000_000,
+            }],
+        };
+
+        FileWriter.write(&path, &state).expect("write");
+        let actual = std::fs::read_to_string(&path).expect("read back");
+
+        let expected = "{\n  \"version\": 1,\n  \"server_url\": \"http://a:1\",\n  \"active_session_id\": \"s\",\n  \"window_width\": 800.0,\n  \"window_height\": 600.0,\n  \"recent_sessions\": [\n    {\n      \"session_id\": \"s\",\n      \"timestamp\": 1700000000\n    }\n  ]\n}";
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -170,10 +170,10 @@ impl MainView {
     fn open_terminal(&mut self, session_id: &str, host_id: &str, cx: &mut Context<Self>) {
         let session_id_owned = session_id.to_string();
 
-        // Persist active session.
+        // Persist active session. `update` queues the save via the background
+        // worker; no explicit flush needed at the call site.
         if let Ok(mut p) = self.app_state.persistence.lock() {
             p.update(|s| s.active_session_id = Some(session_id_owned.clone()));
-            let _ = p.save_if_changed();
         }
 
         // Keep sidebar selection in sync (covers command palette, switcher, etc.)

--- a/docs/rfc/rfc-004-batched-async-persistence.md
+++ b/docs/rfc/rfc-004-batched-async-persistence.md
@@ -1,0 +1,441 @@
+# RFC-004: Batched Async Persistence for GUI State
+
+## Status: Draft
+
+## Problem Statement
+
+`crates/zremote-gui/src/persistence.rs` owns the GUI's on-disk state file (`~/.config/zremote/gui-state.json`). Its current shape works well for the tiny state it handles today (window bounds, `server_url`, `active_session_id`, 10-entry `recent_sessions`):
+
+1. `update(|s| ...)` mutates state synchronously and bumps `data_version`.
+2. `save_if_changed()` does a blocking atomic-with-backup write on the calling thread if `data_version != last_saved_version`.
+3. Call sites today: `lib.rs` init, `lib.rs` quit, `main_view.rs` session switch, `record_session_access` inside persistence itself.
+
+The data volume is small enough that synchronous `fsync` calls are invisible. That changes with the upcoming features:
+
+- **#23 Multi-theme** — persists selected theme on every switch.
+- **#26 Command palette (recent actions + context rank)** — persists on *every* palette pick. Under normal usage that's a burst of ~5–20 writes in a second after a rapid session.
+- **#27 Extended agent detection** — persists active prompt excerpts as they arrive.
+- **#29 AI chat** — persists streaming assistant tokens, potentially hundreds of mutations over a few seconds.
+- **#30 Live logs** — persists filter/level preferences less frequently but alongside a busy render loop.
+
+If we keep the synchronous save path, any of these features stalls the GPUI render thread on `fsync` during a burst. On spinning disks, encrypted filesystems, or network home directories, the stall is visible (10–100 ms per write). Worst case: 100 rapid picks in the command palette cause 100 `fsync` calls on the render thread, dropping frames.
+
+The issue (#31) specifies a concrete fix: mutations stay synchronous and non-blocking; a background worker owns all file I/O; bursts are debounced and coalesced; shutdown flushes with a bounded timeout.
+
+## Goals
+
+1. **Non-blocking `update`.** `Persistence::update(|s| ...)` returns in microseconds under all load. No `fsync`, no file I/O on the caller's thread (GPUI main thread in practice).
+2. **Single background writer.** Exactly one dedicated thread performs disk I/O. No fan-out, no multi-writer races.
+3. **Automatic coalescing.** 100 rapid updates in a 250 ms window produce ≤ 2 actual writes (one for the window, optionally one follow-up).
+4. **Bounded shutdown flush.** `flush_blocking(Duration)` blocks on the calling thread until the in-flight + pending writes complete, or the timeout elapses. Drop-time cleanup always flushes with a 2 s deadline.
+5. **Durability preserved.** Atomic write, rolling backup (`.json.bak`), "don't save default state", version-bump skip — all retained from the current implementation.
+6. **Testability.** Writer is injectable so tests can count writes and assert coalescing without touching real disks.
+7. **Backwards-compatible API.** Existing call sites continue to work. `record_session_access`, `update`, `state()`, and `save_if_changed` stay. `save_if_changed` becomes a lightweight "mark dirty + return immediately" that preserves its current Boolean semantics (`true` if a write was queued, `false` if nothing had changed).
+
+## Non-Goals
+
+- Changing the on-disk format, schema version, or backup scheme.
+- Cross-process locking (GUI is the sole writer).
+- Schema migration logic (only one format version today).
+- Splitting the state file into per-feature shards — that is a separate refactor when chat history (#29) actually lands and only if profiling demands it.
+- Replacing `Mutex<Persistence>` in `AppState` with an entity-shaped alternative. The batched path is orthogonal to that discussion and can ship first.
+
+## Current State (verified)
+
+`crates/zremote-gui/src/persistence.rs` (179 lines):
+
+```rust
+pub struct Persistence {
+    path: PathBuf,
+    state: GuiState,
+    data_version: u64,
+    last_saved_version: u64,
+}
+
+impl Persistence {
+    pub fn load() -> Self { /* read file or default */ }
+    pub fn state(&self) -> &GuiState { &self.state }
+    pub fn update(&mut self, f: impl FnOnce(&mut GuiState)) {
+        f(&mut self.state);
+        self.data_version += 1;
+    }
+    pub fn record_session_access(&mut self, session_id: &str) {
+        /* move session to head, cap 10, internal save_if_changed */
+    }
+    pub fn save_if_changed(&mut self) -> io::Result<bool> { /* blocking fsync */ }
+    fn atomic_write(&self) -> io::Result<()> { /* backup + tmp + rename */ }
+}
+```
+
+Call sites:
+
+- `crates/zremote-gui/src/lib.rs:94` — `persistence.update(|s| s.server_url = ...);` (no explicit save; relies on later save_if_changed in quit path).
+- `crates/zremote-gui/src/lib.rs:138-142` — on window close:
+  ```rust
+  if let Ok(mut p) = app_state_for_quit.persistence.lock() {
+      p.update(|s| { /* window bounds */ });
+      if let Err(e) = p.save_if_changed() { /* log */ }
+  }
+  ```
+- `crates/zremote-gui/src/views/main_view.rs:174-177` — on session switch:
+  ```rust
+  if let Ok(mut p) = self.app_state.persistence.lock() {
+      p.update(|s| s.active_session_id = Some(session_id_owned.clone()));
+      let _ = p.save_if_changed();
+  }
+  ```
+- `crates/zremote-gui/src/views/main_view.rs:1359` — `p.record_session_access(session_id);`
+
+`AppState` holds `persistence: Mutex<Persistence>` (`crates/zremote-gui/src/app_state.rs:22`), so batched saves must be thread-safe and the `Persistence` struct must live across the app's lifetime.
+
+## Architecture
+
+```
+┌─────────────────────────┐         ┌────────────────────────────┐
+│  Caller (GPUI thread)   │         │  Background saver thread   │
+│  ─────────────────────  │         │  ───────────────────────   │
+│  Persistence::update()  │         │                            │
+│    mutate self.state    │         │     phase 1: wait on cv    │
+│    bump data_version    │         │       while pending.none() │
+│    clone snapshot       │ signal  │       && !shutdown         │
+│    store in pending ────┼────────►│                            │
+│    cv.notify_all()      │         │     phase 2: debounce      │
+│  returns < 1 μs         │         │       cv.wait_timeout(250) │
+│                         │         │                            │
+│                         │         │     phase 3: take pending  │
+│  flush_blocking(dur):   │         │       set in_flight = v    │
+│    wait on cv until     │         │                            │
+│    last_saved >= target │◄────────┤     phase 4: write         │
+│    or deadline          │ done    │       atomic_write_with_   │
+│                         │         │         backup()           │
+└─────────────────────────┘         │                            │
+                                    │     phase 5: publish       │
+                                    │       last_saved = v       │
+                                    │       in_flight = 0        │
+                                    │       cv.notify_all()      │
+                                    └────────────────────────────┘
+```
+
+### Data model
+
+```rust
+// Public types: unchanged
+pub struct GuiState { /* existing fields */ }
+impl GuiState { fn is_default(&self) -> bool { /* unchanged */ } }
+
+// Persistence: caller-side handle
+pub struct Persistence {
+    state: GuiState,
+    data_version: u64,
+    shared: Arc<SharedSaver>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+// Worker-facing shared state
+struct SharedSaver {
+    mu: std::sync::Mutex<SaverInner>,
+    cv: std::sync::Condvar,
+    debounce: std::time::Duration,
+    writer: Box<dyn PersistenceWriter>,
+    path: PathBuf,
+    /// Observability / tests.
+    writes_performed: std::sync::atomic::AtomicU64,
+}
+
+struct SaverInner {
+    /// Newest snapshot queued for writing. Overwritten on every update —
+    /// only the latest survives, which is the coalescing invariant.
+    pending: Option<GuiState>,
+    pending_version: u64,
+    /// Version currently being written by the worker. 0 = no write in flight.
+    in_flight_version: u64,
+    last_saved_version: u64,
+    shutdown: bool,
+}
+
+/// Pluggable writer so tests can observe / inject failures without real I/O.
+pub trait PersistenceWriter: Send + Sync {
+    fn write(&self, path: &Path, state: &GuiState) -> std::io::Result<()>;
+}
+
+/// Production writer: atomic + rolling backup, identical bytes to current impl.
+struct FileWriter;
+impl PersistenceWriter for FileWriter { /* parent mkdir, backup, tmp+fsync+rename */ }
+```
+
+### Worker loop (pseudocode)
+
+```rust
+fn run(shared: Arc<SharedSaver>) {
+    loop {
+        // Phase 1: wait for pending work or shutdown.
+        {
+            let mut inner = shared.mu.lock().unwrap();
+            while inner.pending.is_none() && !inner.shutdown {
+                inner = shared.cv.wait(inner).unwrap();
+            }
+            if inner.shutdown && inner.pending.is_none() {
+                break;
+            }
+        }
+
+        // Phase 2: debounce — release the lock, let additional updates
+        // coalesce into the same `pending` slot. Interruptible by shutdown.
+        {
+            let inner = shared.mu.lock().unwrap();
+            let (_guard, _) = shared
+                .cv
+                .wait_timeout_while(inner, shared.debounce, |st| !st.shutdown)
+                .unwrap();
+        }
+
+        // Phase 3: take the latest snapshot.
+        let taken = {
+            let mut inner = shared.mu.lock().unwrap();
+            if let Some(snapshot) = inner.pending.take() {
+                inner.in_flight_version = inner.pending_version;
+                Some((snapshot, inner.in_flight_version))
+            } else if inner.shutdown {
+                break;
+            } else {
+                None
+            }
+        };
+        let Some((snapshot, version)) = taken else { continue; };
+
+        // Phase 4: write OUTSIDE the lock. Skip default-state to match current behaviour.
+        let result = if snapshot.is_default() {
+            Ok(())
+        } else {
+            shared.writer.write(&shared.path, &snapshot)
+        };
+
+        // Phase 5: publish result, notify flushers.
+        {
+            let mut inner = shared.mu.lock().unwrap();
+            match &result {
+                Ok(()) => {
+                    inner.last_saved_version = version;
+                    shared.writes_performed.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => tracing::warn!(error = %e, path = %shared.path.display(),
+                                         "persistence worker write failed"),
+            }
+            inner.in_flight_version = 0;
+            shared.cv.notify_all();
+        }
+    }
+    tracing::debug!("persistence worker exiting");
+}
+```
+
+### Caller-side API
+
+```rust
+impl Persistence {
+    /// Load state from disk and spawn the background writer.
+    /// Default debounce: 250 ms. Default writer: FileWriter.
+    pub fn load() -> Self { /* existing load logic + spawn worker */ }
+
+    /// Test / advanced constructor with injected writer and debounce.
+    pub fn with_writer(
+        path: PathBuf,
+        writer: Box<dyn PersistenceWriter>,
+        debounce: Duration,
+    ) -> Self { /* ... */ }
+
+    pub fn state(&self) -> &GuiState { &self.state }
+
+    /// Mutate state, bump version, queue a save. Non-blocking: returns after
+    /// touching only in-memory fields and the saver mutex.
+    pub fn update(&mut self, f: impl FnOnce(&mut GuiState)) {
+        f(&mut self.state);
+        self.data_version += 1;
+        self.queue_save();
+    }
+
+    /// Record a session access. Identical semantics to today; internally
+    /// calls `update` (so the save is queued, not synchronous).
+    pub fn record_session_access(&mut self, session_id: &str) { /* same as today */ }
+
+    /// Back-compat shim. With batched persistence, there is nothing to do
+    /// at the call site beyond ensuring the queued save reaches disk —
+    /// which the worker already does. Returns `true` if the most-recent
+    /// data_version is not yet on disk, `false` if everything is flushed.
+    /// NEVER blocks.
+    pub fn save_if_changed(&mut self) -> std::io::Result<bool> { /* ... */ }
+
+    /// Block the current thread until every mutation up to `self.data_version`
+    /// is on disk, or `timeout` elapses. Returns Err on timeout.
+    pub fn flush_blocking(&mut self, timeout: Duration) -> Result<(), FlushTimeout> {
+        let target = self.data_version;
+        let deadline = Instant::now() + timeout;
+        let mut inner = self.shared.mu.lock().unwrap();
+        while inner.last_saved_version < target && !inner.shutdown {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return Err(FlushTimeout);
+            };
+            let (new_inner, result) = self.shared.cv.wait_timeout(inner, remaining).unwrap();
+            inner = new_inner;
+            if result.timed_out() && inner.last_saved_version < target {
+                return Err(FlushTimeout);
+            }
+        }
+        Ok(())
+    }
+
+    fn queue_save(&mut self) {
+        let snapshot = self.state.clone();
+        let version = self.data_version;
+        let mut inner = self.shared.mu.lock().unwrap();
+        inner.pending = Some(snapshot);
+        inner.pending_version = version;
+        self.shared.cv.notify_all();
+    }
+}
+
+impl Drop for Persistence {
+    fn drop(&mut self) {
+        // Best-effort flush with a 2 s deadline.
+        let _ = self.flush_blocking(Duration::from_secs(2));
+        // Signal shutdown and join the worker.
+        {
+            let mut inner = self.shared.mu.lock().unwrap();
+            inner.shutdown = true;
+        }
+        self.shared.cv.notify_all();
+        if let Some(handle) = self.worker.take() {
+            let _ = handle.join();
+        }
+    }
+}
+```
+
+### Invariants
+
+- **Single writer.** Only the worker thread calls `PersistenceWriter::write`. The caller never touches disk after `load()`.
+- **Monotonic versions.** `last_saved_version <= pending_version` always. `last_saved_version` never decreases.
+- **Coalescing.** If `update` is called N times while a save is pending or in flight, the worker performs at most 2 writes: one for whatever was in `pending` when the current write started, plus at most one more for everything after.
+- **Shutdown-safe.** After `Drop` returns, the worker thread has joined and no background I/O is possible.
+- **No deadlock on lock ordering.** Only one Mutex (`shared.mu`). No nested locks. Worker never holds `mu` during disk I/O.
+- **Default-state guard preserved.** Worker skips writing if the snapshot is `is_default()`. Matches today's behaviour precisely.
+
+### Error handling
+
+- **Worker write failure** → logged at `warn` level, `last_saved_version` stays unchanged. Next update triggers a retry on the same or newer version. No panic, no `unwrap` on I/O.
+- **Flush timeout** → `FlushTimeout` error returned to caller. Caller logs and proceeds (shutdown path already tolerates write failures).
+- **Mutex poisoning** → matches current code: `.unwrap()` on the lock. Justification: the worker is the only critical section, and a poisoned persistence mutex means the process is already dead. Documented with a comment at each `.unwrap()` site.
+- **Worker panic** → the `JoinHandle::join()` in `Drop` returns `Err`. Logged, not propagated. Process continues to exit.
+
+## Phases
+
+### Phase 1 — Rewrite `persistence.rs` with batched worker
+
+**Create / modify:**
+
+- `crates/zremote-gui/src/persistence.rs` — full rewrite preserving `GuiState`, `RecentSession`, and public method signatures.
+
+**Behaviour:**
+
+- `Persistence::load()` reads the file (identical parse logic), spawns the worker thread, returns.
+- `update`, `record_session_access`, `save_if_changed`, `state()`, `flush_blocking` per the Architecture section above.
+- `atomic_write_with_backup` moved out of `impl Persistence` into a free function consumed by `FileWriter`, identical byte layout.
+- `Drop` flushes then shuts down the worker.
+
+**Constraint:** No changes to `GuiState` fields, no JSON-schema change. The format version stays `1`. An existing `gui-state.json` loads and saves identically.
+
+### Phase 2 — Adapt call sites
+
+**Modify:**
+
+- `crates/zremote-gui/src/lib.rs:138-146` — the quit path currently calls `save_if_changed()` and logs errors. With batched persistence, the right primitive is `flush_blocking(Duration::from_secs(2))` so the window-bounds update actually reaches disk before the process exits. Replace the call.
+- `crates/zremote-gui/src/views/main_view.rs:174-177` — drop the `let _ = p.save_if_changed();` line. `update` now queues the save. The line becomes pure noise.
+- `crates/zremote-gui/src/lib.rs:94` — already only calls `update`, no change.
+
+**Constraint:** No API changes visible to anyone outside `persistence.rs`. The `save_if_changed` method stays for back-compat; we just stop calling it in the trivial cases.
+
+### Phase 3 — Tests
+
+**Create:** `#[cfg(test)] mod tests` at the bottom of `crates/zremote-gui/src/persistence.rs`.
+
+Test matrix (mandatory):
+
+1. **`test_update_is_nonblocking`** — with a writer that sleeps 500 ms per write, issue 20 updates in a loop. The whole loop must complete in well under 100 ms.
+2. **`test_coalescing_100_updates`** — with a counting writer + short debounce, issue 100 rapid updates, flush, assert `writes_performed <= 2`.
+3. **`test_flush_blocking_returns_after_save`** — single update, flush_blocking(1s), verify writer was called once and `last_saved_version == data_version`.
+4. **`test_flush_blocking_timeout`** — writer that blocks until signaled, flush_blocking(50ms) → `Err(FlushTimeout)`.
+5. **`test_drop_flushes_pending_writes`** — update, then drop Persistence with the counting writer; assert writer saw the write.
+6. **`test_write_failure_does_not_advance_last_saved`** — writer that returns `Err`, update, flush_blocking(short) returns `Err(FlushTimeout)` because last_saved_version never advances.
+7. **`test_default_state_is_not_written`** — fresh `Persistence` in a temp dir, no updates, flush, writer never called.
+8. **`test_record_session_access_queues_save`** — call record_session_access, flush, writer sees a snapshot whose `recent_sessions[0].session_id` matches.
+9. **`test_worker_joins_on_drop`** — writer with an Arc counter; after Persistence drops, the counter is correct and the worker thread has terminated.
+10. **`test_burst_then_idle_then_burst`** — update burst, flush, second burst, flush; `writes_performed` between 2 and 4.
+
+**Test helpers:**
+
+```rust
+struct CountingWriter {
+    calls: Arc<AtomicU64>,
+    last_written: Arc<Mutex<Option<GuiState>>>,
+}
+impl PersistenceWriter for CountingWriter { /* increment + store snapshot */ }
+
+struct BlockingWriter { /* blocks until a channel fires */ }
+struct FailingWriter { /* always returns Err(ErrorKind::Other) */ }
+```
+
+**Debounce in tests:** use 10–50 ms, not the production 250 ms, to keep wall-clock time short.
+
+### Phase 4 — Wire-up verification
+
+**Manual + automated:**
+
+- `cargo build --workspace` — succeeds.
+- `cargo clippy --workspace -- -D warnings` — no new lints.
+- `cargo test -p zremote-gui` — all tests, including the new ones, pass.
+- `cargo test --workspace` — nothing else regresses.
+- Manual: run the GUI (`cargo run -p zremote -- gui --local`), change the window size, close the window, reopen. Window size restored.
+- Manual: navigate between sessions 10 times rapidly. No visible stutter. `~/.config/zremote/gui-state.json` reflects the latest selection after close.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Worker panic leaves the GUI writing nothing forever | Panic is logged, `Drop` still joins. Any future update would push `pending` but no writer would drain it. Acceptable: a panicked worker is a bug we must fix, and the GUI continues running. |
+| `flush_blocking` deadlock if the mutex is poisoned | `.unwrap()` on the lock panics, which is equivalent to today's behaviour. Documented. |
+| Test flakiness from real wall-clock debounce | Tests use 10–50 ms debounce and rely on ordering through cv notifications, not time alone. Flush uses `last_saved_version` monotonicity for correctness, not sleeps. |
+| Cloning GuiState on every update becomes expensive later when chat history lands | Explicit non-goal here; split the state file when that happens. Current GuiState is < 1 KB, clone is free. |
+| Existing call sites that read `state()` right after `update()` see the new state (correct) but not its on-disk counterpart (expected) | Documented: `state()` is in-memory truth. Disk truth lags by ≤ debounce + one `fsync`. No caller depends on disk truth. |
+
+## Acceptance criteria (maps to issue #31)
+
+- [ ] `update(...)` returns without touching disk I/O.
+- [ ] Exactly one background thread performs file writes.
+- [ ] Debounce configurable, default 250 ms.
+- [ ] Test `test_coalescing_100_updates` asserts ≤ 2 writes.
+- [ ] `flush_blocking(timeout)` bounded and returns Err on timeout.
+- [ ] `Drop::drop` flushes with a 2 s deadline.
+- [ ] `atomic_write`, rolling `.bak`, skip-default behaviour preserved — verified by a byte-for-byte comparison test against a hand-written reference file.
+- [ ] `record_session_access` unchanged externally.
+- [ ] All call sites in `lib.rs` / `main_view.rs` updated.
+- [ ] Module-level doc comment explains the model, invariants, and testing helpers.
+- [ ] Ready for consumption by #23, #26, #29 — no further changes needed.
+
+## Out of scope
+
+- Changing the persistence file name, location, or schema.
+- Migrating away from `Mutex<Persistence>` in `AppState`.
+- Compressing the on-disk format.
+- Cross-machine state sync.
+
+## Rollout
+
+Land in a single PR that bundles phases 1–3. Phase 4 is the CI matrix plus a manual smoke test. No feature flag. No migration step — the on-disk format is unchanged.
+
+## References
+
+- Issue: #31
+- Current file: `crates/zremote-gui/src/persistence.rs`
+- Call sites: `lib.rs:94`, `lib.rs:138-146`, `views/main_view.rs:174-177`, `views/main_view.rs:1359`
+- AppState glue: `app_state.rs:22`
+- Related future consumers: #23 (theme), #26 (recent actions), #27 (agent prompt), #29 (chat history), #30 (log filters)


### PR DESCRIPTION
## Summary

Closes #31

- Moves GUI state persistence off the main thread into a dedicated background worker thread
- Worker debounces (250 ms), coalesces rapid updates, and retries failed writes automatically
- Adds `FlushWaiter` API for lock-free shutdown flush (outer `AppState` mutex released before blocking)
- Atomic write with rolling `.bak` backup, `.tmp` cleanup on failure, no TOCTOU on backup rename
- 13 tests: coalescing, retry-on-transient-failure, flush timeout, default-state skip, byte-compatibility, worker termination on drop

## Key design decisions

- Single `Mutex<SaverInner>` + `Condvar` — no nested locks, I/O always outside critical section
- Failed writes re-queued into `pending` slot (coalescing preserved: newest wins)
- `flush_blocking` returns `Err(FlushTimeout)` on both deadline and shutdown-with-pending-data
- Worker thread panics logged via `tracing::error` in `Drop` (not silently swallowed)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --workspace` — 2368 tests pass
- [x] 13 persistence-specific tests covering all RFC-004 acceptance criteria
- [x] Byte-for-byte JSON compatibility with legacy format verified