### PR TITLE
feat(gui): centralized keyboard dispatch

### DIFF
--- a/crates/zremote-gui/src/views/command_palette/keybindings.rs
+++ b/crates/zremote-gui/src/views/command_palette/keybindings.rs
@@ -3,7 +3,8 @@
 use gpui::*;
 
 use super::items::is_item_drillable;
-use super::{CommandPalette, CommandPaletteEvent, DrillDownLevel, PaletteTab};
+use super::{CommandPalette, CommandPaletteEvent, DrillDownLevel};
+use crate::views::key_bindings::{KeyAction, dispatch_global_key};
 
 impl CommandPalette {
     pub(super) fn handle_key_down(
@@ -93,35 +94,20 @@ impl CommandPalette {
             return;
         }
 
-        // Toggle shortcuts
-        if key == "k" && mods.control && !mods.shift {
-            self.dismiss(cx);
-            return;
-        }
-
-        if key == "e" && mods.control && mods.shift {
-            if self.active_tab == PaletteTab::Sessions {
-                self.dismiss(cx);
-            } else {
-                self.switch_tab(PaletteTab::Sessions, cx);
-            }
-            return;
-        }
-
-        if key == "p" && mods.control && mods.shift {
-            if self.active_tab == PaletteTab::Projects {
-                self.dismiss(cx);
-            } else {
-                self.switch_tab(PaletteTab::Projects, cx);
-            }
-            return;
-        }
-
-        if key == "a" && mods.control && mods.shift {
-            if self.active_tab == PaletteTab::Actions {
-                self.dismiss(cx);
-            } else {
-                self.switch_tab(PaletteTab::Actions, cx);
+        // Toggle shortcuts via centralized dispatch
+        if let Some(action) = dispatch_global_key(key, mods.control, mods.shift, mods.alt) {
+            match action {
+                KeyAction::OpenCommandPalette(tab) => {
+                    if self.active_tab == tab {
+                        self.dismiss(cx);
+                    } else {
+                        self.switch_tab(tab, cx);
+                    }
+                }
+                _ => {
+                    // Other global shortcuts close the palette
+                    self.dismiss(cx);
+                }
             }
             return;
         }

--- a/crates/zremote-gui/src/views/help_modal.rs
+++ b/crates/zremote-gui/src/views/help_modal.rs
@@ -3,51 +3,7 @@
 use gpui::*;
 
 use crate::theme;
-
-/// Keyboard shortcut entry for the help modal.
-struct Shortcut {
-    keys: &'static str,
-    description: &'static str,
-}
-
-const SHORTCUTS: &[Shortcut] = &[
-    Shortcut {
-        keys: "Ctrl+K",
-        description: "Command palette",
-    },
-    Shortcut {
-        keys: "Shift Shift",
-        description: "Command palette",
-    },
-    Shortcut {
-        keys: "Ctrl+Tab",
-        description: "Switch session",
-    },
-    Shortcut {
-        keys: "Ctrl+Shift+E",
-        description: "Sessions",
-    },
-    Shortcut {
-        keys: "Ctrl+Shift+P",
-        description: "Projects",
-    },
-    Shortcut {
-        keys: "Ctrl+Shift+A",
-        description: "Actions",
-    },
-    Shortcut {
-        keys: "Ctrl+F",
-        description: "Search in terminal",
-    },
-    Shortcut {
-        keys: "Escape",
-        description: "Close overlay",
-    },
-    Shortcut {
-        keys: "F1",
-        description: "Help",
-    },
-];
+use crate::views::key_bindings::{KeyAction, dispatch_modal_key, help_shortcuts};
 
 /// Help modal showing keyboard shortcuts and version information.
 pub struct HelpModal {
@@ -88,7 +44,7 @@ impl HelpModal {
             .child(title.to_string())
     }
 
-    fn render_shortcut_row(shortcut: &Shortcut) -> Div {
+    fn render_shortcut_row(keys: &str, description: &str) -> Div {
         div()
             .flex()
             .items_center()
@@ -102,13 +58,13 @@ impl HelpModal {
                     .py(px(2.0))
                     .text_size(px(11.0))
                     .text_color(theme::text_primary())
-                    .child(shortcut.keys),
+                    .child(keys.to_string()),
             )
             .child(
                 div()
                     .text_size(px(12.0))
                     .text_color(theme::text_secondary())
-                    .child(shortcut.description),
+                    .child(description.to_string()),
             )
     }
 
@@ -152,20 +108,24 @@ impl Render for HelpModal {
             .flex_col()
             .size_full()
             .overflow_y_scroll()
-            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
-                if event.keystroke.key.as_str() == "escape" {
+            .on_key_down(cx.listener(|_this, event: &KeyDownEvent, _window, cx| {
+                let key = event.keystroke.key.as_str();
+                let mods = &event.keystroke.modifiers;
+                if let Some(KeyAction::CloseOverlay) =
+                    dispatch_modal_key(key, mods.control, mods.shift, mods.alt)
+                {
                     cx.emit(HelpModalEvent::Close);
                     cx.stop_propagation();
                 }
-                let _ = this;
             }));
 
-        // Keyboard shortcuts section
+        // Keyboard shortcuts section (auto-generated from binding registry)
         let mut shortcuts_section = div().px(px(16.0)).py(px(12.0));
         shortcuts_section =
             shortcuts_section.child(Self::render_section_header("Keyboard Shortcuts"));
-        for shortcut in SHORTCUTS {
-            shortcuts_section = shortcuts_section.child(Self::render_shortcut_row(shortcut));
+        for (keys, description) in help_shortcuts() {
+            shortcuts_section =
+                shortcuts_section.child(Self::render_shortcut_row(keys, description));
         }
         content = content.child(shortcuts_section);
 

--- a/crates/zremote-gui/src/views/key_bindings.rs
+++ b/crates/zremote-gui/src/views/key_bindings.rs
@@ -1,0 +1,305 @@
+//! Centralized keyboard binding registry and dispatch.
+//!
+//! All global shortcuts are defined once here. Individual view handlers call
+//! `dispatch_global_key()` instead of duplicating match logic. Modal-scoped
+//! handlers (palette navigation, search input, switcher cycling) remain on
+//! their own focused elements — only the shared global shortcuts are centralized.
+
+use crate::views::command_palette::PaletteTab;
+
+// ---------------------------------------------------------------------------
+// Binding data
+// ---------------------------------------------------------------------------
+
+/// Modifier requirements for a binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyModifiers {
+    pub control: bool,
+    pub shift: bool,
+    pub alt: bool,
+}
+
+impl KeyModifiers {
+    const fn new(control: bool, shift: bool, alt: bool) -> Self {
+        Self {
+            control,
+            shift,
+            alt,
+        }
+    }
+
+    fn matches(self, control: bool, shift: bool, alt: bool) -> bool {
+        self.control == control && self.shift == shift && self.alt == alt
+    }
+}
+
+/// Scope in which a binding is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyScope {
+    /// Active everywhere (empty state, terminal, unless a modal consumes first).
+    Global,
+    /// Active only when a modal is focused (Esc to close).
+    Modal,
+}
+
+/// A registered keyboard binding.
+#[derive(Debug, Clone)]
+pub struct KeyBinding {
+    pub key: &'static str,
+    pub modifiers: KeyModifiers,
+    pub scope: KeyScope,
+    pub action: KeyAction,
+    /// Display label for the help modal (e.g. "Ctrl+K").
+    pub label: &'static str,
+    /// Description for the help modal.
+    pub description: &'static str,
+}
+
+/// Actions that the dispatch function can return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAction {
+    OpenCommandPalette(PaletteTab),
+    OpenSessionSwitcher,
+    OpenSearch,
+    OpenHelp,
+    CloseOverlay,
+}
+
+// ---------------------------------------------------------------------------
+// Binding registry
+// ---------------------------------------------------------------------------
+
+/// All registered keyboard bindings. Order determines help modal display order.
+pub static BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        key: "k",
+        modifiers: KeyModifiers::new(true, false, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenCommandPalette(PaletteTab::All),
+        label: "Ctrl+K",
+        description: "Command palette",
+    },
+    KeyBinding {
+        key: "tab",
+        modifiers: KeyModifiers::new(true, false, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenSessionSwitcher,
+        label: "Ctrl+Tab",
+        description: "Switch session",
+    },
+    KeyBinding {
+        key: "e",
+        modifiers: KeyModifiers::new(true, true, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenCommandPalette(PaletteTab::Sessions),
+        label: "Ctrl+Shift+E",
+        description: "Sessions",
+    },
+    KeyBinding {
+        key: "p",
+        modifiers: KeyModifiers::new(true, true, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenCommandPalette(PaletteTab::Projects),
+        label: "Ctrl+Shift+P",
+        description: "Projects",
+    },
+    KeyBinding {
+        key: "a",
+        modifiers: KeyModifiers::new(true, true, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenCommandPalette(PaletteTab::Actions),
+        label: "Ctrl+Shift+A",
+        description: "Actions",
+    },
+    KeyBinding {
+        key: "f",
+        modifiers: KeyModifiers::new(true, false, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenSearch,
+        label: "Ctrl+F",
+        description: "Search in terminal",
+    },
+    KeyBinding {
+        key: "f1",
+        modifiers: KeyModifiers::new(false, false, false),
+        scope: KeyScope::Global,
+        action: KeyAction::OpenHelp,
+        label: "F1",
+        description: "Help",
+    },
+    KeyBinding {
+        key: "escape",
+        modifiers: KeyModifiers::new(false, false, false),
+        scope: KeyScope::Modal,
+        action: KeyAction::CloseOverlay,
+        label: "Escape",
+        description: "Close overlay",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Match a keystroke against global-scope bindings.
+/// Returns `Some(action)` if a binding matches, `None` otherwise.
+pub fn dispatch_global_key(key: &str, control: bool, shift: bool, alt: bool) -> Option<KeyAction> {
+    for binding in BINDINGS {
+        if binding.scope == KeyScope::Global
+            && binding.key == key
+            && binding.modifiers.matches(control, shift, alt)
+        {
+            return Some(binding.action);
+        }
+    }
+    None
+}
+
+/// Match a keystroke against modal-scope bindings (e.g. Esc to close).
+pub fn dispatch_modal_key(key: &str, control: bool, shift: bool, alt: bool) -> Option<KeyAction> {
+    for binding in BINDINGS {
+        if binding.scope == KeyScope::Modal
+            && binding.key == key
+            && binding.modifiers.matches(control, shift, alt)
+        {
+            return Some(binding.action);
+        }
+    }
+    None
+}
+
+/// Generate help modal shortcut entries from the binding registry.
+/// Returns (label, description) pairs in display order.
+/// Includes the "Shift Shift" double-shift entry which is not a standard binding.
+pub fn help_shortcuts() -> Vec<(&'static str, &'static str)> {
+    let mut shortcuts: Vec<(&str, &str)> =
+        BINDINGS.iter().map(|b| (b.label, b.description)).collect();
+    // Double-shift is detected via modifiers_changed, not key_down,
+    // so it's not in the binding registry. Add it manually.
+    shortcuts.insert(1, ("Shift Shift", "Command palette"));
+    shortcuts
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn no_duplicate_bindings_in_same_scope() {
+        let mut seen: HashSet<(KeyScope, &str, bool, bool, bool)> = HashSet::new();
+        for binding in BINDINGS {
+            let key = (
+                binding.scope,
+                binding.key,
+                binding.modifiers.control,
+                binding.modifiers.shift,
+                binding.modifiers.alt,
+            );
+            assert!(
+                seen.insert(key),
+                "Duplicate binding: {:?} scope={:?} key={} ctrl={} shift={} alt={}",
+                binding.label,
+                binding.scope,
+                binding.key,
+                binding.modifiers.control,
+                binding.modifiers.shift,
+                binding.modifiers.alt,
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_k() {
+        let action = dispatch_global_key("k", true, false, false);
+        assert_eq!(action, Some(KeyAction::OpenCommandPalette(PaletteTab::All)));
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_tab() {
+        let action = dispatch_global_key("tab", true, false, false);
+        assert_eq!(action, Some(KeyAction::OpenSessionSwitcher));
+    }
+
+    #[test]
+    fn dispatch_global_f1() {
+        let action = dispatch_global_key("f1", false, false, false);
+        assert_eq!(action, Some(KeyAction::OpenHelp));
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_shift_e() {
+        let action = dispatch_global_key("e", true, true, false);
+        assert_eq!(
+            action,
+            Some(KeyAction::OpenCommandPalette(PaletteTab::Sessions))
+        );
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_shift_p() {
+        let action = dispatch_global_key("p", true, true, false);
+        assert_eq!(
+            action,
+            Some(KeyAction::OpenCommandPalette(PaletteTab::Projects))
+        );
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_shift_a() {
+        let action = dispatch_global_key("a", true, true, false);
+        assert_eq!(
+            action,
+            Some(KeyAction::OpenCommandPalette(PaletteTab::Actions))
+        );
+    }
+
+    #[test]
+    fn dispatch_global_ctrl_f() {
+        let action = dispatch_global_key("f", true, false, false);
+        assert_eq!(action, Some(KeyAction::OpenSearch));
+    }
+
+    #[test]
+    fn dispatch_modal_escape() {
+        let action = dispatch_modal_key("escape", false, false, false);
+        assert_eq!(action, Some(KeyAction::CloseOverlay));
+    }
+
+    #[test]
+    fn dispatch_unmatched_returns_none() {
+        assert_eq!(dispatch_global_key("z", false, false, false), None);
+        assert_eq!(dispatch_global_key("k", false, false, false), None);
+    }
+
+    #[test]
+    fn help_shortcuts_includes_all_bindings_plus_double_shift() {
+        let shortcuts = help_shortcuts();
+        // All bindings + 1 for double-shift
+        assert_eq!(shortcuts.len(), BINDINGS.len() + 1);
+        // Double-shift is at index 1 (after Ctrl+K)
+        assert_eq!(shortcuts[1], ("Shift Shift", "Command palette"));
+    }
+
+    #[test]
+    fn help_shortcuts_order_matches_bindings() {
+        let shortcuts = help_shortcuts();
+        // First entry is the first binding (Ctrl+K)
+        assert_eq!(shortcuts[0], ("Ctrl+K", "Command palette"));
+        // Skip index 1 (double-shift), rest match bindings 1..
+        for (i, binding) in BINDINGS.iter().enumerate().skip(1) {
+            assert_eq!(shortcuts[i + 1], (binding.label, binding.description));
+        }
+    }
+
+    // Scope must be Hash+Eq for the test above
+    impl std::hash::Hash for KeyScope {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            core::mem::discriminant(self).hash(state);
+        }
+    }
+}

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -20,6 +20,7 @@ use crate::views::command_palette::{
 };
 use crate::views::double_shift::DoubleShiftDetector;
 use crate::views::help_modal::{HelpModal, HelpModalEvent};
+use crate::views::key_bindings::{KeyAction, dispatch_global_key};
 use crate::views::session_switcher::{SessionSwitcher, SessionSwitcherEvent};
 use crate::views::settings_modal::{SettingsModal, SettingsModalEvent, SettingsTab};
 use crate::views::sidebar::SidebarView;
@@ -884,6 +885,31 @@ impl MainView {
         ]
     }
 
+    // -- Centralized keyboard dispatch -------------------------------------------
+
+    fn handle_global_action(&mut self, action: KeyAction, cx: &mut Context<Self>) {
+        match action {
+            KeyAction::OpenCommandPalette(tab) => self.open_command_palette(tab, cx),
+            KeyAction::OpenSessionSwitcher => self.open_session_switcher(cx),
+            KeyAction::OpenSearch => {
+                // Search is terminal-panel-scoped; no-op when no terminal is focused
+            }
+            KeyAction::OpenHelp => self.open_help_modal(cx),
+            KeyAction::CloseOverlay => {
+                // Close topmost modal
+                if self.command_palette.is_some() {
+                    self.close_command_palette(cx);
+                } else if self.session_switcher.is_some() {
+                    self.close_session_switcher(cx);
+                } else if self.help_modal.is_some() {
+                    self.close_help_modal(cx);
+                } else if self.settings_modal.is_some() {
+                    self.close_settings_modal(cx);
+                }
+            }
+        }
+    }
+
     // -- Command palette ---------------------------------------------------------
 
     fn open_command_palette(&mut self, tab: PaletteTab, cx: &mut Context<Self>) {
@@ -1405,18 +1431,10 @@ impl MainView {
 
                         this.double_shift.on_key_down_during_shift();
 
-                        if mods.control && !mods.shift && key == "tab" {
-                            this.open_session_switcher(cx);
-                        } else if mods.control && !mods.shift && key == "k" {
-                            this.open_command_palette(PaletteTab::All, cx);
-                        } else if mods.control && mods.shift && key == "e" {
-                            this.open_command_palette(PaletteTab::Sessions, cx);
-                        } else if mods.control && mods.shift && key == "p" {
-                            this.open_command_palette(PaletteTab::Projects, cx);
-                        } else if mods.control && mods.shift && key == "a" {
-                            this.open_command_palette(PaletteTab::Actions, cx);
-                        } else if !mods.control && !mods.shift && !mods.alt && key == "f1" {
-                            this.open_help_modal(cx);
+                        if let Some(action) =
+                            dispatch_global_key(key, mods.control, mods.shift, mods.alt)
+                        {
+                            this.handle_global_action(action, cx);
                         }
                     }))
                     .on_modifiers_changed(cx.listener(

--- a/crates/zremote-gui/src/views/mod.rs
+++ b/crates/zremote-gui/src/views/mod.rs
@@ -3,6 +3,7 @@ pub mod command_palette;
 pub mod double_shift;
 pub mod fuzzy;
 pub mod help_modal;
+pub mod key_bindings;
 pub mod main_view;
 pub mod search_overlay;
 pub mod session_switcher;

--- a/crates/zremote-gui/src/views/settings_modal.rs
+++ b/crates/zremote-gui/src/views/settings_modal.rs
@@ -17,6 +17,7 @@ use gpui::*;
 use crate::app_state::AppState;
 use crate::icons::{Icon, icon};
 use crate::theme;
+use crate::views::key_bindings::{KeyAction, dispatch_modal_key};
 use crate::views::settings::agent_profiles_tab::{AgentProfilesTab, AgentProfilesTabEvent};
 use zremote_client::{AgentKindInfo, AgentProfile};
 
@@ -195,7 +196,11 @@ impl Render for SettingsModal {
             .flex_col()
             .size_full()
             .on_key_down(cx.listener(|_this, event: &KeyDownEvent, _window, cx| {
-                if event.keystroke.key.as_str() == "escape" {
+                let key = event.keystroke.key.as_str();
+                let mods = &event.keystroke.modifiers;
+                if let Some(KeyAction::CloseOverlay) =
+                    dispatch_modal_key(key, mods.control, mods.shift, mods.alt)
+                {
                     cx.emit(SettingsModalEvent::Close);
                     cx.stop_propagation();
                 }

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -61,6 +61,7 @@ use crate::terminal_handle::{InputSender, TerminalHandle};
 use crate::theme;
 use crate::views::command_palette::PaletteTab;
 use crate::views::double_shift::DoubleShiftDetector;
+use crate::views::key_bindings::{KeyAction, dispatch_global_key};
 use crate::views::terminal_element::{CellRunCache, GlyphCache, TerminalElement};
 use crate::views::url_detector::UrlDetector;
 use zremote_client::{AgenticStatus, TerminalEvent};
@@ -1317,79 +1318,30 @@ impl Render for TerminalPanel {
 
                     double_shift_kd.on_key_down_during_shift();
 
-                    // Ctrl+F: open search
-                    if mods.control && !mods.shift && key == "f" {
-                        let _ = entity.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            this.open_search(cx);
-                        });
-                        return;
-                    }
-
-                    // Ctrl+Tab: session switcher
-                    if mods.control && !mods.shift && !mods.alt && key == "tab" {
-                        let _ = entity.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
-                            cx.emit(TerminalPanelEvent::OpenSessionSwitcher);
-                        });
-                        return;
-                    }
-
-                    // Ctrl+K: open command palette (All tab)
-                    if mods.control && !mods.shift && !mods.alt && key == "k" {
-                        let _ = entity.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.search_open {
-                                this.close_search(cx);
-                            }
-                            cx.emit(TerminalPanelEvent::OpenCommandPalette {
-                                tab: PaletteTab::All,
-                            });
-                        });
-                        return;
-                    }
-
-                    // Ctrl+Shift+E: open command palette (Sessions tab)
-                    if mods.control && mods.shift && !mods.alt && key == "e" {
-                        let _ = entity.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.search_open {
-                                this.close_search(cx);
-                            }
-                            cx.emit(TerminalPanelEvent::OpenCommandPalette {
-                                tab: PaletteTab::Sessions,
-                            });
-                        });
-                        return;
-                    }
-
-                    // Ctrl+Shift+P: open command palette (Projects tab)
-                    if mods.control && mods.shift && !mods.alt && key == "p" {
-                        let _ = entity.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.search_open {
-                                this.close_search(cx);
-                            }
-                            cx.emit(TerminalPanelEvent::OpenCommandPalette {
-                                tab: PaletteTab::Projects,
-                            });
-                        });
-                        return;
-                    }
-
-                    // F1: open help modal
-                    if !mods.control && !mods.shift && !mods.alt && key == "f1" {
-                        let _ = entity.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
-                            cx.emit(TerminalPanelEvent::OpenHelp);
-                        });
-                        return;
-                    }
-
-                    // Ctrl+Shift+A: open command palette (Actions tab)
-                    if mods.control && mods.shift && !mods.alt && key == "a" {
-                        let _ = entity.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.search_open {
-                                this.close_search(cx);
-                            }
-                            cx.emit(TerminalPanelEvent::OpenCommandPalette {
-                                tab: PaletteTab::Actions,
-                            });
-                        });
+                    // Global shortcuts via centralized dispatch
+                    if let Some(action) =
+                        dispatch_global_key(key, mods.control, mods.shift, mods.alt)
+                    {
+                        let _ =
+                            entity.update(
+                                cx,
+                                |this: &mut Self, cx: &mut Context<Self>| match action {
+                                    KeyAction::OpenSearch => this.open_search(cx),
+                                    KeyAction::OpenSessionSwitcher => {
+                                        cx.emit(TerminalPanelEvent::OpenSessionSwitcher);
+                                    }
+                                    KeyAction::OpenCommandPalette(tab) => {
+                                        if this.search_open {
+                                            this.close_search(cx);
+                                        }
+                                        cx.emit(TerminalPanelEvent::OpenCommandPalette { tab });
+                                    }
+                                    KeyAction::OpenHelp => {
+                                        cx.emit(TerminalPanelEvent::OpenHelp);
+                                    }
+                                    KeyAction::CloseOverlay => {}
+                                },
+                            );
                         return;
                     }
 

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -1342,6 +1342,7 @@ impl Render for TerminalPanel {
                                     KeyAction::CloseOverlay => {}
                                 },
                             );
+                        cx.stop_propagation();
                         return;
                     }
 

--- a/docs/rfc/rfc-005-centralized-keyboard-dispatch.md
+++ b/docs/rfc/rfc-005-centralized-keyboard-dispatch.md
@@ -1,0 +1,90 @@
+# RFC-005: Centralized Keyboard Dispatch
+
+## Context
+
+Keyboard shortcuts are duplicated across 3+ locations in the GUI. The same global shortcuts (Ctrl+K, Ctrl+Tab, Ctrl+Shift+E/P/A, F1) are defined in `main_view.rs` (empty state), `terminal_panel.rs`, and `command_palette/keybindings.rs`. This duplication causes maintenance burden and risk of inconsistency.
+
+## GPUI Constraint
+
+GPUI dispatches `on_key_down` events to the element that owns focus. There is no capture phase or global interceptor. When a modal opens, it steals focus, so its `on_key_down` handler receives events directly. This means we cannot have a single `on_key_down` handler on `MainView` that intercepts all events — child views that hold focus would never propagate keys upward.
+
+## Architecture
+
+### Shared binding registry (`key_bindings.rs`)
+
+A static registry of all keyboard bindings with their scope, keystroke pattern, and metadata (for help modal auto-generation). Bindings are data, not closures — the dispatch function matches keystrokes against the registry and returns an action enum.
+
+```rust
+pub struct KeyBinding {
+    pub key: &'static str,
+    pub modifiers: Modifiers,
+    pub scope: KeyScope,
+    pub label: &'static str,        // For help modal
+    pub description: &'static str,  // For help modal
+}
+
+pub enum KeyScope {
+    Global,          // Active everywhere (unless consumed by modal)
+    Terminal,        // Only when terminal has focus
+    CommandPalette,  // Only when palette is open
+    SearchOverlay,   // Only when search is open
+    SessionSwitcher, // Only when switcher is open
+    Modal,           // Any modal (Esc to close)
+}
+
+pub enum KeyAction {
+    OpenCommandPalette(PaletteTab),
+    OpenSessionSwitcher,
+    OpenSearch,
+    OpenHelp,
+    CloseOverlay,
+    // Terminal-scoped
+    CopySelection,
+    PasteClipboard,
+    // Palette-scoped
+    PaletteNavigateUp,
+    PaletteNavigateDown,
+    PaletteConfirm,
+    PaletteTabNext,
+    PaletteTabPrev,
+    // etc.
+    Unhandled,
+}
+```
+
+### Dispatch function
+
+A pure function `dispatch_key(key, modifiers, scope) -> KeyAction` that all handlers call instead of duplicating match logic. Each view's `on_key_down` passes its scope context and acts on the returned action.
+
+### Migration plan
+
+| Current handler | Migration |
+|---|---|
+| `main_view.rs` empty state `on_key_down` | Call `dispatch_key(..., Global)`, handle returned action |
+| `terminal_panel.rs` `on_key_down` global shortcuts | Call `dispatch_key(..., Global)` for the shared shortcuts. Keep PTY encoding inline |
+| `command_palette/keybindings.rs` toggle shortcuts | Call `dispatch_key(..., CommandPalette)` for Ctrl+K/E/P/A toggle. Keep navigation inline |
+| `help_modal.rs` Esc handler | Call `dispatch_key(..., Modal)` |
+| `settings_modal.rs` Esc handler | Call `dispatch_key(..., Modal)` |
+| `session_switcher.rs` Tab/Esc/modifiers | Keep inline (switcher-specific logic: Ctrl-release confirm, quick-switch) |
+| `search_overlay.rs` | Keep inline (char-by-char input, overlay-specific) |
+
+### Double-shift detection
+
+`DoubleShiftDetector` uses `on_modifiers_changed`, not `on_key_down`. Both MainView (empty state) and TerminalPanel have `on_modifiers_changed` handlers for double-shift. The shared dispatch module provides a helper that both locations call.
+
+### Help modal auto-generation
+
+The `SHORTCUTS` constant in `help_modal.rs` is replaced by a function that iterates the binding registry and generates the shortcut list. New bindings automatically appear in the help modal.
+
+### Conflict detection test
+
+A unit test iterates all bindings and verifies no two bindings with the same scope have identical keystroke patterns.
+
+## Phases
+
+1. Create `key_bindings.rs` with binding registry, `KeyAction` enum, `dispatch_key()` function
+2. Migrate `main_view.rs` and `terminal_panel.rs` global shortcuts to use dispatch
+3. Migrate `command_palette` toggle shortcuts
+4. Migrate modal Esc handlers (help, settings)
+5. Auto-generate help modal shortcuts
+6. Add conflict detection test


### PR DESCRIPTION
Closes #32

## Summary

- Created `key_bindings.rs` — a centralized binding registry (`BINDINGS` static array) with `dispatch_global_key()` and `dispatch_modal_key()` functions
- Migrated all global shortcut handling from 3 files (`main_view.rs`, `terminal_panel.rs`, `command_palette/keybindings.rs`) to use the shared dispatch
- Help modal shortcuts are now auto-generated from the registry via `help_shortcuts()`
- Modal Esc handling (`help_modal.rs`, `settings_modal.rs`) uses `dispatch_modal_key()`
- 12 unit tests including duplicate binding conflict detection

## Architecture

```
key_bindings.rs (single source of truth)
├── BINDINGS: &[KeyBinding]        — all shortcuts defined once
├── dispatch_global_key()          — called by main_view, terminal_panel, command_palette
├── dispatch_modal_key()           — called by help_modal, settings_modal
└── help_shortcuts()               — auto-generates help modal entries
```

## What's preserved (not migrated)

- **Double-shift detection** — uses `on_modifiers_changed`, orthogonal to key_down dispatch
- **Command palette navigation** — modal-scoped (arrows, enter, tab, backspace, printable chars)
- **Terminal PTY encoding** — `encode_keystroke` for passthrough to terminal
- **Session switcher Ctrl-release** — uses `on_modifiers_changed` for confirmation
- **Search overlay** — char-by-char input, component-specific

## Files changed

| File | Change |
|------|--------|
| `views/key_bindings.rs` | **NEW** — binding registry, dispatch, tests |
| `views/mod.rs` | Added `pub mod key_bindings` |
| `views/main_view.rs` | Replaced inline if/else chain with `dispatch_global_key()` |
| `views/terminal_panel.rs` | Replaced 7 shortcut blocks with single dispatch call |
| `views/command_palette/keybindings.rs` | Replaced 4 toggle blocks with dispatch call |
| `views/help_modal.rs` | Auto-generates shortcuts from registry, Esc via `dispatch_modal_key()` |
| `views/settings_modal.rs` | Esc via `dispatch_modal_key()` |
| `docs/rfc/rfc-005-*.md` | RFC documenting architecture and decisions |

## Test plan

- [x] 12 new unit tests in `key_bindings::tests` (dispatch, conflict detection, help generation)
- [x] Full `cargo test --workspace` passes (all 2272 tests)
- [x] `cargo clippy -D warnings` clean
- [x] Pre-commit hooks pass (fmt + clippy + test)