### PR TITLE
fix: scope PTY socket directory to agent instance

### DIFF
--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -1484,7 +1484,11 @@ mod tests {
         std::collections::HashMap<SessionId, OutputAnalyzer>,
     ) {
         let (pty_tx, _pty_rx) = mpsc::channel(16);
-        let session_manager = SessionManager::new(pty_tx, crate::config::PersistenceBackend::None);
+        let session_manager = SessionManager::new(
+            pty_tx,
+            crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
+        );
         let agentic_manager = AgenticLoopManager::new();
         let project_scanner = ProjectScanner::new();
         let (outbound_tx, outbound_rx) = mpsc::channel(16);

--- a/crates/zremote-agent/src/daemon/discovery.rs
+++ b/crates/zremote-agent/src/daemon/discovery.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -8,8 +8,6 @@ use zremote_protocol::SessionId;
 use super::DaemonStateFile;
 use super::session::DaemonSession;
 use crate::session::PtyOutput;
-
-use super::socket_dir;
 
 /// Maximum number of reconnect attempts per daemon session during discovery.
 const RECONNECT_MAX_ATTEMPTS: u32 = 3;
@@ -27,8 +25,9 @@ const RECONNECT_RETRY_DELAY: Duration = Duration::from_millis(500);
 pub async fn discover_daemon_sessions(
     output_tx: mpsc::Sender<PtyOutput>,
     already_tracked: &HashSet<SessionId>,
+    socket_dir: &Path,
 ) -> Vec<(DaemonSession, Option<Vec<u8>>)> {
-    let dir = socket_dir();
+    let dir = socket_dir.to_path_buf();
     if !dir.exists() {
         return Vec::new();
     }
@@ -170,8 +169,8 @@ pub async fn discover_daemon_sessions(
 ///
 /// Removes files for daemons that are no longer running, with a 24-hour
 /// staleness threshold to avoid removing files from very recently started daemons.
-pub fn cleanup_stale_daemons() {
-    let dir = socket_dir();
+pub fn cleanup_stale_daemons(socket_dir: &Path) {
+    let dir = socket_dir.to_path_buf();
     if !dir.exists() {
         return;
     }
@@ -359,10 +358,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn socket_dir_format() {
-        let dir = socket_dir();
+    fn socket_dir_is_scoped_by_instance_key() {
         let uid = nix::unistd::getuid();
-        assert_eq!(dir, PathBuf::from(format!("/tmp/zremote-pty-{uid}")));
+        let dir = super::super::socket_dir("test-key");
+        let s = dir.to_string_lossy();
+        assert!(s.starts_with(&format!("/tmp/zremote-pty-{uid}-")));
     }
 
     #[test]
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn cleanup_stale_daemons_no_dir() {
         // Should not panic when directory doesn't exist
-        cleanup_stale_daemons();
+        cleanup_stale_daemons(Path::new("/tmp/zremote-no-such-dir"));
     }
 
     #[test]
@@ -694,22 +694,21 @@ mod tests {
 
     #[tokio::test]
     async fn discover_empty_dir() {
-        // Create a temp dir and override socket_dir logic by directly testing
-        // that discover returns empty when the socket dir has no state files.
         let tmp = tempfile::tempdir().unwrap();
-        // Verify no .json files yields empty results
-        let entries = std::fs::read_dir(tmp.path()).unwrap();
-        let json_count = entries
-            .flatten()
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-            .count();
-        assert_eq!(json_count, 0, "temp dir should have no json files");
-
-        // The actual discover_daemon_sessions uses a fixed socket_dir(),
-        // so we just verify it doesn't panic with whatever state exists.
         let (tx, _rx) = mpsc::channel(64);
-        let result = discover_daemon_sessions(tx, &HashSet::new()).await;
-        // Result depends on environment, but must not panic
-        drop(result);
+        let result = discover_daemon_sessions(tx, &HashSet::new(), tmp.path()).await;
+        assert!(result.is_empty(), "empty dir should yield no sessions");
+    }
+
+    #[tokio::test]
+    async fn discover_nonexistent_dir() {
+        let (tx, _rx) = mpsc::channel(64);
+        let result =
+            discover_daemon_sessions(tx, &HashSet::new(), Path::new("/tmp/zremote-no-such-dir"))
+                .await;
+        assert!(
+            result.is_empty(),
+            "nonexistent dir should yield no sessions"
+        );
     }
 }

--- a/crates/zremote-agent/src/daemon/mod.rs
+++ b/crates/zremote-agent/src/daemon/mod.rs
@@ -34,8 +34,26 @@ pub struct DaemonStateFile {
     pub started_at: String,
 }
 
-/// Return the socket directory for the current user.
-pub fn socket_dir() -> PathBuf {
+/// Return a scoped socket directory for the current user and agent instance.
+///
+/// The directory name includes a hash of `instance_key` (the canonical DB path
+/// in local mode, or the server URL in server mode) so that two agent instances
+/// on the same machine use separate socket namespaces and never collide.
+pub fn socket_dir(instance_key: &str) -> PathBuf {
+    let uid = nix::unistd::getuid();
+    let hash = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, instance_key.as_bytes());
+    let b = hash.as_bytes();
+    let short = format!(
+        "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]
+    );
+    PathBuf::from(format!("/tmp/zremote-pty-{uid}-{short}"))
+}
+
+/// Return the legacy (pre-scoping) socket directory path.
+///
+/// Used only for migration warnings when upgrading from an older agent version.
+pub fn legacy_socket_dir() -> PathBuf {
     let uid = nix::unistd::getuid();
     PathBuf::from(format!("/tmp/zremote-pty-{uid}"))
 }
@@ -623,10 +641,76 @@ mod tests {
     }
 
     #[test]
-    fn socket_dir_format() {
+    fn socket_dir_is_scoped_by_instance_key() {
         let uid = nix::unistd::getuid();
-        let dir = socket_dir();
+        let dir = socket_dir("test-key");
+        let s = dir.to_string_lossy();
+        assert!(s.starts_with(&format!("/tmp/zremote-pty-{uid}-")));
+        // Hash suffix should be 16 hex chars (8 bytes)
+        let suffix = s.strip_prefix(&format!("/tmp/zremote-pty-{uid}-")).unwrap();
+        assert_eq!(suffix.len(), 16, "hash suffix should be 16 hex chars");
+    }
+
+    #[test]
+    fn socket_dir_different_keys_produce_different_dirs() {
+        let dir_a = socket_dir("key-a");
+        let dir_b = socket_dir("key-b");
+        assert_ne!(dir_a, dir_b);
+    }
+
+    #[test]
+    fn socket_dir_same_key_is_deterministic() {
+        let dir1 = socket_dir("same-key");
+        let dir2 = socket_dir("same-key");
+        assert_eq!(dir1, dir2);
+    }
+
+    #[test]
+    fn socket_dir_db_path_key() {
+        let dir = socket_dir("/home/user/.zremote/local.db");
+        let uid = nix::unistd::getuid();
+        assert!(
+            dir.to_string_lossy()
+                .starts_with(&format!("/tmp/zremote-pty-{uid}-"))
+        );
+    }
+
+    #[test]
+    fn socket_dir_server_url_key() {
+        let dir = socket_dir("ws://myserver:3000/ws/agent");
+        let uid = nix::unistd::getuid();
+        assert!(
+            dir.to_string_lossy()
+                .starts_with(&format!("/tmp/zremote-pty-{uid}-"))
+        );
+    }
+
+    #[test]
+    fn socket_dir_path_under_macos_limit() {
+        // Longest realistic instance key
+        let long_key = "a".repeat(500);
+        let dir = socket_dir(&long_key);
+        // Socket path = dir + "/" + uuid + ".sock" ≈ dir + 42 chars
+        let socket_path = dir.join("00000000-0000-0000-0000-000000000000.sock");
+        assert!(
+            socket_path.to_string_lossy().len() < 104,
+            "socket path must be < 104 bytes (macOS sun_path limit), got {}",
+            socket_path.to_string_lossy().len()
+        );
+    }
+
+    #[test]
+    fn legacy_socket_dir_has_no_hash() {
+        let uid = nix::unistd::getuid();
+        let dir = legacy_socket_dir();
         assert_eq!(dir, PathBuf::from(format!("/tmp/zremote-pty-{uid}")));
+    }
+
+    #[test]
+    fn legacy_and_scoped_differ() {
+        let legacy = legacy_socket_dir();
+        let scoped = socket_dir("any-key");
+        assert_ne!(legacy, scoped);
     }
 
     #[test]

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -115,10 +115,52 @@ impl DaemonSession {
         // Ensure socket directory exists before opening log file
         {
             use std::os::unix::fs::DirBuilderExt;
-            let _ = std::fs::DirBuilder::new()
+            use std::os::unix::fs::MetadataExt;
+            if let Err(e) = std::fs::DirBuilder::new()
                 .recursive(true)
                 .mode(0o700)
-                .create(sock_dir);
+                .create(sock_dir)
+                .or_else(|e| {
+                    if e.kind() == std::io::ErrorKind::AlreadyExists {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                })
+            {
+                return Err(format!(
+                    "failed to create socket directory {}: {e}",
+                    sock_dir.display()
+                )
+                .into());
+            }
+
+            // Verify the directory is safe: not a symlink and owned by us
+            let meta = std::fs::symlink_metadata(sock_dir).map_err(|e| {
+                format!(
+                    "failed to stat socket directory {}: {e}",
+                    sock_dir.display()
+                )
+            })?;
+            if meta.file_type().is_symlink() {
+                return Err(format!(
+                    "socket directory {} is a symlink — refusing to use it \
+                     (possible symlink attack)",
+                    sock_dir.display()
+                )
+                .into());
+            }
+            let uid = nix::unistd::getuid();
+            if meta.uid() != uid.as_raw() {
+                return Err(format!(
+                    "socket directory {} is owned by uid {}, expected {} — \
+                     refusing to use it",
+                    sock_dir.display(),
+                    meta.uid(),
+                    uid
+                )
+                .into());
+            }
         }
 
         // Open per-session log file for daemon stderr (diagnostics)

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -44,6 +44,7 @@ impl DaemonSession {
         env: Option<&std::collections::HashMap<String, String>>,
         output_tx: mpsc::Sender<PtyOutput>,
         shell_config: Option<&ShellIntegrationConfig>,
+        sock_dir: &std::path::Path,
     ) -> Result<(Self, u32), Box<dyn std::error::Error + Send + Sync>> {
         // Use current_exe() for binary name detection, but /proc/PID/exe for
         // the actual spawn path on Linux. After recompilation, cargo replaces
@@ -55,8 +56,6 @@ impl DaemonSession {
         } else {
             resolved_exe.clone()
         };
-        let uid = nix::unistd::getuid();
-        let sock_dir = PathBuf::from(format!("/tmp/zremote-pty-{uid}"));
         let socket_path = sock_dir.join(format!("{session_id}.sock"));
         let state_path = sock_dir.join(format!("{session_id}.json"));
         let log_path = sock_dir.join(format!("{session_id}.log"));
@@ -119,7 +118,7 @@ impl DaemonSession {
             let _ = std::fs::DirBuilder::new()
                 .recursive(true)
                 .mode(0o700)
-                .create(&sock_dir);
+                .create(sock_dir);
         }
 
         // Open per-session log file for daemon stderr (diagnostics)
@@ -513,13 +512,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn socket_dir_contains_uid() {
+    fn socket_dir_contains_uid_and_hash() {
         let uid = nix::unistd::getuid();
-        let dir = super::super::socket_dir();
+        let dir = super::super::socket_dir("test-instance");
+        let s = dir.to_string_lossy();
         assert!(
-            dir.to_string_lossy().contains(&uid.to_string()),
-            "socket dir should contain uid: {}",
-            dir.display()
+            s.contains(&uid.to_string()),
+            "socket dir should contain uid: {s}"
+        );
+        // Should have a hash suffix after the uid
+        assert!(
+            s.starts_with(&format!("/tmp/zremote-pty-{uid}-")),
+            "socket dir should have hash suffix: {s}"
         );
     }
 

--- a/crates/zremote-agent/src/lib.rs
+++ b/crates/zremote-agent/src/lib.rs
@@ -390,7 +390,21 @@ async fn run_agent() {
     // when full rather than blocking. With 4KB chunks this buffers ~16MB before
     // dropping, enough for most reconnect windows (backoff up to 300s).
     let (pty_output_tx, mut pty_output_rx) = tokio::sync::mpsc::channel::<session::PtyOutput>(4096);
-    let mut session_manager = session::SessionManager::new(pty_output_tx, backend);
+    let socket_dir = daemon::socket_dir(config.server_url.as_str());
+
+    // Warn about legacy global socket directory (pre-scoping)
+    let legacy_dir = daemon::legacy_socket_dir();
+    if legacy_dir.exists() && !socket_dir.exists() {
+        tracing::warn!(
+            legacy_dir = %legacy_dir.display(),
+            scoped_dir = %socket_dir.display(),
+            "found legacy global PTY socket directory; sessions from a previous \
+             agent version will not be recovered automatically — they will be \
+             cleaned up when those daemon processes exit"
+        );
+    }
+
+    let mut session_manager = session::SessionManager::new(pty_output_tx, backend, socket_dir);
     let mut agentic_manager = agentic::manager::AgenticLoopManager::new();
     let session_mapper = hooks::mapper::SessionMapper::new();
     let sent_cc_session_ids = std::sync::Arc::new(tokio::sync::RwLock::new(

--- a/crates/zremote-agent/src/local/mod.rs
+++ b/crates/zremote-agent/src/local/mod.rs
@@ -101,6 +101,22 @@ pub async fn run_local(
         }
     }
 
+    // Compute scoped socket directory from canonical DB path
+    let canonical_db = std::fs::canonicalize(&db_file).unwrap_or_else(|_| db_file.clone());
+    let socket_dir = crate::daemon::socket_dir(&canonical_db.display().to_string());
+
+    // Warn about legacy global socket directory (pre-scoping)
+    let legacy_dir = crate::daemon::legacy_socket_dir();
+    if legacy_dir.exists() && !socket_dir.exists() {
+        tracing::warn!(
+            legacy_dir = %legacy_dir.display(),
+            scoped_dir = %socket_dir.display(),
+            "found legacy global PTY socket directory; sessions from a previous \
+             agent version will not be recovered automatically — they will be \
+             cleaned up when those daemon processes exit"
+        );
+    }
+
     // Create application state
     let state = LocalAppState::new(
         pool.clone(),
@@ -108,6 +124,7 @@ pub async fn run_local(
         host_id,
         shutdown.clone(),
         backend,
+        socket_dir,
     );
 
     // === Session recovery ===
@@ -399,6 +416,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let router = build_router(state).unwrap();
@@ -428,6 +446,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let router = build_router(state).unwrap();
@@ -461,6 +480,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let router = build_router(state).unwrap();
@@ -496,6 +516,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let router = build_router(state).unwrap();

--- a/crates/zremote-agent/src/local/mod.rs
+++ b/crates/zremote-agent/src/local/mod.rs
@@ -102,7 +102,11 @@ pub async fn run_local(
     }
 
     // Compute scoped socket directory from canonical DB path
-    let canonical_db = std::fs::canonicalize(&db_file).unwrap_or_else(|_| db_file.clone());
+    let canonical_db = db_file
+        .parent()
+        .and_then(|p| std::fs::canonicalize(p).ok())
+        .and_then(|p| db_file.file_name().map(|name| p.join(name)))
+        .unwrap_or_else(|| db_file.clone());
     let socket_dir = crate::daemon::socket_dir(&canonical_db.display().to_string());
 
     // Warn about legacy global socket directory (pre-scoping)

--- a/crates/zremote-agent/src/local/routes/agent_profiles.rs
+++ b/crates/zremote-agent/src/local/routes/agent_profiles.rs
@@ -397,6 +397,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/agent_tasks.rs
+++ b/crates/zremote-agent/src/local/routes/agent_tasks.rs
@@ -299,6 +299,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/agentic.rs
+++ b/crates/zremote-agent/src/local/routes/agentic.rs
@@ -75,6 +75,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/channel.rs
+++ b/crates/zremote-agent/src/local/routes/channel.rs
@@ -140,6 +140,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/claude_sessions.rs
+++ b/crates/zremote-agent/src/local/routes/claude_sessions.rs
@@ -595,6 +595,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/config.rs
+++ b/crates/zremote-agent/src/local/routes/config.rs
@@ -126,6 +126,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/events.rs
+++ b/crates/zremote-agent/src/local/routes/events.rs
@@ -36,6 +36,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let mut rx = state.events.subscribe();

--- a/crates/zremote-agent/src/local/routes/health.rs
+++ b/crates/zremote-agent/src/local/routes/health.rs
@@ -43,6 +43,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/hosts.rs
+++ b/crates/zremote-agent/src/local/routes/hosts.rs
@@ -58,6 +58,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/knowledge.rs
+++ b/crates/zremote-agent/src/local/routes/knowledge.rs
@@ -355,6 +355,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/projects/tests.rs
+++ b/crates/zremote-agent/src/local/routes/projects/tests.rs
@@ -66,6 +66,7 @@ async fn test_state() -> Arc<LocalAppState> {
         host_id,
         shutdown,
         crate::config::PersistenceBackend::None,
+        std::path::PathBuf::from("/tmp/zremote-test"),
     )
 }
 

--- a/crates/zremote-agent/src/local/routes/sessions.rs
+++ b/crates/zremote-agent/src/local/routes/sessions.rs
@@ -532,6 +532,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/routes/terminal.rs
+++ b/crates/zremote-agent/src/local/routes/terminal.rs
@@ -278,6 +278,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         )
     }
 

--- a/crates/zremote-agent/src/local/state.rs
+++ b/crates/zremote-agent/src/local/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use sqlx::SqlitePool;
@@ -55,13 +56,14 @@ impl LocalAppState {
         host_id: Uuid,
         shutdown: CancellationToken,
         backend: crate::config::PersistenceBackend,
+        socket_dir: PathBuf,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(1024);
         let sessions = SessionStore::default();
         let agentic_loops = AgenticLoopStore::default();
 
         let (pty_output_tx, pty_output_rx) = mpsc::channel(4096);
-        let session_manager = SessionManager::new(pty_output_tx, backend);
+        let session_manager = SessionManager::new(pty_output_tx, backend, socket_dir);
 
         let agentic_manager = AgenticLoopManager::new();
         let session_mapper = SessionMapper::new();
@@ -111,6 +113,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         assert_eq!(state.hostname, "test-host");
@@ -128,6 +131,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         // Session store should be empty
@@ -149,6 +153,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         let mut rx = state.events.subscribe();
@@ -173,6 +178,7 @@ mod tests {
             host_id,
             shutdown,
             crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
         );
 
         // Agentic manager should be accessible

--- a/crates/zremote-agent/src/session.rs
+++ b/crates/zremote-agent/src/session.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use tokio::sync::mpsc;
 use zremote_protocol::SessionId;
@@ -31,16 +32,23 @@ pub struct SessionManager {
     shell_integrations: HashMap<SessionId, ShellIntegrationState>,
     output_tx: mpsc::Sender<PtyOutput>,
     backend: PersistenceBackend,
+    /// Scoped socket directory for daemon sessions.
+    socket_dir: PathBuf,
 }
 
 impl SessionManager {
-    pub fn new(output_tx: mpsc::Sender<PtyOutput>, backend: PersistenceBackend) -> Self {
+    pub fn new(
+        output_tx: mpsc::Sender<PtyOutput>,
+        backend: PersistenceBackend,
+        socket_dir: PathBuf,
+    ) -> Self {
         Self {
             sessions: HashMap::new(),
             shell_names: HashMap::new(),
             shell_integrations: HashMap::new(),
             output_tx,
             backend,
+            socket_dir,
         }
     }
 
@@ -76,6 +84,7 @@ impl SessionManager {
                     env,
                     self.output_tx.clone(),
                     shell_config,
+                    &self.socket_dir,
                 )
                 .await?;
                 self.sessions
@@ -258,12 +267,13 @@ impl SessionManager {
             PersistenceBackend::None => Vec::new(),
             PersistenceBackend::Daemon => {
                 // Clean up stale daemon files first
-                crate::daemon::discovery::cleanup_stale_daemons();
+                crate::daemon::discovery::cleanup_stale_daemons(&self.socket_dir);
 
                 let tracked_ids: HashSet<SessionId> = self.sessions.keys().copied().collect();
                 let recovered = crate::daemon::discovery::discover_daemon_sessions(
                     self.output_tx.clone(),
                     &tracked_ids,
+                    &self.socket_dir,
                 )
                 .await;
                 let mut result = Vec::new();
@@ -366,7 +376,11 @@ mod tests {
 
     fn make_manager() -> SessionManager {
         let (tx, _rx) = mpsc::channel(64);
-        SessionManager::new(tx, PersistenceBackend::None)
+        SessionManager::new(
+            tx,
+            PersistenceBackend::None,
+            PathBuf::from("/tmp/zremote-test"),
+        )
     }
 
     #[test]
@@ -419,10 +433,18 @@ mod tests {
     #[test]
     fn supports_persistence_returns_configured_value() {
         let (tx, _rx) = mpsc::channel(64);
-        let mgr_none = SessionManager::new(tx.clone(), PersistenceBackend::None);
+        let mgr_none = SessionManager::new(
+            tx.clone(),
+            PersistenceBackend::None,
+            PathBuf::from("/tmp/zremote-test"),
+        );
         assert!(!mgr_none.supports_persistence());
 
-        let mgr_daemon = SessionManager::new(tx, PersistenceBackend::Daemon);
+        let mgr_daemon = SessionManager::new(
+            tx,
+            PersistenceBackend::Daemon,
+            PathBuf::from("/tmp/zremote-test"),
+        );
         assert!(mgr_daemon.supports_persistence());
     }
 
@@ -497,7 +519,11 @@ mod tests {
     #[test]
     fn new_manager_with_daemon_backend() {
         let (tx, _rx) = mpsc::channel(64);
-        let mgr = SessionManager::new(tx, PersistenceBackend::Daemon);
+        let mgr = SessionManager::new(
+            tx,
+            PersistenceBackend::Daemon,
+            PathBuf::from("/tmp/zremote-test"),
+        );
         assert!(mgr.supports_persistence());
         assert_eq!(mgr.backend(), PersistenceBackend::Daemon);
         assert_eq!(mgr.count(), 0);


### PR DESCRIPTION
## Summary

- Scopes the PTY daemon socket directory per agent instance using a UUID v5 hash of the instance key (canonical DB path in local mode, server URL in server mode), preventing a second agent from silently killing PTY sessions owned by the first
- Threads the scoped `socket_dir` through `DaemonSession::spawn`, `discover_daemon_sessions`, `cleanup_stale_daemons`, `SessionManager`, and `LocalAppState`
- Adds legacy socket directory migration warning for agents upgrading from the old global `/tmp/zremote-pty-{uid}` layout

Closes #21

## Quality gates

- `cargo fmt --check` -- pass
- `cargo clippy --workspace -- -D warnings` -- pass
- `cargo test --workspace` -- 2388 tests pass, 0 failures

## Test plan

- [x] `socket_dir()` with different instance keys produces different directories
- [x] Same key is deterministic (same dir each time)
- [x] Hash suffix is 16 hex chars (8 bytes, 64 bits of entropy)
- [x] Socket path stays under macOS 104-byte sun_path limit
- [x] Legacy directory path unchanged (no hash suffix)
- [x] Legacy and scoped directories always differ
- [x] Discovery with empty/nonexistent directory returns no sessions
- [x] Cleanup with nonexistent directory does not panic
- [x] All existing tests pass (session creation, recovery, routes, state)