### PR TITLE
refactor(gui): async Task ownership convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,14 @@ Local mode CLI flags: `--port` (3000), `--db` (~/.zremote/local.db), `--bind` (1
 3. **Each helper returns `impl IntoElement`** (or `Option<AnyElement>` when conditionally rendered) and lives in the same `impl` block.
 4. **Use `.when()` / `.when_some()`** for conditional chaining instead of `if/else` breaking builder chains.
 
+### Async Task Ownership Convention
+
+- Every long-running async task (polling loop, WebSocket listener, timer, debounce) must be stored as a `Task<()>` field (or `Option<Task<()>>`) on the owning struct. Dropping the struct cancels the task automatically.
+- **No `.detach()` for long-lived work.** Detached tasks leak if the parent entity is dropped before the task's exit condition fires.
+- `.detach()` is OK for: fire-and-forget short work (single API call, show toast, open URL), `cx.subscribe()` results (GPUI manages their lifetime).
+- Use `cx.spawn()` for tasks that touch GPUI entity state. Use `cx.background_spawn()` for pure CPU/IO work (resize debounce, file reads).
+- Replacing a `Task<()>` field with a new task cancels the previous one — use this for reconnect/restart patterns instead of manual cancellation.
+
 ## Protocol Conventions
 
 - All message enums use `#[serde(tag = "type")]` for tagged JSON serialization.

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -67,6 +67,12 @@ pub struct MainView {
     last_viewed_session: Option<(String, String)>,
     /// Maps claude task_id to (session_id, host_id, project_path) for context on ClaudeTaskEnded.
     claude_task_sessions: HashMap<String, (String, String, String)>,
+    /// Owned event polling task — cancelled on drop.
+    _event_poller: Task<()>,
+    /// Owned loop reconciliation task — cancelled on drop.
+    _loop_reconciler: Task<()>,
+    /// Owned toast tick task — cancelled on drop.
+    _toast_ticker: Task<()>,
 }
 
 impl MainView {
@@ -77,10 +83,10 @@ impl MainView {
         cx.subscribe(&sidebar, Self::on_sidebar_event).detach();
 
         // Start polling server events
-        Self::start_event_polling(&app_state, cx);
+        let event_poller = Self::start_event_polling(&app_state, cx);
 
         // Start periodic loop reconciliation (fallback for missed WS events)
-        Self::start_loop_reconciliation(&sidebar, cx);
+        let loop_reconciler = Self::start_loop_reconciliation(&sidebar, cx);
 
         let toasts = cx.new(|_| ToastContainer::new());
 
@@ -96,7 +102,7 @@ impl MainView {
         .detach();
 
         // Start toast tick timer (removes expired toasts every second)
-        Self::start_toast_tick(&toasts, cx);
+        let toast_ticker = Self::start_toast_tick(&toasts, cx);
 
         let focus_handle = cx.focus_handle();
 
@@ -126,6 +132,9 @@ impl MainView {
             pending_waiting_notifications: HashMap::new(),
             last_viewed_session: None,
             claude_task_sessions: HashMap::new(),
+            _event_poller: event_poller,
+            _loop_reconciler: loop_reconciler,
+            _toast_ticker: toast_ticker,
         }
     }
 
@@ -203,7 +212,7 @@ impl MainView {
         cx.notify();
     }
 
-    fn start_event_polling(app_state: &Arc<AppState>, cx: &mut Context<Self>) {
+    fn start_event_polling(app_state: &Arc<AppState>, cx: &mut Context<Self>) -> Task<()> {
         let event_rx = app_state.event_rx.clone();
         cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             while let Ok(client_event) = event_rx.recv_async().await {
@@ -231,10 +240,12 @@ impl MainView {
                     );
             }
         })
-        .detach();
     }
 
-    fn start_loop_reconciliation(sidebar: &Entity<SidebarView>, cx: &mut Context<Self>) {
+    fn start_loop_reconciliation(
+        sidebar: &Entity<SidebarView>,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
         let sidebar = sidebar.clone();
         cx.spawn(async move |_this: WeakEntity<Self>, cx: &mut AsyncApp| {
             loop {
@@ -249,10 +260,9 @@ impl MainView {
                 }
             }
         })
-        .detach();
     }
 
-    fn start_toast_tick(toasts: &Entity<ToastContainer>, cx: &mut Context<Self>) {
+    fn start_toast_tick(toasts: &Entity<ToastContainer>, cx: &mut Context<Self>) -> Task<()> {
         let toasts = toasts.clone();
         cx.spawn(async move |_this: WeakEntity<Self>, cx: &mut AsyncApp| {
             loop {
@@ -267,7 +277,6 @@ impl MainView {
                 }
             }
         })
-        .detach();
     }
 
     /// Build a [`ToastContext`] by resolving human-readable names from IDs.

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -256,6 +256,10 @@ pub struct TerminalPanel {
     cc_status: Option<AgenticStatus>,
     /// Tokio runtime handle for spawning async tasks (coalescing, etc.).
     tokio_handle: tokio::runtime::Handle,
+    /// Owned resize debounce task — cancelled on drop or reconnect.
+    resize_debounce_task: Option<Task<()>>,
+    /// Owned PTY reader task — cancelled on drop or reconnect.
+    pty_reader_task: Option<Task<()>>,
 }
 
 impl TerminalPanel {
@@ -278,7 +282,7 @@ impl TerminalPanel {
         // tokio task forwards to real resize_tx after 150ms of inactivity.
         let (resize_debounce_tx, resize_debounce_rx) = flume::bounded::<(u16, u16)>(4);
         let real_resize_tx = handle.resize_tx().clone();
-        tokio_handle.spawn(async move {
+        let resize_debounce_task = cx.background_spawn(async move {
             let mut first_resize = true;
             loop {
                 // Wait for first resize event.
@@ -356,6 +360,8 @@ impl TerminalPanel {
             cc_metrics: None,
             cc_status: None,
             tokio_handle: tokio_handle.clone(),
+            resize_debounce_task: Some(resize_debounce_task),
+            pty_reader_task: None, // Set when start_output_reader() is called
         }
     }
 
@@ -475,9 +481,10 @@ impl TerminalPanel {
         self.tokio_handle = tokio_handle.clone();
 
         // Set up new resize debounce pipeline for the new handle.
+        // Replacing the task field cancels the previous debounce task.
         let (resize_debounce_tx, resize_debounce_rx) = flume::bounded::<(u16, u16)>(4);
         let real_resize_tx = self.handle.resize_tx().clone();
-        tokio_handle.spawn(async move {
+        self.resize_debounce_task = Some(cx.background_spawn(async move {
             let mut first_resize = true;
             loop {
                 let Ok(mut dims) = resize_debounce_rx.recv_async().await else {
@@ -510,7 +517,7 @@ impl TerminalPanel {
                     }
                 }
             }
-        });
+        }));
         self.resize_debounce_tx = resize_debounce_tx;
 
         // Trigger immediate resize to sync the new connection with current terminal size.
@@ -530,6 +537,8 @@ impl TerminalPanel {
             return;
         }
         self.reader_started = true;
+        // Replacing the task field cancels any previous reader (e.g. after reconnect).
+        self.pty_reader_task = None;
 
         let output_rx = self.handle.output_rx().clone();
         let term = self.term.clone();
@@ -646,67 +655,68 @@ impl TerminalPanel {
         });
 
         // GPUI task: reads unified signal channel and updates UI accordingly.
-        cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
-            loop {
-                match gui_rx.recv_async().await {
-                    Ok(GuiSignal::Repaint) => {
-                        let _ = this.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
-                            cx.notify();
-                        });
-                    }
-                    Ok(GuiSignal::TitleChanged(new_title)) => {
-                        let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.terminal_title != new_title {
-                                this.terminal_title = new_title.clone();
-                                cx.emit(TerminalPanelEvent::TitleChanged {
-                                    session_id: this.session_id.clone(),
-                                    title: new_title,
-                                });
-                            }
-                        });
-                    }
-                    Ok(GuiSignal::Event(TerminalEvent::SessionClosed { .. })) => {
-                        let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            this.closed = true;
-                            cx.notify();
-                        });
-                        break;
-                    }
-                    Ok(GuiSignal::Event(TerminalEvent::ScrollbackEnd { .. })) => {
-                        let _ = this.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
-                            cx.notify();
-                        });
-                    }
-                    Ok(GuiSignal::Event(TerminalEvent::Error { message })) => {
-                        let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            if this.handle.is_bridge() {
-                                let sid = this.session_id.clone();
-                                cx.emit(TerminalPanelEvent::BridgeFailed { session_id: sid });
-                            } else {
-                                this.error_message = Some(message);
+        self.pty_reader_task = Some(cx.spawn(
+            async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
+                loop {
+                    match gui_rx.recv_async().await {
+                        Ok(GuiSignal::Repaint) => {
+                            let _ = this.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
+                                cx.notify();
+                            });
+                        }
+                        Ok(GuiSignal::TitleChanged(new_title)) => {
+                            let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
+                                if this.terminal_title != new_title {
+                                    this.terminal_title = new_title.clone();
+                                    cx.emit(TerminalPanelEvent::TitleChanged {
+                                        session_id: this.session_id.clone(),
+                                        title: new_title,
+                                    });
+                                }
+                            });
+                        }
+                        Ok(GuiSignal::Event(TerminalEvent::SessionClosed { .. })) => {
+                            let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
                                 this.closed = true;
                                 cx.notify();
-                            }
-                        });
-                        // Always break: for bridge errors, reconnect() starts a fresh reader;
-                        // for other errors, the terminal is closed.
-                        break;
+                            });
+                            break;
+                        }
+                        Ok(GuiSignal::Event(TerminalEvent::ScrollbackEnd { .. })) => {
+                            let _ = this.update(cx, |_this: &mut Self, cx: &mut Context<Self>| {
+                                cx.notify();
+                            });
+                        }
+                        Ok(GuiSignal::Event(TerminalEvent::Error { message })) => {
+                            let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
+                                if this.handle.is_bridge() {
+                                    let sid = this.session_id.clone();
+                                    cx.emit(TerminalPanelEvent::BridgeFailed { session_id: sid });
+                                } else {
+                                    this.error_message = Some(message);
+                                    this.closed = true;
+                                    cx.notify();
+                                }
+                            });
+                            // Always break: for bridge errors, reconnect() starts a fresh reader;
+                            // for other errors, the terminal is closed.
+                            break;
+                        }
+                        Ok(GuiSignal::Event(TerminalEvent::Disconnected)) => {
+                            let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
+                                this.disconnected = true;
+                                cx.notify();
+                            });
+                            break;
+                        }
+                        Ok(GuiSignal::Event(_)) => {
+                            // Pane and suspension events not yet handled
+                        }
+                        Err(_) => break,
                     }
-                    Ok(GuiSignal::Event(TerminalEvent::Disconnected)) => {
-                        let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
-                            this.disconnected = true;
-                            cx.notify();
-                        });
-                        break;
-                    }
-                    Ok(GuiSignal::Event(_)) => {
-                        // Pane and suspension events not yet handled
-                    }
-                    Err(_) => break,
                 }
-            }
-        })
-        .detach();
+            },
+        ));
     }
 
     /// Start the cursor blink timer. Spawns an async loop that toggles

--- a/docs/rfc/rfc-006-async-task-ownership.md
+++ b/docs/rfc/rfc-006-async-task-ownership.md
@@ -1,0 +1,44 @@
+# RFC-006: Async Task Ownership Convention
+
+**Status:** Implemented
+**Issue:** #34
+**Date:** 2026-04-11
+
+## Context
+
+GPUI's `Task<()>` type implements `Drop` to cancel the underlying future. When a struct field holds a `Task<()>`, the task is automatically cancelled when the struct is dropped. This is the correct pattern for long-running async work tied to an entity's lifetime.
+
+The codebase had several long-running async tasks that called `.detach()` instead of being stored as fields. While each had proper exit conditions (channel close, entity drop check), `.detach()` means the task can outlive its parent entity if the exit condition races with the drop.
+
+## Audit Results
+
+### Converted (6 tasks)
+
+**TerminalPanel** (`terminal_panel.rs`):
+1. **Resize debounce** (constructor) — `tokio_handle.spawn()` → `cx.background_spawn()` stored as `_resize_debounce_task: Option<Task<()>>`
+2. **Resize debounce** (reconnect) — same pattern, replacing the field cancels the old task
+3. **PTY reader** (`start_output_reader`) — `cx.spawn().detach()` → stored as `_pty_reader_task: Option<Task<()>>`
+
+**MainView** (`main_view.rs`):
+4. **Event polling loop** (`start_event_polling`) — `cx.spawn().detach()` → stored as `_event_poller: Task<()>`
+5. **Loop reconciliation** (`start_loop_reconciliation`) — `cx.spawn().detach()` → stored as `_loop_reconciler: Task<()>`
+6. **Toast tick timer** (`start_toast_tick`) — `cx.spawn().detach()` → stored as `_toast_ticker: Task<()>`
+
+### Already correct (not touched)
+
+- `pending_waiting_notifications: HashMap<String, Task<()>>` in MainView — already owned
+- Short fire-and-forget `.detach()` calls in sidebar.rs, agent_profiles_tab.rs — single API calls, correct
+- `cx.subscribe().detach()` calls — GPUI manages subscription lifetime
+- `lib.rs:155` exit timer — fire-and-forget by design
+
+## Convention (added to CLAUDE.md)
+
+1. Every long-running async task → `Task<()>` field (or `Option<Task<()>>`)
+2. No `.detach()` for polling loops, WebSocket listeners, timers
+3. `.detach()` OK for: fire-and-forget short work, `cx.subscribe()` results
+4. Use `cx.spawn` for state-touching tasks, `cx.background_spawn` for CPU/IO
+5. Replacing a `Task<()>` field cancels the previous task automatically
+
+## Risk Assessment
+
+**Low risk.** No behavior change — all converted tasks had proper exit conditions already. The only difference is that tasks now cancel deterministically on struct drop instead of racing with their exit condition.

--- a/docs/rfc/rfc-006-async-task-ownership.md
+++ b/docs/rfc/rfc-006-async-task-ownership.md
@@ -15,9 +15,9 @@ The codebase had several long-running async tasks that called `.detach()` instea
 ### Converted (6 tasks)
 
 **TerminalPanel** (`terminal_panel.rs`):
-1. **Resize debounce** (constructor) — `tokio_handle.spawn()` → `cx.background_spawn()` stored as `_resize_debounce_task: Option<Task<()>>`
+1. **Resize debounce** (constructor) — `tokio_handle.spawn()` → `cx.background_spawn()` stored as `resize_debounce_task: Option<Task<()>>`
 2. **Resize debounce** (reconnect) — same pattern, replacing the field cancels the old task
-3. **PTY reader** (`start_output_reader`) — `cx.spawn().detach()` → stored as `_pty_reader_task: Option<Task<()>>`
+3. **PTY reader** (`start_output_reader`) — `cx.spawn().detach()` → stored as `pty_reader_task: Option<Task<()>>`
 
 **MainView** (`main_view.rs`):
 4. **Event polling loop** (`start_event_polling`) — `cx.spawn().detach()` → stored as `_event_poller: Task<()>`


### PR DESCRIPTION
Closes #34

## Summary

- Converted 6 long-running `.detach()`ed async tasks to owned `Task<()>` fields for cancel-on-drop semantics
- Added "Async Task Ownership Convention" to CLAUDE.md
- Wrote RFC-006 documenting the audit and convention

## Fields added

**TerminalPanel:**
- `resize_debounce_task: Option<Task<()>>` — resize debounce loop (cancelled on drop or reconnect)
- `pty_reader_task: Option<Task<()>>` — PTY output reader + GUI signal loop (cancelled on drop or reconnect)

**MainView:**
- `_event_poller: Task<()>` — server event polling loop
- `_loop_reconciler: Task<()>` — periodic loop reconciliation
- `_toast_ticker: Task<()>` — 1s toast expiry timer

## Tasks converted

| # | File | Task | Before | After |
|---|------|------|--------|-------|
| 1 | terminal_panel.rs:281 | Resize debounce (init) | `tokio_handle.spawn()` | `cx.background_spawn()` stored |
| 2 | terminal_panel.rs:487 | Resize debounce (reconnect) | `tokio_handle.spawn()` | `cx.background_spawn()` stored |
| 3 | terminal_panel.rs:658 | PTY reader GPUI loop | `cx.spawn().detach()` | `cx.spawn()` stored |
| 4 | main_view.rs:208 | Event polling | `cx.spawn().detach()` | return `Task<()>` |
| 5 | main_view.rs:239 | Loop reconciliation | `cx.spawn().detach()` | return `Task<()>` |
| 6 | main_view.rs:257 | Toast tick | `cx.spawn().detach()` | return `Task<()>` |

## What was NOT touched (already correct)

- `pending_waiting_notifications: HashMap<String, Task<()>>` — already owned
- Short fire-and-forget `.detach()` in sidebar.rs, agent_profiles_tab.rs
- `cx.subscribe().detach()` calls (GPUI manages lifetime)
- `lib.rs:155` exit timer (fire-and-forget by design)

## Test plan

- [x] `cargo clippy -D warnings` clean
- [x] `cargo test --workspace` — 2368 tests pass
- [x] Pre-commit hooks pass (fmt + clippy + test)
- [x] No behavior change — all converted tasks had proper exit conditions already