### PR TITLE
feat(gui): command palette — recent actions, acronyms, tiered ranking

### DIFF
--- a/crates/zremote-gui/assets/icons/clock.svg
+++ b/crates/zremote-gui/assets/icons/clock.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <polyline points="12 6 12 12 16 14" />
+</svg>

--- a/crates/zremote-gui/src/icons.rs
+++ b/crates/zremote-gui/src/icons.rs
@@ -31,6 +31,7 @@ pub enum Icon {
     Settings,
     PanelRight,
     FileText,
+    Clock,
 }
 
 impl Icon {
@@ -65,6 +66,7 @@ impl Icon {
             Self::Settings => "icons/settings.svg",
             Self::PanelRight => "icons/panel-right.svg",
             Self::FileText => "icons/file-text.svg",
+            Self::Clock => "icons/clock.svg",
         }
     }
 }

--- a/crates/zremote-gui/src/persistence.rs
+++ b/crates/zremote-gui/src/persistence.rs
@@ -61,8 +61,16 @@ pub struct RecentSession {
     pub timestamp: i64,
 }
 
-/// Current format version.
-const FORMAT_VERSION: u32 = 1;
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RecentAction {
+    pub action_key: String,
+    /// Unix timestamp in seconds.
+    pub timestamp: i64,
+}
+
+/// Current format version. Informational only — written on save but not checked
+/// on load. New fields use `#[serde(default)]` for backward compatibility.
+const FORMAT_VERSION: u32 = 2;
 
 /// Default debounce window for the production worker.
 const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(250);
@@ -84,6 +92,8 @@ pub struct GuiState {
     pub window_height: Option<f32>,
     #[serde(default)]
     pub recent_sessions: Vec<RecentSession>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent_actions: Vec<RecentAction>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub activity_panel_visible: bool,
 }
@@ -95,6 +105,7 @@ impl GuiState {
             && self.window_width.is_none()
             && self.window_height.is_none()
             && self.recent_sessions.is_empty()
+            && self.recent_actions.is_empty()
             && !self.activity_panel_visible
     }
 }
@@ -341,6 +352,36 @@ impl Persistence {
                 },
             );
             state.recent_sessions.truncate(10);
+        });
+    }
+
+    /// Record a palette action usage. Deduplicates by key, moves to front,
+    /// caps at 20. Save is queued automatically via `update`.
+    pub fn record_action_usage(&mut self, action_key: &str) {
+        self.update(|state| {
+            state.recent_actions.retain(|r| r.action_key != action_key);
+            state.recent_actions.insert(
+                0,
+                RecentAction {
+                    action_key: action_key.to_string(),
+                    timestamp: i64::try_from(
+                        SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map_or(0, |d| d.as_secs()),
+                    )
+                    .unwrap_or(0),
+                },
+            );
+            if state.recent_actions.len() > 20 {
+                state.recent_actions.truncate(20);
+            }
+        });
+    }
+
+    /// Clear all recent palette actions (used from settings UI).
+    pub fn clear_recent_actions(&mut self) {
+        self.update(|state| {
+            state.recent_actions.clear();
         });
     }
 
@@ -978,6 +1019,7 @@ mod tests {
                 session_id: "s".to_string(),
                 timestamp: 1_700_000_000,
             }],
+            recent_actions: vec![],
             activity_panel_visible: false,
         };
 
@@ -986,5 +1028,55 @@ mod tests {
 
         let expected = "{\n  \"version\": 1,\n  \"server_url\": \"http://a:1\",\n  \"active_session_id\": \"s\",\n  \"window_width\": 800.0,\n  \"window_height\": 600.0,\n  \"recent_sessions\": [\n    {\n      \"session_id\": \"s\",\n      \"timestamp\": 1700000000\n    }\n  ]\n}";
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_record_action_usage() {
+        let (writer, _, _) = counting_writer();
+        let path = temp_path("record-action");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.record_action_usage("NewSession");
+        p.record_action_usage("SearchInTerminal");
+        p.record_action_usage("NewSession"); // duplicate — should move to front
+
+        let actions = &p.state().recent_actions;
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].action_key, "NewSession");
+        assert_eq!(actions[1].action_key, "SearchInTerminal");
+    }
+
+    #[test]
+    fn test_record_action_usage_cap() {
+        let (writer, _, _) = counting_writer();
+        let path = temp_path("record-action-cap");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        for i in 0..25 {
+            p.record_action_usage(&format!("Action{i}"));
+        }
+        assert_eq!(p.state().recent_actions.len(), 20);
+        assert_eq!(p.state().recent_actions[0].action_key, "Action24");
+    }
+
+    #[test]
+    fn test_clear_recent_actions() {
+        let (writer, _, _) = counting_writer();
+        let path = temp_path("clear-actions");
+        let mut p = Persistence::with_writer(path, writer, Duration::from_millis(10));
+
+        p.record_action_usage("NewSession");
+        p.record_action_usage("Search");
+        assert_eq!(p.state().recent_actions.len(), 2);
+
+        p.clear_recent_actions();
+        assert!(p.state().recent_actions.is_empty());
+    }
+
+    #[test]
+    fn test_backward_compat_v1() {
+        let v1_json = r#"{"version":1,"recent_sessions":[]}"#;
+        let state: GuiState = serde_json::from_str(v1_json).unwrap();
+        assert!(state.recent_actions.is_empty());
     }
 }

--- a/crates/zremote-gui/src/views/command_palette/actions.rs
+++ b/crates/zremote-gui/src/views/command_palette/actions.rs
@@ -45,6 +45,32 @@ pub enum PaletteAction {
     ManageAgentProfiles,
 }
 
+impl PaletteAction {
+    /// Returns a stable string key identifying the action variant, stripping
+    /// instance data. Used for recent-action persistence.
+    ///
+    /// `CloseCurrentSession` and `CloseSession` are intentionally distinct keys:
+    /// the former is a contextual shortcut (close what I'm looking at), the
+    /// latter targets a specific session from drill-down. Tracking them
+    /// separately reflects different user intents.
+    pub fn action_key(&self) -> &'static str {
+        match self {
+            Self::CloseCurrentSession { .. } => "CloseCurrentSession",
+            Self::SearchInTerminal => "SearchInTerminal",
+            Self::NewSession => "NewSession",
+            Self::ToggleProjectPin { .. } => "ToggleProjectPin",
+            Self::Reconnect => "Reconnect",
+            Self::NewSessionInProject { .. } => "NewSessionInProject",
+            Self::CloseSession { .. } => "CloseSession",
+            Self::SwitchToSession { .. } => "SwitchToSession",
+            Self::SwitchSession => "SwitchSession",
+            Self::AddProject => "AddProject",
+            Self::StartAgent { .. } => "StartAgent",
+            Self::ManageAgentProfiles => "ManageAgentProfiles",
+        }
+    }
+}
+
 impl CommandPalette {
     pub(super) fn execute_selected(&mut self, cx: &mut Context<Self>) {
         let item = self
@@ -71,97 +97,165 @@ impl CommandPalette {
                     working_dir: project.path.clone(),
                 });
             }
-            PaletteItem::Action(action) => match action {
-                PaletteAction::CloseCurrentSession { session_id }
-                | PaletteAction::CloseSession { session_id } => {
-                    cx.emit(CommandPaletteEvent::CloseSession {
-                        session_id: session_id.clone(),
-                    });
-                }
-                PaletteAction::SearchInTerminal => {
-                    cx.emit(CommandPaletteEvent::OpenSearch);
-                }
-                PaletteAction::NewSession => {
-                    let is_local = self.snapshot.mode == "local";
-                    let single_host = self.snapshot.hosts.len() == 1;
-                    if is_local || single_host {
-                        if let Some(host) = self.snapshot.hosts.first() {
-                            cx.emit(CommandPaletteEvent::CreateSession {
-                                host_id: host.id.clone(),
-                            });
-                        }
-                    } else {
-                        self.enter_host_picker();
-                        cx.notify();
-                        return; // Don't close
+            PaletteItem::Action(action) => {
+                match action {
+                    PaletteAction::CloseCurrentSession { session_id }
+                    | PaletteAction::CloseSession { session_id } => {
+                        cx.emit(CommandPaletteEvent::CloseSession {
+                            session_id: session_id.clone(),
+                        });
                     }
-                }
-                PaletteAction::ToggleProjectPin {
-                    project_id,
-                    currently_pinned,
-                    ..
-                } => {
-                    cx.emit(CommandPaletteEvent::ToggleProjectPin {
-                        project_id: project_id.clone(),
-                        pinned: !currently_pinned,
-                    });
-                }
-                PaletteAction::Reconnect => {
-                    cx.emit(CommandPaletteEvent::Reconnect);
-                }
-                PaletteAction::NewSessionInProject {
-                    host_id,
-                    working_dir,
-                    ..
-                } => {
-                    cx.emit(CommandPaletteEvent::CreateSessionInProject {
-                        host_id: host_id.clone(),
-                        working_dir: working_dir.clone(),
-                    });
-                }
-                PaletteAction::SwitchToSession {
-                    session_id,
-                    host_id,
-                } => {
-                    cx.emit(CommandPaletteEvent::SelectSession {
-                        session_id: session_id.clone(),
-                        host_id: host_id.clone(),
-                    });
-                }
-                PaletteAction::AddProject => {
-                    let is_local = self.snapshot.mode == "local";
-                    let online = self.snapshot.online_hosts();
-                    if is_local || online.len() == 1 {
-                        if let Some(host) = online.first() {
-                            self.enter_path_input(host.id.clone());
+                    PaletteAction::SearchInTerminal => {
+                        cx.emit(CommandPaletteEvent::OpenSearch);
+                    }
+                    PaletteAction::NewSession => {
+                        let is_local = self.snapshot.mode == "local";
+                        let single_host = self.snapshot.hosts.len() == 1;
+                        if is_local || single_host {
+                            if let Some(host) = self.snapshot.hosts.first() {
+                                cx.emit(CommandPaletteEvent::CreateSession {
+                                    host_id: host.id.clone(),
+                                });
+                            }
+                        } else {
+                            self.enter_host_picker();
+                            cx.notify();
+                            return; // Don't close
+                        }
+                    }
+                    PaletteAction::ToggleProjectPin {
+                        project_id,
+                        currently_pinned,
+                        ..
+                    } => {
+                        cx.emit(CommandPaletteEvent::ToggleProjectPin {
+                            project_id: project_id.clone(),
+                            pinned: !currently_pinned,
+                        });
+                    }
+                    PaletteAction::Reconnect => {
+                        cx.emit(CommandPaletteEvent::Reconnect);
+                    }
+                    PaletteAction::NewSessionInProject {
+                        host_id,
+                        working_dir,
+                        ..
+                    } => {
+                        cx.emit(CommandPaletteEvent::CreateSessionInProject {
+                            host_id: host_id.clone(),
+                            working_dir: working_dir.clone(),
+                        });
+                    }
+                    PaletteAction::SwitchToSession {
+                        session_id,
+                        host_id,
+                    } => {
+                        cx.emit(CommandPaletteEvent::SelectSession {
+                            session_id: session_id.clone(),
+                            host_id: host_id.clone(),
+                        });
+                    }
+                    PaletteAction::AddProject => {
+                        let is_local = self.snapshot.mode == "local";
+                        let online = self.snapshot.online_hosts();
+                        if is_local || online.len() == 1 {
+                            if let Some(host) = online.first() {
+                                self.enter_path_input(host.id.clone());
+                                cx.notify();
+                                return;
+                            }
+                        } else {
+                            self.enter_host_picker_for_project();
                             cx.notify();
                             return;
                         }
-                    } else {
-                        self.enter_host_picker_for_project();
-                        cx.notify();
-                        return;
+                    }
+                    PaletteAction::SwitchSession => {
+                        cx.emit(CommandPaletteEvent::OpenSessionSwitcher);
+                    }
+                    PaletteAction::StartAgent {
+                        profile_id,
+                        host_id,
+                        working_dir,
+                    } => {
+                        cx.emit(CommandPaletteEvent::StartAgent {
+                            profile_id: profile_id.clone(),
+                            host_id: host_id.clone(),
+                            working_dir: working_dir.clone(),
+                        });
+                    }
+                    PaletteAction::ManageAgentProfiles => {
+                        cx.emit(CommandPaletteEvent::ShowSettings);
                     }
                 }
-                PaletteAction::SwitchSession => {
-                    cx.emit(CommandPaletteEvent::OpenSessionSwitcher);
-                }
-                PaletteAction::StartAgent {
-                    profile_id,
-                    host_id,
-                    working_dir,
-                } => {
-                    cx.emit(CommandPaletteEvent::StartAgent {
-                        profile_id: profile_id.clone(),
-                        host_id: host_id.clone(),
-                        working_dir: working_dir.clone(),
-                    });
-                }
-                PaletteAction::ManageAgentProfiles => {
-                    cx.emit(CommandPaletteEvent::ShowSettings);
-                }
-            },
+                // Record recent action usage (only fires when the action
+                // actually executes — early returns above skip this).
+                cx.emit(CommandPaletteEvent::RecordRecentAction {
+                    action_key: action.action_key().to_string(),
+                });
+            }
         }
         cx.emit(CommandPaletteEvent::Close);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::views::command_palette::actions::PaletteAction;
+
+    #[test]
+    fn test_action_key_uniqueness() {
+        let actions: Vec<PaletteAction> = vec![
+            PaletteAction::CloseCurrentSession {
+                session_id: "a".into(),
+            },
+            PaletteAction::SearchInTerminal,
+            PaletteAction::NewSession,
+            PaletteAction::ToggleProjectPin {
+                project_id: "a".into(),
+                project_name: "a".into(),
+                currently_pinned: false,
+            },
+            PaletteAction::Reconnect,
+            PaletteAction::NewSessionInProject {
+                host_id: "a".into(),
+                working_dir: "a".into(),
+                project_name: "a".into(),
+            },
+            PaletteAction::CloseSession {
+                session_id: "a".into(),
+            },
+            PaletteAction::SwitchToSession {
+                session_id: "a".into(),
+                host_id: "a".into(),
+            },
+            PaletteAction::SwitchSession,
+            PaletteAction::AddProject,
+            PaletteAction::StartAgent {
+                profile_id: "a".into(),
+                host_id: None,
+                working_dir: None,
+            },
+            PaletteAction::ManageAgentProfiles,
+        ];
+        let keys: std::collections::HashSet<&str> =
+            actions.iter().map(|a| a.action_key()).collect();
+        assert_eq!(keys.len(), actions.len(), "all action keys must be unique");
+    }
+
+    #[test]
+    fn test_action_key_stability() {
+        assert_eq!(PaletteAction::NewSession.action_key(), "NewSession");
+        assert_eq!(
+            PaletteAction::SearchInTerminal.action_key(),
+            "SearchInTerminal"
+        );
+        assert_eq!(
+            PaletteAction::CloseCurrentSession {
+                session_id: "x".into()
+            }
+            .action_key(),
+            "CloseCurrentSession"
+        );
     }
 }

--- a/crates/zremote-gui/src/views/command_palette/items.rs
+++ b/crates/zremote-gui/src/views/command_palette/items.rs
@@ -9,8 +9,8 @@ use zremote_client::{
     AgentKindInfo, AgentProfile, AgenticStatus, Host, HostStatus, Project, Session, SessionStatus,
 };
 
-use crate::persistence::RecentSession;
-use crate::views::fuzzy::FuzzyMatch;
+use crate::persistence::{RecentAction, RecentSession};
+use crate::views::fuzzy::{FuzzyMatch, MatchTier};
 use std::collections::HashSet;
 
 // ---------------------------------------------------------------------------
@@ -58,6 +58,12 @@ pub(crate) struct ScoredEntry {
     pub(super) index: usize,
     pub(super) source: ItemSource,
     pub(super) fuzzy_match: FuzzyMatch,
+    pub(super) tier: MatchTier,
+    /// 0 = most recent action, u32::MAX = not a recent action.
+    pub(super) recent_rank: u32,
+    /// 0 = active session/project, 1 = same host, u32::MAX = unrelated.
+    pub(super) context_rank: u32,
+    pub(super) title_len: u32,
 }
 
 pub(crate) enum PaletteResults {
@@ -126,6 +132,7 @@ pub struct PaletteSnapshot {
     pub(super) recent_set: HashSet<String>,
     pub(super) cc_states: HashMap<String, CcState>,
     pub(super) cc_metrics: HashMap<String, CcMetrics>,
+    pub(super) recent_action_keys: Vec<String>,
 }
 
 impl PaletteSnapshot {
@@ -137,6 +144,7 @@ impl PaletteSnapshot {
         mode: String,
         active_session_id: Option<String>,
         recent_sessions: &[RecentSession],
+        recent_actions: &[RecentAction],
         cc_states: HashMap<String, CcState>,
         cc_metrics: HashMap<String, CcMetrics>,
         agent_profiles: Rc<Vec<AgentProfile>>,
@@ -158,6 +166,10 @@ impl PaletteSnapshot {
             .iter()
             .map(|r| r.session_id.clone())
             .collect();
+        let recent_action_keys: Vec<String> = recent_actions
+            .iter()
+            .map(|r| r.action_key.clone())
+            .collect();
         Self {
             hosts,
             sessions,
@@ -172,6 +184,7 @@ impl PaletteSnapshot {
             recent_set,
             cc_states,
             cc_metrics,
+            recent_action_keys,
         }
     }
 
@@ -798,6 +811,7 @@ mod tests {
             "local".to_string(),
             Some("sess-1".to_string()),
             &[],
+            &[],
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             Rc::new(Vec::new()),
@@ -1033,6 +1047,7 @@ mod tests {
             "local".to_string(),
             None,
             &[],
+            &[],
             HashMap::new(),
             HashMap::new(),
             profiles,
@@ -1176,6 +1191,7 @@ mod tests {
             "local".to_string(),
             None,
             &[],
+            &[],
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             Rc::new(Vec::new()),
@@ -1311,6 +1327,7 @@ mod tests {
             projects,
             "local".to_string(),
             None,
+            &[],
             &[],
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
@@ -1554,6 +1571,7 @@ mod tests {
             "server".to_string(),
             None,
             &[],
+            &[],
             HashMap::new(),
             HashMap::new(),
             Rc::new(Vec::new()),
@@ -1627,6 +1645,7 @@ mod tests {
             projects,
             "server".to_string(),
             None,
+            &[],
             &[],
             HashMap::new(),
             HashMap::new(),

--- a/crates/zremote-gui/src/views/command_palette/mod.rs
+++ b/crates/zremote-gui/src/views/command_palette/mod.rs
@@ -36,7 +36,7 @@ use items::{
     is_item_drillable, session_title,
 };
 
-use super::fuzzy::{FuzzyMatch, fuzzy_match_item};
+use super::fuzzy::{FuzzyMatch, tiered_match_item};
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -140,6 +140,9 @@ pub enum CommandPaletteEvent {
         working_dir: Option<String>,
     },
     ShowSettings,
+    RecordRecentAction {
+        action_key: String,
+    },
     Close,
 }
 
@@ -427,18 +430,36 @@ impl CommandPalette {
             if !item.selectable {
                 continue;
             }
-            if let Some(fm) = fuzzy_match_item(&self.query, &item.title, &item.subtitle) {
+            if let Some(tm) = tiered_match_item(&self.query, &item.title, &item.subtitle) {
                 scored.push(ScoredEntry {
                     index: i,
                     source: ItemSource::Action,
-                    fuzzy_match: fm,
+                    fuzzy_match: FuzzyMatch {
+                        score: tm.score,
+                        matched_indices: tm.matched_indices,
+                    },
+                    tier: tm.tier,
+                    recent_rank: self.recent_action_rank(&item.item),
+                    context_rank: u32::MAX,
+                    title_len: item.title.chars().count() as u32,
                 });
             }
         }
-        scored.sort_by(|a, b| b.fuzzy_match.score.cmp(&a.fuzzy_match.score));
+        scored.sort_by(|a, b| {
+            a.tier
+                .cmp(&b.tier)
+                .then(a.recent_rank.cmp(&b.recent_rank))
+                .then(b.fuzzy_match.score.cmp(&a.fuzzy_match.score))
+                .then(a.title_len.cmp(&b.title_len))
+        });
         PaletteResults::Scored(scored)
     }
 
+    /// Build grouped results for the empty-query view.
+    ///
+    /// Context ranking is intentionally NOT applied here: the grouped view
+    /// uses explicit categories (Recent/Active/Suspended/Pinned) that already
+    /// provide meaningful ordering. Actions are sorted by recent usage instead.
     fn compute_grouped(&self) -> PaletteResults {
         let mut groups: Vec<CategoryGroup> = Vec::new();
 
@@ -471,11 +492,14 @@ impl CommandPalette {
                     });
                 }
 
-                // Actions
+                // Actions (recently used first)
                 if !self.action_items.is_empty() {
+                    let mut action_indices: Vec<usize> = (0..self.action_items.len()).collect();
+                    action_indices
+                        .sort_by_key(|&i| self.recent_action_rank(&self.action_items[i].item));
                     groups.push(CategoryGroup {
                         category: PaletteCategory::Actions,
-                        indices: (0..self.action_items.len()).collect(),
+                        indices: action_indices,
                         source: ItemSource::Action,
                     });
                 }
@@ -511,9 +535,12 @@ impl CommandPalette {
             }
             PaletteTab::Actions => {
                 if !self.action_items.is_empty() {
+                    let mut action_indices: Vec<usize> = (0..self.action_items.len()).collect();
+                    action_indices
+                        .sort_by_key(|&i| self.recent_action_rank(&self.action_items[i].item));
                     groups.push(CategoryGroup {
                         category: PaletteCategory::Actions,
-                        indices: (0..self.action_items.len()).collect(),
+                        indices: action_indices,
                         source: ItemSource::Action,
                     });
                 }
@@ -565,6 +592,74 @@ impl CommandPalette {
         }
     }
 
+    /// Return the recent-action rank for an item (0 = most recent, u32::MAX = not recent).
+    fn recent_action_rank(&self, item: &PaletteItem) -> u32 {
+        match item {
+            PaletteItem::Action(action) => {
+                let key = action.action_key();
+                self.snapshot
+                    .recent_action_keys
+                    .iter()
+                    .position(|k| k == key)
+                    .map_or(u32::MAX, |pos| pos as u32)
+            }
+            _ => u32::MAX,
+        }
+    }
+
+    /// Context relevance rank: 0 = directly active, 1 = same host, u32::MAX = unrelated.
+    fn context_rank(&self, item: &PaletteItem) -> u32 {
+        let active_session_id = self.snapshot.active_session_id.as_deref();
+        let active_session =
+            active_session_id.and_then(|sid| self.snapshot.sessions.iter().find(|s| s.id == sid));
+        let active_host_id = active_session.map(|s| s.host_id.as_str());
+        let active_project_id = active_session.and_then(|s| s.project_id.as_deref());
+
+        match item {
+            PaletteItem::Session { session_idx } => {
+                let s = &self.snapshot.sessions[*session_idx];
+                if Some(s.id.as_str()) == active_session_id {
+                    return 0;
+                }
+                if Some(s.host_id.as_str()) == active_host_id {
+                    return 1;
+                }
+                u32::MAX
+            }
+            PaletteItem::Project { project_idx } => {
+                let p = &self.snapshot.projects[*project_idx];
+                if Some(p.id.as_str()) == active_project_id {
+                    return 0;
+                }
+                if Some(p.host_id.as_str()) == active_host_id {
+                    return 1;
+                }
+                u32::MAX
+            }
+            PaletteItem::Action(action) => match action {
+                PaletteAction::NewSessionInProject { host_id, .. }
+                | PaletteAction::StartAgent {
+                    host_id: Some(host_id),
+                    ..
+                } => {
+                    if Some(host_id.as_str()) == active_host_id {
+                        1
+                    } else {
+                        u32::MAX
+                    }
+                }
+                PaletteAction::SwitchToSession { session_id, .. } => {
+                    if Some(session_id.as_str()) == active_session_id {
+                        0
+                    } else {
+                        u32::MAX
+                    }
+                }
+                _ => u32::MAX,
+            },
+        }
+    }
+
     fn compute_scored(&self) -> PaletteResults {
         let mut scored: Vec<ScoredEntry> = Vec::new();
 
@@ -577,39 +672,67 @@ impl CommandPalette {
 
         if include_sessions {
             for (i, item) in self.session_items.iter().enumerate() {
-                if let Some(fm) = fuzzy_match_item(&self.query, &item.title, &item.subtitle) {
+                if let Some(tm) = tiered_match_item(&self.query, &item.title, &item.subtitle) {
                     scored.push(ScoredEntry {
                         index: i,
                         source: ItemSource::Session,
-                        fuzzy_match: fm,
+                        fuzzy_match: FuzzyMatch {
+                            score: tm.score,
+                            matched_indices: tm.matched_indices,
+                        },
+                        tier: tm.tier,
+                        recent_rank: u32::MAX,
+                        context_rank: self.context_rank(&item.item),
+                        title_len: item.title.chars().count() as u32,
                     });
                 }
             }
         }
         if include_projects {
             for (i, item) in self.project_items.iter().enumerate() {
-                if let Some(fm) = fuzzy_match_item(&self.query, &item.title, &item.subtitle) {
+                if let Some(tm) = tiered_match_item(&self.query, &item.title, &item.subtitle) {
                     scored.push(ScoredEntry {
                         index: i,
                         source: ItemSource::Project,
-                        fuzzy_match: fm,
+                        fuzzy_match: FuzzyMatch {
+                            score: tm.score,
+                            matched_indices: tm.matched_indices,
+                        },
+                        tier: tm.tier,
+                        recent_rank: u32::MAX,
+                        context_rank: self.context_rank(&item.item),
+                        title_len: item.title.chars().count() as u32,
                     });
                 }
             }
         }
         if include_actions {
             for (i, item) in self.action_items.iter().enumerate() {
-                if let Some(fm) = fuzzy_match_item(&self.query, &item.title, &item.subtitle) {
+                if let Some(tm) = tiered_match_item(&self.query, &item.title, &item.subtitle) {
                     scored.push(ScoredEntry {
                         index: i,
                         source: ItemSource::Action,
-                        fuzzy_match: fm,
+                        fuzzy_match: FuzzyMatch {
+                            score: tm.score,
+                            matched_indices: tm.matched_indices,
+                        },
+                        tier: tm.tier,
+                        recent_rank: self.recent_action_rank(&item.item),
+                        context_rank: self.context_rank(&item.item),
+                        title_len: item.title.chars().count() as u32,
                     });
                 }
             }
         }
 
-        scored.sort_by(|a, b| b.fuzzy_match.score.cmp(&a.fuzzy_match.score));
+        scored.sort_by(|a, b| {
+            a.tier
+                .cmp(&b.tier)
+                .then(a.recent_rank.cmp(&b.recent_rank))
+                .then(a.context_rank.cmp(&b.context_rank))
+                .then(b.fuzzy_match.score.cmp(&a.fuzzy_match.score))
+                .then(a.title_len.cmp(&b.title_len))
+        });
 
         PaletteResults::Scored(scored)
     }
@@ -704,7 +827,49 @@ impl CommandPalette {
             row = row.child(pill);
         }
 
+        // Context chip: show active host / project when a session is selected.
+        if let Some(chip) = self.render_context_chip() {
+            row = row.child(div().flex_1()).child(chip);
+        }
+
         row
+    }
+
+    fn render_context_chip(&self) -> Option<Div> {
+        let session_id = self.snapshot.active_session_id.as_deref()?;
+        let session = self.snapshot.sessions.iter().find(|s| s.id == session_id)?;
+        let host_name = self.snapshot.host_name(&session.host_id);
+        let project_name = session
+            .project_id
+            .as_deref()
+            .and_then(|pid| self.snapshot.project_name(pid));
+
+        let label: SharedString = match project_name {
+            Some(proj) => format!("{host_name} / {proj}").into(),
+            None => host_name.into(),
+        };
+
+        Some(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(4.0))
+                .px(px(6.0))
+                .py(px(2.0))
+                .rounded(px(4.0))
+                .bg(theme::bg_tertiary())
+                .text_size(px(10.0))
+                .text_color(theme::text_secondary())
+                .overflow_hidden()
+                .whitespace_nowrap()
+                .max_w(px(180.0))
+                .child(
+                    icon(Icon::Server)
+                        .size(px(10.0))
+                        .text_color(theme::text_tertiary()),
+                )
+                .child(label),
+        )
     }
 
     fn render_input_bar(&self) -> impl IntoElement {
@@ -1101,10 +1266,26 @@ impl CommandPalette {
             PaletteAction::SwitchSession => Some("Ctrl+Tab"),
             _ => None,
         };
+        let is_recent = self
+            .snapshot
+            .recent_action_keys
+            .iter()
+            .any(|k| k == action.action_key());
 
-        div().when_some(shortcut, |s: Div, shortcut| {
-            s.child(render_key_pill(shortcut))
-        })
+        div()
+            .flex()
+            .items_center()
+            .gap(px(4.0))
+            .when(is_recent, |s: Div| {
+                s.child(
+                    icon(Icon::Clock)
+                        .size(px(12.0))
+                        .text_color(theme::text_tertiary()),
+                )
+            })
+            .when_some(shortcut, |s: Div, shortcut| {
+                s.child(render_key_pill(shortcut))
+            })
     }
 
     fn render_footer(&self) -> impl IntoElement {

--- a/crates/zremote-gui/src/views/fuzzy.rs
+++ b/crates/zremote-gui/src/views/fuzzy.rs
@@ -261,6 +261,156 @@ fn is_camel_transition(chars: &[char], idx: usize) -> bool {
     prev.is_lowercase() && curr.is_uppercase()
 }
 
+/// Match query against word-initial letters of target.
+///
+/// Returns the indices of matched word-boundary characters if every query
+/// character matches a successive word initial (case-insensitive). Returns
+/// `None` if the query is empty or if any query character has no matching
+/// word initial.
+///
+/// Example: `acronym_match("nt", "New Terminal")` → `Some(vec![0, 4])`
+pub fn acronym_match(query: &str, target: &str) -> Option<Vec<usize>> {
+    if query.is_empty() {
+        return None;
+    }
+
+    let query_chars: Vec<char> = query.chars().collect();
+    let target_chars: Vec<char> = target.chars().collect();
+
+    // Collect positions of word-initial characters.
+    let word_starts: Vec<usize> = target_chars
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| is_word_boundary(&target_chars, i))
+        .map(|(i, _)| i)
+        .collect();
+
+    let mut matched = Vec::with_capacity(query_chars.len());
+    let mut ws_idx = 0;
+
+    for &qc in &query_chars {
+        let qc_lower = qc.to_lowercase().next()?;
+        let mut found = false;
+        while ws_idx < word_starts.len() {
+            let pos = word_starts[ws_idx];
+            ws_idx += 1;
+            if target_chars[pos].to_lowercase().next() == Some(qc_lower) {
+                matched.push(pos);
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return None;
+        }
+    }
+
+    Some(matched)
+}
+
+/// Explicit match tier. Lower numeric value = better match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MatchTier {
+    /// Query exactly equals the title (case-insensitive).
+    ExactTitle = 1,
+    /// Title starts with the query (case-insensitive).
+    TitlePrefix = 2,
+    /// Word-initial letters match (acronym).
+    Acronym = 3,
+    /// All matched chars land on word boundaries in title.
+    WordBoundary = 4,
+    /// General fuzzy match in title.
+    TitleSubstring = 5,
+    /// Match involves subtitle characters.
+    SubtitleMatch = 6,
+}
+
+/// Extended match result with tier classification.
+#[derive(Debug, Clone)]
+pub struct TieredMatch {
+    pub tier: MatchTier,
+    /// Intra-tier tiebreaker score (from legacy fuzzy scoring).
+    pub score: i32,
+    pub matched_indices: Vec<usize>,
+}
+
+/// Tier-aware match of query against title + subtitle.
+///
+/// Tries tiers top-down (T1 -> T6), returns the best (lowest-numbered) tier
+/// that matches. Uses existing `fuzzy_match()`, `fuzzy_match_item()`, and
+/// `acronym_match()` internally.
+pub fn tiered_match_item(query: &str, title: &str, subtitle: &str) -> Option<TieredMatch> {
+    if query.is_empty() {
+        return None;
+    }
+
+    let q_lower: String = query.chars().flat_map(char::to_lowercase).collect();
+    let t_lower: String = title.chars().flat_map(char::to_lowercase).collect();
+
+    // T1: Exact title match (case-insensitive).
+    if q_lower == t_lower {
+        let indices: Vec<usize> = (0..title.chars().count()).collect();
+        return Some(TieredMatch {
+            tier: MatchTier::ExactTitle,
+            score: i32::MAX,
+            matched_indices: indices,
+        });
+    }
+
+    // T2: Title starts-with (case-insensitive).
+    // Indices are the leading character positions — no need for a full fuzzy scan.
+    if t_lower.starts_with(&q_lower) {
+        let char_count = query.chars().count();
+        let indices: Vec<usize> = (0..char_count).collect();
+        return Some(TieredMatch {
+            tier: MatchTier::TitlePrefix,
+            score: i32::MAX - 1,
+            matched_indices: indices,
+        });
+    }
+
+    // T3: Acronym match (word-initial letters).
+    if let Some(indices) = acronym_match(query, title) {
+        return Some(TieredMatch {
+            tier: MatchTier::Acronym,
+            score: 0,
+            matched_indices: indices,
+        });
+    }
+
+    // T4/T5: Fuzzy match in title only.
+    if let Some(fm) = fuzzy_match(query, title) {
+        let title_chars: Vec<char> = title.chars().collect();
+        let all_on_boundaries = fm
+            .matched_indices
+            .iter()
+            .all(|&i| is_word_boundary(&title_chars, i) || is_camel_transition(&title_chars, i));
+        if all_on_boundaries {
+            return Some(TieredMatch {
+                tier: MatchTier::WordBoundary,
+                score: fm.score,
+                matched_indices: fm.matched_indices,
+            });
+        }
+        return Some(TieredMatch {
+            tier: MatchTier::TitleSubstring,
+            score: fm.score,
+            matched_indices: fm.matched_indices,
+        });
+    }
+
+    // T6: Match involves subtitle.
+    if let Some(fm) = fuzzy_match_item(query, title, subtitle) {
+        return Some(TieredMatch {
+            tier: MatchTier::SubtitleMatch,
+            score: fm.score,
+            matched_indices: fm.matched_indices,
+        });
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,5 +497,153 @@ mod tests {
             title_match.score,
             subtitle_match.score
         );
+    }
+
+    // --- Acronym matching tests ---
+
+    #[test]
+    fn test_acronym_basic() {
+        let m = acronym_match("nt", "New Terminal").expect("should match");
+        assert_eq!(m, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_acronym_case_insensitive() {
+        let m = acronym_match("cs", "Close Session").expect("should match");
+        assert_eq!(m, vec![0, 6]);
+    }
+
+    #[test]
+    fn test_acronym_three_words() {
+        let m = acronym_match("nts", "New Terminal Session").expect("should match");
+        assert_eq!(m, vec![0, 4, 13]);
+    }
+
+    #[test]
+    fn test_acronym_no_match() {
+        assert!(acronym_match("xyz", "New Terminal").is_none());
+    }
+
+    #[test]
+    fn test_acronym_single_char() {
+        let m = acronym_match("n", "New Terminal").expect("should match");
+        assert_eq!(m, vec![0]);
+    }
+
+    #[test]
+    fn test_acronym_rejects_non_initial() {
+        // "e" is not a word-initial character in "New Terminal"
+        assert!(acronym_match("ne", "New Terminal").is_none());
+    }
+
+    #[test]
+    fn test_acronym_hyphenated() {
+        let m = acronym_match("pa", "project-admin").expect("should match hyphenated words");
+        assert_eq!(m, vec![0, 8]);
+    }
+
+    #[test]
+    fn test_acronym_empty_query() {
+        assert!(acronym_match("", "New Terminal").is_none());
+    }
+
+    #[test]
+    fn test_acronym_empty_target() {
+        assert!(acronym_match("nt", "").is_none());
+    }
+
+    #[test]
+    fn test_acronym_more_query_than_words() {
+        // 3 query chars but only 2 words
+        assert!(acronym_match("nts", "New Terminal").is_none());
+    }
+
+    // --- Tiered matching tests ---
+
+    #[test]
+    fn test_tier_exact_title() {
+        let m = tiered_match_item("New Session", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::ExactTitle);
+    }
+
+    #[test]
+    fn test_tier_exact_case_insensitive() {
+        let m = tiered_match_item("new session", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::ExactTitle);
+    }
+
+    #[test]
+    fn test_tier_prefix() {
+        let m = tiered_match_item("New", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::TitlePrefix);
+    }
+
+    #[test]
+    fn test_tier_acronym() {
+        let m = tiered_match_item("ns", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::Acronym);
+    }
+
+    #[test]
+    fn test_tier_title_substring() {
+        let m = tiered_match_item("essi", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::TitleSubstring);
+    }
+
+    #[test]
+    fn test_tier_subtitle_match() {
+        let m = tiered_match_item("myhost", "New Session", "myhost.example.com").unwrap();
+        assert_eq!(m.tier, MatchTier::SubtitleMatch);
+    }
+
+    #[test]
+    fn test_tier_no_match() {
+        assert!(tiered_match_item("zzz", "New Session", "subtitle").is_none());
+    }
+
+    #[test]
+    fn test_tier_ordering() {
+        assert!(MatchTier::ExactTitle < MatchTier::TitlePrefix);
+        assert!(MatchTier::TitlePrefix < MatchTier::Acronym);
+        assert!(MatchTier::Acronym < MatchTier::WordBoundary);
+        assert!(MatchTier::WordBoundary < MatchTier::TitleSubstring);
+        assert!(MatchTier::TitleSubstring < MatchTier::SubtitleMatch);
+    }
+
+    #[test]
+    fn test_tier_empty_query() {
+        assert!(tiered_match_item("", "New Session", "").is_none());
+    }
+
+    // --- Tier precedence tests (integration-level) ---
+
+    #[test]
+    fn test_tier_beats_score() {
+        // ExactTitle (T1) must rank above Acronym (T3) regardless of score.
+        let exact = tiered_match_item("New Session", "New Session", "").unwrap();
+        let acronym = tiered_match_item("ns", "New Session", "").unwrap();
+        assert!(exact.tier < acronym.tier, "T1 must beat T3");
+    }
+
+    #[test]
+    fn test_prefix_beats_acronym() {
+        let prefix = tiered_match_item("New", "New Session", "").unwrap();
+        let acronym = tiered_match_item("ns", "New Session", "").unwrap();
+        assert!(prefix.tier < acronym.tier, "T2 must beat T3");
+    }
+
+    #[test]
+    fn test_title_match_beats_subtitle() {
+        // A title substring match (T5) must beat a subtitle-only match (T6).
+        let title = tiered_match_item("essi", "New Session", "some host").unwrap();
+        let sub = tiered_match_item("host", "New Session", "some host").unwrap();
+        assert!(title.tier < sub.tier, "T5 must beat T6");
+    }
+
+    #[test]
+    fn test_prefix_indices_are_leading() {
+        let m = tiered_match_item("New", "New Session", "").unwrap();
+        assert_eq!(m.tier, MatchTier::TitlePrefix);
+        assert_eq!(m.matched_indices, vec![0, 1, 2]);
     }
 }

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -1018,12 +1018,15 @@ impl MainView {
 
         // Build snapshot from sidebar + persistence (Rc::clone = O(1), no data copying)
         let snapshot = self.sidebar.read(cx);
-        let recent_sessions = self
+        let (recent_sessions, recent_actions) = self
             .app_state
             .persistence
             .lock()
             .ok()
-            .map(|p| p.state().recent_sessions.clone())
+            .map(|p| {
+                let state = p.state();
+                (state.recent_sessions.clone(), state.recent_actions.clone())
+            })
             .unwrap_or_default();
         let cc_states = snapshot.cc_states().clone();
         let cc_metrics = snapshot.cc_metrics().clone();
@@ -1034,6 +1037,7 @@ impl MainView {
             self.app_state.mode.clone(),
             snapshot.selected_session_id().map(String::from),
             &recent_sessions,
+            &recent_actions,
             cc_states,
             cc_metrics,
             Rc::clone(snapshot.agent_profiles_rc()),
@@ -1279,6 +1283,11 @@ impl MainView {
                     );
                 }
             }
+            CommandPaletteEvent::RecordRecentAction { action_key } => {
+                if let Ok(mut p) = self.app_state.persistence.lock() {
+                    p.record_action_usage(action_key);
+                }
+            }
             CommandPaletteEvent::ShowSettings => {
                 // Handled directly here (not via `SidebarEvent::OpenSettings`)
                 // because the modal is owned by `MainView`, not the sidebar --
@@ -1441,6 +1450,11 @@ impl MainView {
                     this.sidebar.update(cx, |sidebar, cx| {
                         sidebar.refresh_agent_profiles(cx);
                     });
+                }
+                SettingsModalEvent::ClearRecentActions => {
+                    if let Ok(mut p) = this.app_state.persistence.lock() {
+                        p.clear_recent_actions();
+                    }
                 }
             },
         )

--- a/crates/zremote-gui/src/views/settings_modal.rs
+++ b/crates/zremote-gui/src/views/settings_modal.rs
@@ -24,14 +24,20 @@ use zremote_client::{AgentKindInfo, AgentProfile};
 /// Which tab is currently active in the settings modal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsTab {
+    General,
     AgentProfiles,
 }
 
 impl SettingsTab {
     fn label(self) -> &'static str {
         match self {
+            Self::General => "General",
             Self::AgentProfiles => "Agent Profiles",
         }
+    }
+
+    fn all() -> &'static [Self] {
+        &[Self::General, Self::AgentProfiles]
     }
 }
 
@@ -48,6 +54,8 @@ pub enum SettingsModalEvent {
     /// A CRUD mutation succeeded in one of the tabs. `MainView` re-fetches
     /// the shared sidebar caches in response.
     ProfilesChanged,
+    /// User clicked "Clear Recent Actions" in the General tab.
+    ClearRecentActions,
 }
 
 impl EventEmitter<SettingsModalEvent> for SettingsModal {}
@@ -94,6 +102,64 @@ impl SettingsModal {
         });
     }
 
+    fn render_general_tab(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex_1()
+            .min_h_0()
+            .p(px(16.0))
+            .flex()
+            .flex_col()
+            .gap(px(16.0))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(8.0))
+                    .child(
+                        div()
+                            .text_size(px(13.0))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme::text_primary())
+                            .child("Command Palette"),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(theme::text_secondary())
+                            .child(
+                                "Recently used actions are tracked and boosted in palette results.",
+                            ),
+                    )
+                    .child(
+                        div()
+                            .id("clear-recent-actions")
+                            .cursor_pointer()
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .px(px(10.0))
+                            .py(px(6.0))
+                            .rounded(px(4.0))
+                            .bg(theme::bg_tertiary())
+                            .hover(|s| s.bg(theme::border()))
+                            .child(
+                                icon(Icon::Clock)
+                                    .size(px(14.0))
+                                    .text_color(theme::text_secondary()),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(12.0))
+                                    .text_color(theme::text_primary())
+                                    .child("Clear Recent Actions"),
+                            )
+                            .on_click(cx.listener(|_this, _: &ClickEvent, _window, cx| {
+                                cx.emit(SettingsModalEvent::ClearRecentActions);
+                            })),
+                    ),
+            )
+    }
+
     fn render_tab_button(&self, tab: SettingsTab, cx: &mut Context<Self>) -> impl IntoElement {
         let is_active = self.active_tab == tab;
         let id = SharedString::from(format!("settings-tab-{}", tab.label()));
@@ -129,22 +195,23 @@ impl Focusable for SettingsModal {
 
 impl Render for SettingsModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // Delegate focus to the active tab so its keyboard routing receives
-        // printable chars for the text fields. Only take focus if nothing in
-        // the modal's focus tree currently holds it -- otherwise we would
-        // steal focus back from the tab every frame and break typing.
-        //
-        // FIXME: when a second tab is introduced, this check must inspect
-        // **every** tab's focus handle (not just the active one). Otherwise,
-        // switching tabs while an inactive tab's input still has focus will
-        // cause the active tab to steal it on the next frame, breaking typing
-        // in the background tab. Today only `AgentProfiles` exists, so the
-        // single-tab check is sufficient.
-        let tab_focus = self.agent_profiles_tab.read(cx).focus_handle(cx);
-        if !tab_focus.contains_focused(window, cx)
-            && !self.focus_handle.contains_focused(window, cx)
-        {
-            tab_focus.focus(window);
+        // Delegate focus to the active tab's focus handle so keyboard routing
+        // reaches text fields. For tabs without their own focus (General), the
+        // modal keeps focus itself.
+        match self.active_tab {
+            SettingsTab::AgentProfiles => {
+                let tab_focus = self.agent_profiles_tab.read(cx).focus_handle(cx);
+                if !tab_focus.contains_focused(window, cx)
+                    && !self.focus_handle.contains_focused(window, cx)
+                {
+                    tab_focus.focus(window);
+                }
+            }
+            SettingsTab::General => {
+                if !self.focus_handle.contains_focused(window, cx) {
+                    self.focus_handle.focus(window);
+                }
+            }
         }
 
         let header = div()
@@ -170,11 +237,11 @@ impl Render for SettingsModal {
                     .child("Settings"),
             )
             .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .px(px(8.0))
-                    .child(self.render_tab_button(SettingsTab::AgentProfiles, cx)),
+                div().flex().items_center().px(px(8.0)).children(
+                    SettingsTab::all()
+                        .iter()
+                        .map(|&tab| self.render_tab_button(tab, cx).into_any_element()),
+                ),
             );
 
         // `min_h_0` on the body is the first link in a chain that lets the
@@ -182,6 +249,7 @@ impl Render for SettingsModal {
         // 560px height. Without it, the body grows to fit its child's
         // intrinsic height and the scroll region never gets a bounded frame.
         let body = match self.active_tab {
+            SettingsTab::General => self.render_general_tab(cx).into_any_element(),
             SettingsTab::AgentProfiles => div()
                 .flex_1()
                 .min_h_0()


### PR DESCRIPTION
## Summary

Closes #26

- **Recent action tracking**: Actions executed from the palette are persisted (capped at 20, deduplicated), recently used actions float to the top in grouped view and receive a ranking boost in search
- **Acronym matching**: Typing word-initial letters matches items (e.g., `nt` matches "New Terminal", `cs` matches "Close Session")
- **Tiered scoring**: Replaces flat numeric score with explicit match tiers — ExactTitle > TitlePrefix > Acronym > WordBoundary > TitleSubstring > SubtitleMatch. Within tiers: recent rank, context rank, legacy score, title length
- **Context-aware ranking**: Active session/host boosts related items as tiebreaker within the same match tier
- **UX polish**: Clock badge on recently-used actions, context chip in palette tab bar showing active host/project, General tab in Settings modal with "Clear Recent Actions" button

## Files changed (9)

| File | Changes |
|------|---------|
| `fuzzy.rs` | `acronym_match()`, `MatchTier`, `TieredMatch`, `tiered_match_item()` |
| `actions.rs` | `action_key()` method, `RecordRecentAction` emit |
| `items.rs` | `ScoredEntry` extended with tier/ranking fields, `PaletteSnapshot` extended |
| `mod.rs` | `compute_scored()` rewritten with tiered sort, `recent_action_rank()`, `context_rank()`, clock badge, context chip, grouped recent sort |
| `persistence.rs` | `RecentAction` type, `record_action_usage()`, `clear_recent_actions()` |
| `settings_modal.rs` | General tab with Clear Recent Actions |
| `main_view.rs` | `RecordRecentAction` + `ClearRecentActions` event handlers |
| `icons.rs` | `Clock` variant |
| `clock.svg` | Lucide clock icon |

## Test plan

- [x] 26 new unit tests (145 total in zremote-gui, 2306 workspace-wide)
- [x] Tier precedence tests (ExactTitle beats Prefix beats Acronym, etc.)
- [x] Recent action persistence tests (dedup, cap, clear, backward compat)
- [x] Acronym matching edge cases (hyphenated, empty, over-specified)
- [x] Pre-commit hooks pass (fmt, clippy, full test suite)
- [ ] Visual verification of clock badges, context chip, General settings tab