### PR TITLE
feat: suspend tasks on persistent-agent disconnect instead of error

### DIFF
--- a/crates/zremote-cli/src/commands/task.rs
+++ b/crates/zremote-cli/src/commands/task.rs
@@ -96,6 +96,14 @@ pub enum TaskCommand {
         #[arg(long)]
         force: bool,
     },
+    /// Manually resolve a suspended or errored task
+    Resolve {
+        /// Task ID to resolve
+        task_id: String,
+        /// Summary for the resolution
+        #[arg(long)]
+        summary: Option<String>,
+    },
     /// Show task output
     Log {
         /// Task ID
@@ -148,6 +156,15 @@ pub async fn run(
         TaskCommand::Get { task_id } => match client.get_claude_task(&task_id).await {
             Ok(task) => {
                 println!("{}", fmt.task(&task));
+                if let Some(ref reason) = task.disconnect_reason {
+                    println!("disconnect_reason: {reason}");
+                    if let Some(cost) = task.total_cost_usd {
+                        println!("  cost at disconnect: ${cost:.4}");
+                    }
+                    if task.loop_id.is_some() {
+                        println!("  loop was active at disconnect");
+                    }
+                }
                 0
             }
             Err(e) => {
@@ -292,6 +309,24 @@ pub async fn run(
             match client.cancel_claude_task(&task_id, force).await {
                 Ok(()) => {
                     println!("Task {task_id} cancelled");
+                    0
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
+            }
+        }
+        TaskCommand::Resolve { task_id, summary } => {
+            match client
+                .resolve_claude_task(&task_id, summary.as_deref())
+                .await
+            {
+                Ok(task) => {
+                    println!("Task {task_id} resolved successfully");
+                    if let Some(ref s) = task.summary {
+                        println!("Summary: {s}");
+                    }
                     0
                 }
                 Err(e) => {

--- a/crates/zremote-cli/src/format/llm.rs
+++ b/crates/zremote-cli/src/format/llm.rs
@@ -347,6 +347,7 @@ mod tests {
             task_name: None,
             created_at: "2025-01-01T00:00:00Z".to_string(),
             error_message: None,
+            disconnect_reason: None,
         }
     }
 

--- a/crates/zremote-cli/src/format/plain.rs
+++ b/crates/zremote-cli/src/format/plain.rs
@@ -117,6 +117,9 @@ impl Formatter for PlainFormatter {
         if let Some(ref err) = t.error_message {
             let _ = write!(result, "\nerror: {err}");
         }
+        if let Some(ref reason) = t.disconnect_reason {
+            let _ = write!(result, "\ndisconnect_reason: {reason}");
+        }
         result
     }
 

--- a/crates/zremote-client/src/client.rs
+++ b/crates/zremote-client/src/client.rs
@@ -1396,6 +1396,27 @@ impl ApiClient {
         Ok(())
     }
 
+    /// Manually resolve a suspended or errored Claude task.
+    pub async fn resolve_claude_task(
+        &self,
+        task_id: &str,
+        summary: Option<&str>,
+    ) -> Result<ClaudeTask, ApiError> {
+        let body = serde_json::json!({ "summary": summary });
+        let resp = self
+            .client
+            .post(format!(
+                "{}/api/claude-tasks/{}/resolve",
+                self.base_url,
+                encode_path(task_id)
+            ))
+            .json(&body)
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     /// Get task log (scrollback output).
     pub async fn get_task_log(&self, task_id: &str) -> Result<String, ApiError> {
         let resp = self

--- a/crates/zremote-client/src/types.rs
+++ b/crates/zremote-client/src/types.rs
@@ -189,6 +189,8 @@ pub struct ClaudeTask {
     pub created_at: String,
     #[serde(default)]
     pub error_message: Option<String>,
+    #[serde(default)]
+    pub disconnect_reason: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zremote-core/migrations/025_task_disconnect_reason.sql
+++ b/crates/zremote-core/migrations/025_task_disconnect_reason.sql
@@ -1,0 +1,2 @@
+-- Track why a task was interrupted (agent_disconnected, timeout, etc.)
+ALTER TABLE claude_sessions ADD COLUMN disconnect_reason TEXT;

--- a/crates/zremote-core/src/queries/claude_sessions.rs
+++ b/crates/zremote-core/src/queries/claude_sessions.rs
@@ -34,13 +34,14 @@ pub struct ClaudeTaskRow {
     pub lines_removed: Option<i64>,
     pub cc_version: Option<String>,
     pub error_message: Option<String>,
+    pub disconnect_reason: Option<String>,
 }
 
 const TASK_COLUMNS: &str = "id, session_id, host_id, project_path, project_id, model, initial_prompt, \
      claude_session_id, resume_from, status, options_json, loop_id, started_at, ended_at, \
      total_cost_usd, total_tokens_in, total_tokens_out, summary, task_name, created_at, \
      context_used_pct, context_window_size, rate_limit_5h_pct, rate_limit_7d_pct, \
-     lines_added, lines_removed, cc_version, error_message";
+     lines_added, lines_removed, cc_version, error_message, disconnect_reason";
 
 pub struct ListClaudeTasksFilter {
     pub host_id: Option<String>,

--- a/crates/zremote-protocol/src/claude.rs
+++ b/crates/zremote-protocol/src/claude.rs
@@ -12,6 +12,9 @@ pub enum ClaudeTaskStatus {
     Completed,
     Error,
     Suspended,
+    /// Forward-compatibility: unknown status from a newer server.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Discovered Claude Code session info (for resume).
@@ -168,6 +171,10 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ClaudeTaskStatus>(r#""suspended""#).unwrap(),
             ClaudeTaskStatus::Suspended
+        );
+        assert_eq!(
+            serde_json::from_str::<ClaudeTaskStatus>(r#""some_future_status""#).unwrap(),
+            ClaudeTaskStatus::Unknown
         );
     }
 

--- a/crates/zremote-protocol/src/claude.rs
+++ b/crates/zremote-protocol/src/claude.rs
@@ -11,6 +11,7 @@ pub enum ClaudeTaskStatus {
     Active,
     Completed,
     Error,
+    Suspended,
 }
 
 /// Discovered Claude Code session info (for resume).
@@ -140,6 +141,10 @@ mod tests {
             serde_json::to_string(&ClaudeTaskStatus::Error).unwrap(),
             r#""error""#
         );
+        assert_eq!(
+            serde_json::to_string(&ClaudeTaskStatus::Suspended).unwrap(),
+            r#""suspended""#
+        );
     }
 
     #[test]
@@ -159,6 +164,10 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ClaudeTaskStatus>(r#""error""#).unwrap(),
             ClaudeTaskStatus::Error
+        );
+        assert_eq!(
+            serde_json::from_str::<ClaudeTaskStatus>(r#""suspended""#).unwrap(),
+            ClaudeTaskStatus::Suspended
         );
     }
 

--- a/crates/zremote-server/src/lib.rs
+++ b/crates/zremote-server/src/lib.rs
@@ -292,6 +292,10 @@ fn create_router(state: Arc<AppState>) -> Router {
             post(routes::claude_sessions::cancel_claude_task),
         )
         .route(
+            "/api/claude-tasks/{task_id}/resolve",
+            post(routes::claude_sessions::resolve_claude_task),
+        )
+        .route(
             "/api/claude-tasks/{task_id}/log",
             get(routes::claude_sessions::get_task_log),
         )
@@ -481,6 +485,30 @@ fn spawn_pending_request_cleanup(state: Arc<AppState>, shutdown: CancellationTok
                     let removed = state.cleanup_stale_requests(std::time::Duration::from_secs(120));
                     if removed > 0 {
                         tracing::info!(removed, "cleaned up stale pending requests");
+                    }
+
+                    // Expire tasks suspended for more than 1 hour
+                    let now = chrono::Utc::now();
+                    let threshold = (now - chrono::Duration::hours(1)).to_rfc3339();
+                    let now_str = now.to_rfc3339();
+                    match sqlx::query(
+                        "UPDATE claude_sessions SET status = 'error', ended_at = ?, \
+                         error_message = 'agent did not reconnect within timeout' \
+                         WHERE status = 'suspended' AND disconnect_reason = 'agent_disconnected' \
+                         AND EXISTS (SELECT 1 FROM sessions s WHERE s.id = claude_sessions.session_id AND s.suspended_at < ?)",
+                    )
+                    .bind(&now_str)
+                    .bind(&threshold)
+                    .execute(&state.db)
+                    .await
+                    {
+                        Ok(result) if result.rows_affected() > 0 => {
+                            tracing::info!(count = result.rows_affected(), "expired stale suspended claude tasks");
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::error!(error = %e, "failed to expire stale suspended claude tasks");
+                        }
                     }
                 }
                 () = shutdown.cancelled() => break,

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -841,6 +841,18 @@ pub(super) async fn handle_sessions_recovered(
             pid = recovered.pid,
             "session resumed after agent reconnection"
         );
+
+        // Resume linked claude_sessions that were suspended during disconnect
+        if let Err(e) = sqlx::query(
+            "UPDATE claude_sessions SET status = 'active', disconnect_reason = NULL \
+             WHERE session_id = ? AND status = 'suspended'",
+        )
+        .bind(recovered.session_id.to_string())
+        .execute(&state.db)
+        .await
+        {
+            tracing::error!(session_id = %recovered.session_id, error = %e, "failed to resume claude session on reconnect");
+        }
     }
 
     // Suspend sessions that were NOT recovered by the agent
@@ -1039,7 +1051,7 @@ pub(super) async fn handle_agentic_message(
 
             // Link loop to claude_session if one exists, or auto-create one for manually-started sessions
             let link_result = sqlx::query(
-                "UPDATE claude_sessions SET loop_id = ?, status = 'active' WHERE session_id = ? AND status = 'starting'",
+                "UPDATE claude_sessions SET loop_id = ?, status = 'active', disconnect_reason = NULL WHERE session_id = ? AND status IN ('starting', 'suspended', 'active') AND loop_id IS NULL",
             )
             .bind(&loop_id_str)
             .bind(&session_id_str)
@@ -2638,5 +2650,268 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(row.0, "active");
+    }
+
+    // ── claude_sessions resilience ──
+
+    async fn insert_test_claude_session(
+        state: &AppState,
+        id: &str,
+        session_id: &str,
+        host_id: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status) VALUES (?, ?, ?, '/tmp/project', ?)",
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(host_id)
+        .bind(status)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_persistent_agent_suspends_claude_tasks() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+
+        insert_test_host(&state, &host_id.to_string(), "persist-host").await;
+        insert_test_session(
+            &state,
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+        insert_test_claude_session(
+            &state,
+            &task_id.to_string(),
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+
+        // Add session to in-memory store
+        {
+            let mut sessions = state.sessions.write().await;
+            let mut s = zremote_core::state::SessionState::new(session_id, host_id);
+            s.status = SessionStatus::Active;
+            sessions.insert(session_id, s);
+        }
+
+        // Register as persistent
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let (_, generation) = state
+            .connections
+            .register(host_id, "persist-host".to_string(), tx, true)
+            .await;
+
+        cleanup_agent(&state, &host_id, generation).await;
+
+        // Claude task should be suspended (not error)
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT status, disconnect_reason FROM claude_sessions WHERE id = ?")
+                .bind(task_id.to_string())
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0, "suspended",
+            "persistent agent should suspend claude tasks"
+        );
+        assert_eq!(row.1.as_deref(), Some("agent_disconnected"));
+    }
+
+    #[tokio::test]
+    async fn cleanup_non_persistent_agent_errors_claude_tasks() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+
+        insert_test_host(&state, &host_id.to_string(), "non-persist-host").await;
+        insert_test_session(
+            &state,
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+        insert_test_claude_session(
+            &state,
+            &task_id.to_string(),
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+
+        // Add session to in-memory store
+        {
+            let mut sessions = state.sessions.write().await;
+            let mut s = zremote_core::state::SessionState::new(session_id, host_id);
+            s.status = SessionStatus::Active;
+            sessions.insert(session_id, s);
+        }
+
+        // Register as non-persistent
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let (_, generation) = state
+            .connections
+            .register(host_id, "non-persist-host".to_string(), tx, false)
+            .await;
+
+        cleanup_agent(&state, &host_id, generation).await;
+
+        // Claude task should be error (not suspended)
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT status, error_message, disconnect_reason FROM claude_sessions WHERE id = ?",
+        )
+        .bind(task_id.to_string())
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0, "error",
+            "non-persistent agent should mark claude tasks as error"
+        );
+        assert_eq!(
+            row.1.as_deref(),
+            Some("agent disconnected while task was running")
+        );
+        assert_eq!(row.2.as_deref(), Some("agent_disconnected"));
+    }
+
+    #[tokio::test]
+    async fn loop_detected_links_to_suspended_task() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let loop_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+
+        insert_test_host(&state, &host_id.to_string(), "test-host").await;
+        insert_test_session(
+            &state,
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+
+        // Insert a suspended claude_session (simulating post-disconnect state)
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status, disconnect_reason) \
+             VALUES (?, ?, ?, '/tmp/project', 'suspended', 'agent_disconnected')",
+        )
+        .bind(task_id.to_string())
+        .bind(session_id.to_string())
+        .bind(host_id.to_string())
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        // Register connection so get_hostname works
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        state
+            .connections
+            .register(host_id, "test-host".to_string(), tx, true)
+            .await;
+
+        let msg = AgenticAgentMessage::LoopDetected {
+            loop_id,
+            session_id,
+            project_path: "/tmp/project".to_string(),
+            tool_name: "bash".to_string(),
+        };
+
+        handle_agentic_message(&state, host_id, msg).await.unwrap();
+
+        // Claude task should now be active with loop linked and disconnect_reason cleared
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT status, loop_id, disconnect_reason FROM claude_sessions WHERE id = ?",
+        )
+        .bind(task_id.to_string())
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0, "active",
+            "suspended task should become active on LoopDetected"
+        );
+        assert_eq!(
+            row.1.as_deref(),
+            Some(&loop_id.to_string()[..]),
+            "loop_id should be linked"
+        );
+        assert_eq!(row.2, None, "disconnect_reason should be cleared");
+    }
+
+    #[tokio::test]
+    async fn session_recovery_resumes_suspended_claude_tasks() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+
+        insert_test_host(&state, &host_id.to_string(), "recover-host").await;
+        insert_test_session(
+            &state,
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "suspended",
+        )
+        .await;
+
+        // Insert a suspended claude task linked to the session
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status, disconnect_reason) \
+             VALUES (?, ?, ?, '/tmp/project', 'suspended', 'agent_disconnected')",
+        )
+        .bind(task_id.to_string())
+        .bind(session_id.to_string())
+        .bind(host_id.to_string())
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        // Add session to in-memory store as suspended
+        {
+            let mut sessions = state.sessions.write().await;
+            let mut s = zremote_core::state::SessionState::new(session_id, host_id);
+            s.status = SessionStatus::Suspended;
+            sessions.insert(session_id, s);
+        }
+
+        // Recover the session
+        let recovered = vec![zremote_protocol::RecoveredSession {
+            session_id,
+            shell: "/bin/bash".to_string(),
+            pid: 1234,
+        }];
+
+        super::handle_sessions_recovered(&state, host_id, recovered).await;
+
+        // Claude task should now be active with disconnect_reason cleared
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT status, disconnect_reason FROM claude_sessions WHERE id = ?")
+                .bind(task_id.to_string())
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0, "active",
+            "suspended claude task should be resumed on session recovery"
+        );
+        assert_eq!(
+            row.1, None,
+            "disconnect_reason should be cleared on recovery"
+        );
     }
 }

--- a/crates/zremote-server/src/routes/agents/lifecycle.rs
+++ b/crates/zremote-server/src/routes/agents/lifecycle.rs
@@ -8,6 +8,7 @@ use axum::extract::ws::{Message, WebSocket};
 use chrono::Utc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+use zremote_protocol::claude::ClaudeTaskStatus;
 use zremote_protocol::status::SessionStatus;
 use zremote_protocol::{AgentMessage, AgenticLoopId, HostId, ServerMessage};
 
@@ -327,6 +328,39 @@ pub(super) async fn cleanup_agent(state: &AppState, host_id: &HostId, generation
             tracing::info!(host_id = %host_id, count = suspended_session_ids.len(), "suspended sessions for disconnected agent (persistent)");
         }
 
+        // Suspend claude tasks (may recover on reconnect)
+        if let Err(e) = sqlx::query(
+            "UPDATE claude_sessions SET status = 'suspended', disconnect_reason = 'agent_disconnected' \
+             WHERE host_id = ? AND status IN ('starting', 'active')",
+        )
+        .bind(&host_id_str)
+        .execute(&state.db)
+        .await
+        {
+            tracing::error!(host_id = %host_id, error = %e, "failed to suspend claude sessions on disconnect");
+        }
+
+        // Emit ClaudeTaskEnded events for suspended tasks
+        if let Ok(rows) = sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
+            "SELECT id, project_path, task_name FROM claude_sessions WHERE host_id = ? AND status = 'suspended'",
+        )
+        .bind(&host_id_str)
+        .fetch_all(&state.db)
+        .await
+        {
+            for (task_id, project_path, task_name) in rows {
+                let _ = state.events.send(ServerEvent::ClaudeTaskEnded {
+                    task_id,
+                    status: ClaudeTaskStatus::Suspended,
+                    summary: Some("agent disconnected".to_string()),
+                    session_id: None,
+                    host_id: Some(host_id_str.clone()),
+                    project_path,
+                    task_name,
+                });
+            }
+        }
+
         // Do NOT clean agentic loops or close sessions -- agent may reconnect
     } else {
         // Standard behavior: close all sessions
@@ -400,19 +434,20 @@ pub(super) async fn cleanup_agent(state: &AppState, host_id: &HostId, generation
         if !closed_session_ids.is_empty() {
             tracing::info!(host_id = %host_id, count = closed_session_ids.len(), "closed sessions for disconnected agent");
         }
-    }
 
-    // Mark starting/active claude_sessions for this host as error
-    if let Err(e) = sqlx::query(
-        "UPDATE claude_sessions SET status = 'error', ended_at = ?, error_message = 'agent disconnected while task was running' \
-         WHERE host_id = ? AND status IN ('starting', 'active')",
-    )
-    .bind(&now)
-    .bind(&host_id_str)
-    .execute(&state.db)
-    .await
-    {
-        tracing::error!(host_id = %host_id, error = %e, "failed to mark claude sessions as error on disconnect");
+        // Mark starting/active claude_sessions for this host as error
+        if let Err(e) = sqlx::query(
+            "UPDATE claude_sessions SET status = 'error', ended_at = ?, error_message = 'agent disconnected while task was running', \
+             disconnect_reason = 'agent_disconnected' \
+             WHERE host_id = ? AND status IN ('starting', 'active')",
+        )
+        .bind(&now)
+        .bind(&host_id_str)
+        .execute(&state.db)
+        .await
+        {
+            tracing::error!(host_id = %host_id, error = %e, "failed to mark claude sessions as error on disconnect");
+        }
     }
 
     // Mark host offline in DB

--- a/crates/zremote-server/src/routes/claude_sessions.rs
+++ b/crates/zremote-server/src/routes/claude_sessions.rs
@@ -404,7 +404,9 @@ pub async fn cancel_claude_task(
         .parse()
         .map_err(|_| AppError::Internal("invalid host_id".to_string()))?;
 
-    // If not force and channel might be available, try graceful abort
+    // For suspended tasks the agent is likely disconnected, so the graceful abort
+    // is best-effort (get_sender returns None when offline). Closing the session
+    // below prevents recovery on future agent reconnect.
     if !force && let Some(sender) = state.connections.get_sender(&host_id).await {
         let abort_msg = ServerMessage::ChannelAction(
             zremote_protocol::channel::ChannelServerAction::ChannelSend {
@@ -441,6 +443,16 @@ pub async fn cancel_claude_task(
     {
         tracing::warn!(task_id = %task_id, "failed to update task status on cancel: {e}");
     }
+
+    let _ = state.events.send(ServerEvent::ClaudeTaskEnded {
+        task_id: task_id.clone(),
+        status: zremote_protocol::ClaudeTaskStatus::Error,
+        summary: Some("cancelled by user".to_string()),
+        session_id: Some(task.session_id.clone()),
+        host_id: Some(task.host_id.clone()),
+        project_path: Some(task.project_path.clone()),
+        task_name: task.task_name.clone(),
+    });
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -507,6 +519,16 @@ pub async fn resolve_claude_task(
     .execute(&state.db)
     .await
     .map_err(|e| AppError::Internal(format!("failed to resolve task: {e}")))?;
+
+    let _ = state.events.send(ServerEvent::ClaudeTaskEnded {
+        task_id: task_id.clone(),
+        status: zremote_protocol::ClaudeTaskStatus::Completed,
+        summary: Some(summary.clone()),
+        session_id: Some(task.session_id.clone()),
+        host_id: Some(task.host_id.clone()),
+        project_path: Some(task.project_path.clone()),
+        task_name: task.task_name.clone(),
+    });
 
     let task = q::get_claude_task(&state.db, &task_id).await?;
     Ok((StatusCode::OK, Json(task)))

--- a/crates/zremote-server/src/routes/claude_sessions.rs
+++ b/crates/zremote-server/src/routes/claude_sessions.rs
@@ -387,7 +387,7 @@ pub async fn cancel_claude_task(
 ) -> Result<impl IntoResponse, AppError> {
     let task = q::get_claude_task(&state.db, &task_id).await?;
 
-    if task.status != "starting" && task.status != "active" {
+    if task.status != "starting" && task.status != "active" && task.status != "suspended" {
         return Err(AppError::Conflict(format!(
             "cannot cancel task with status '{}'",
             task.status
@@ -430,9 +430,11 @@ pub async fn cancel_claude_task(
     }
 
     // Update task status to error with cancel reason
+    let now = chrono::Utc::now().to_rfc3339();
     if let Err(e) = sqlx::query(
-        "UPDATE claude_sessions SET status = 'error', error_message = 'cancelled by user' WHERE id = ?",
+        "UPDATE claude_sessions SET status = 'error', ended_at = ?, error_message = 'cancelled by user', disconnect_reason = NULL WHERE id = ?",
     )
+    .bind(&now)
     .bind(&task_id)
     .execute(&state.db)
     .await
@@ -469,6 +471,45 @@ pub async fn get_task_log(
     // Strip ANSI escape codes
     let stripped = strip_ansi_escapes(&output);
     Ok(stripped)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveTaskBody {
+    pub summary: Option<String>,
+}
+
+/// `POST /api/claude-tasks/:task_id/resolve` - Manually resolve a suspended or errored task.
+pub async fn resolve_claude_task(
+    State(state): State<Arc<AppState>>,
+    Path(task_id): Path<String>,
+    body: Option<Json<ResolveTaskBody>>,
+) -> Result<impl IntoResponse, AppError> {
+    let task = q::get_claude_task(&state.db, &task_id).await?;
+
+    if task.status != "error" && task.status != "suspended" {
+        return Err(AppError::Conflict(format!(
+            "can only resolve tasks with status 'error' or 'suspended', got '{}'",
+            task.status
+        )));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let summary = body
+        .and_then(|Json(b)| b.summary)
+        .unwrap_or_else(|| "manually resolved".to_string());
+
+    sqlx::query(
+        "UPDATE claude_sessions SET status = 'completed', ended_at = ?, summary = ?, disconnect_reason = NULL WHERE id = ?",
+    )
+    .bind(&now)
+    .bind(&summary)
+    .bind(&task_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| AppError::Internal(format!("failed to resolve task: {e}")))?;
+
+    let task = q::get_claude_task(&state.db, &task_id).await?;
+    Ok((StatusCode::OK, Json(task)))
 }
 
 /// Strip ANSI escape sequences from a string.
@@ -555,6 +596,14 @@ mod tests {
             .route(
                 "/api/claude-tasks/{task_id}/resume",
                 post(resume_claude_task),
+            )
+            .route(
+                "/api/claude-tasks/{task_id}/cancel",
+                post(cancel_claude_task),
+            )
+            .route(
+                "/api/claude-tasks/{task_id}/resolve",
+                post(resolve_claude_task),
             )
             .route(
                 "/api/hosts/{host_id}/claude-tasks/discover",
@@ -980,5 +1029,202 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    // --- resolve_claude_task tests ---
+
+    /// Helper: create a task and return its ID.
+    async fn create_test_task(state: &Arc<AppState>, host_id: Uuid) -> String {
+        let body = serde_json::json!({
+            "host_id": host_id.to_string(),
+            "project_path": "/proj",
+        });
+        let app = build_router(Arc::clone(state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/claude-tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        json["id"].as_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn resolve_error_task_to_completed() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        insert_host(&state, &host_id.to_string()).await;
+        let mut _rx = register_host_connection(&state, host_id).await;
+
+        let task_id = create_test_task(&state, host_id).await;
+
+        // Mark as error
+        sqlx::query("UPDATE claude_sessions SET status = 'error', error_message = 'agent crashed' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let app = build_router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resolve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"], "completed");
+        assert_eq!(json["summary"], "manually resolved");
+    }
+
+    #[tokio::test]
+    async fn resolve_suspended_task_to_completed() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        insert_host(&state, &host_id.to_string()).await;
+        let mut _rx = register_host_connection(&state, host_id).await;
+
+        let task_id = create_test_task(&state, host_id).await;
+
+        // Mark as suspended
+        sqlx::query("UPDATE claude_sessions SET status = 'suspended', disconnect_reason = 'agent disconnected' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let app = build_router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resolve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"], "completed");
+        // disconnect_reason should be cleared
+        assert!(json["disconnect_reason"].is_null());
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_completed_task() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        insert_host(&state, &host_id.to_string()).await;
+        let mut _rx = register_host_connection(&state, host_id).await;
+
+        let task_id = create_test_task(&state, host_id).await;
+
+        // Mark as completed
+        sqlx::query("UPDATE claude_sessions SET status = 'completed' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let app = build_router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resolve"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn resolve_with_custom_summary() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        insert_host(&state, &host_id.to_string()).await;
+        let mut _rx = register_host_connection(&state, host_id).await;
+
+        let task_id = create_test_task(&state, host_id).await;
+
+        // Mark as error
+        sqlx::query("UPDATE claude_sessions SET status = 'error' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let resolve_body = serde_json::json!({ "summary": "resolved after manual investigation" });
+        let app = build_router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resolve"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&resolve_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["summary"], "resolved after manual investigation");
+    }
+
+    // --- cancel_claude_task for suspended ---
+
+    #[tokio::test]
+    async fn cancel_suspended_task() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        insert_host(&state, &host_id.to_string()).await;
+        let mut _rx = register_host_connection(&state, host_id).await;
+
+        let task_id = create_test_task(&state, host_id).await;
+
+        // Mark as suspended
+        sqlx::query("UPDATE claude_sessions SET status = 'suspended' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let cancel_body = serde_json::json!({ "force": false });
+        let app = build_router(Arc::clone(&state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/cancel"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&cancel_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // Verify status changed to error
+        let updated = q::get_claude_task(&state.db, &task_id).await.unwrap();
+        assert_eq!(updated.status, "error");
     }
 }

--- a/crates/zremote-server/src/telegram/notifications.rs
+++ b/crates/zremote-server/src/telegram/notifications.rs
@@ -105,6 +105,23 @@ fn format_event(event: &ServerEvent) -> Option<String> {
             hostname,
             loop_info.end_reason.as_deref().unwrap_or("unknown"),
         )),
+        ServerEvent::ClaudeTaskEnded {
+            task_id,
+            status: zremote_protocol::ClaudeTaskStatus::Suspended,
+            task_name,
+            project_path,
+            ..
+        } => {
+            let label = task_name.as_deref().unwrap_or(task_id.as_str());
+            let project_line = project_path
+                .as_deref()
+                .map(|p| format!("\nProject: <code>{}</code>", format::escape_html(p)))
+                .unwrap_or_default();
+            Some(format::truncate_message(&format!(
+                "\u{26a0}\u{fe0f} <b>Task Suspended</b>\nTask <code>{}</code> suspended \u{2014} agent disconnected{project_line}",
+                format::escape_html(label),
+            )))
+        }
         // Other events don't trigger Telegram notifications
         _ => None,
     }
@@ -271,5 +288,89 @@ mod tests {
             exit_code: Some(0),
         };
         assert!(format_event(&event).is_none());
+    }
+
+    #[test]
+    fn task_suspended_notifies() {
+        let event = ServerEvent::ClaudeTaskEnded {
+            task_id: "t1".to_string(),
+            status: zremote_protocol::ClaudeTaskStatus::Suspended,
+            summary: None,
+            session_id: Some("s1".to_string()),
+            host_id: Some("h1".to_string()),
+            project_path: Some("/home/user/project".to_string()),
+            task_name: Some("fix bug #42".to_string()),
+        };
+        let result = format_event(&event);
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("Task Suspended"));
+        assert!(text.contains("fix bug #42"));
+        assert!(text.contains("/home/user/project"));
+        assert!(text.contains("agent disconnected"));
+    }
+
+    #[test]
+    fn task_suspended_without_name_uses_id() {
+        let event = ServerEvent::ClaudeTaskEnded {
+            task_id: "task-abc-123".to_string(),
+            status: zremote_protocol::ClaudeTaskStatus::Suspended,
+            summary: None,
+            session_id: None,
+            host_id: None,
+            project_path: None,
+            task_name: None,
+        };
+        let result = format_event(&event);
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("task-abc-123"));
+        assert!(!text.contains("Project:"));
+    }
+
+    #[test]
+    fn task_completed_does_not_notify() {
+        let event = ServerEvent::ClaudeTaskEnded {
+            task_id: "t1".to_string(),
+            status: zremote_protocol::ClaudeTaskStatus::Completed,
+            summary: Some("done".to_string()),
+            session_id: Some("s1".to_string()),
+            host_id: Some("h1".to_string()),
+            project_path: Some("/home/user/project".to_string()),
+            task_name: Some("fix bug".to_string()),
+        };
+        assert!(format_event(&event).is_none());
+    }
+
+    #[test]
+    fn task_error_does_not_notify() {
+        let event = ServerEvent::ClaudeTaskEnded {
+            task_id: "t1".to_string(),
+            status: zremote_protocol::ClaudeTaskStatus::Error,
+            summary: None,
+            session_id: None,
+            host_id: None,
+            project_path: None,
+            task_name: None,
+        };
+        assert!(format_event(&event).is_none());
+    }
+
+    #[test]
+    fn task_suspended_escapes_html_in_name() {
+        let event = ServerEvent::ClaudeTaskEnded {
+            task_id: "t1".to_string(),
+            status: zremote_protocol::ClaudeTaskStatus::Suspended,
+            summary: None,
+            session_id: None,
+            host_id: None,
+            project_path: Some("/home/<user>/project".to_string()),
+            task_name: Some("fix <script> bug".to_string()),
+        };
+        let result = format_event(&event);
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("fix &lt;script&gt; bug"));
+        assert!(text.contains("&lt;user&gt;"));
     }
 }


### PR DESCRIPTION
## Summary

- When an agent with persistent sessions disconnects, claude_sessions are now marked as `suspended` (not `error`) so they can recover on reconnect
- Adds `disconnect_reason` column to track why a task was interrupted
- New `POST /api/claude-tasks/:id/resolve` endpoint to manually resolve suspended/errored tasks
- New `task resolve` CLI subcommand
- Enriched `task get` output showing disconnect context (cost, loop status)
- Telegram notification for task suspension
- Suspended task timeout: tasks suspended >1h without reconnect auto-transition to error
- LoopDetected extended to re-link with suspended tasks on reconnect
- Cancel now works on suspended tasks

## Changes

| File | Change |
|------|--------|
| `zremote-protocol/src/claude.rs` | Add `Suspended` variant to `ClaudeTaskStatus` |
| `zremote-core/migrations/025_task_disconnect_reason.sql` | New migration: `disconnect_reason` column |
| `zremote-core/src/queries/claude_sessions.rs` | Add `disconnect_reason` field to `ClaudeTaskRow` |
| `zremote-client/src/types.rs` | Add `disconnect_reason` field to `ClaudeTask` |
| `zremote-client/src/client.rs` | Add `resolve_claude_task` client method |
| `zremote-server/src/routes/agents/lifecycle.rs` | Branch cleanup on persistence (suspend vs error) |
| `zremote-server/src/routes/agents/dispatch.rs` | Recover suspended tasks on reconnect; extend LoopDetected |
| `zremote-server/src/routes/claude_sessions.rs` | Cancel suspended tasks; resolve endpoint |
| `zremote-server/src/lib.rs` | Suspended task timeout cleanup |
| `zremote-cli/src/commands/task.rs` | `resolve` subcommand; enriched `get` output |
| `zremote-server/src/telegram/notifications.rs` | Task suspension notification |

## Test plan

- [x] `cargo test --workspace` -- 2394 tests pass, 0 failures
- [x] `cargo clippy --workspace` -- clean
- [x] `cargo fmt --check` -- clean
- [ ] Manual: start agent with persistent sessions, create task, kill agent, verify `suspended` status
- [ ] Manual: restart agent, verify task recovers to `active`
- [ ] Manual: `task resolve` on errored task transitions to `completed`

Closes #42