### PR TITLE
feat(projects): detect and link git worktrees to parent repo

### DIFF
--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -337,6 +337,7 @@ pub(super) async fn handle_server_message(
                         has_claude_config: info.has_claude_config,
                         has_zremote_config: info.has_zremote_config,
                         project_type: info.project_type,
+                        main_repo_path: info.main_repo_path,
                     })
                     .is_err()
                 {

--- a/crates/zremote-agent/src/local/mod.rs
+++ b/crates/zremote-agent/src/local/mod.rs
@@ -69,6 +69,13 @@ pub async fn run_local(
             )
         })?;
 
+    // One-time idempotent backfill: re-link any orphan worktree rows whose
+    // main repo is registered but wasn't linked (pre-worktree-aware data).
+    // Don't fail startup on error — log and continue.
+    if let Err(e) = crate::project::repair::repair_orphaned_worktrees(&pool).await {
+        tracing::warn!(error = %e, "repair_orphaned_worktrees failed, continuing startup");
+    }
+
     // Generate deterministic host_id from hostname
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().to_string())

--- a/crates/zremote-agent/src/local/routes/projects/crud.rs
+++ b/crates/zremote-agent/src/local/routes/projects/crud.rs
@@ -14,6 +14,7 @@ use zremote_core::state::ServerEvent;
 use zremote_core::validation::validate_path_no_traversal;
 
 use crate::local::state::LocalAppState;
+use crate::project::metadata;
 use crate::project::scanner::ProjectScanner;
 
 use super::{parse_host_id, parse_project_id};
@@ -51,9 +52,13 @@ pub async fn add_project(
         return Err(AppError::NotFound(format!("host {host_id} not found")));
     }
 
-    // Detect project info directly from filesystem
-    let path = Path::new(&body.path);
-    let info = ProjectScanner::detect_at(path);
+    // Detect project info directly from filesystem on a blocking thread
+    // (ProjectScanner::detect_at performs FS reads + `git` subprocess spawns).
+    let body_path_owned = body.path.clone();
+    let info =
+        tokio::task::spawn_blocking(move || ProjectScanner::detect_at(Path::new(&body_path_owned)))
+            .await
+            .map_err(|e| AppError::Internal(format!("project detection task failed: {e}")))?;
 
     let project_id = Uuid::new_v4().to_string();
     let name = body
@@ -63,62 +68,74 @@ pub async fn add_project(
         .unwrap_or("unknown")
         .to_string();
 
-    let inserted = q::insert_project(&state.db, &project_id, &host_id, &body.path, &name).await?;
+    // If this is a linked worktree, resolve or auto-register the parent project.
+    let parent_project_id = match info.as_ref().and_then(|i| i.main_repo_path.as_ref()) {
+        Some(main_path) => {
+            match q::get_project_by_host_and_path(&state.db, &host_id, main_path).await {
+                Ok(parent) => Some(parent.id),
+                Err(AppError::Database(sqlx::Error::RowNotFound)) => {
+                    let parent_id = Uuid::new_v4().to_string();
+                    let parent_name = main_path
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let inserted =
+                        q::insert_project(&state.db, &parent_id, &host_id, main_path, &parent_name)
+                            .await?;
+                    // INSERT OR IGNORE: on a race a row already exists with a
+                    // different UUID. Always re-fetch the canonical id so the
+                    // worktree FK points at a real row rather than a phantom.
+                    let canonical_parent_id = if inserted {
+                        parent_id
+                    } else {
+                        q::get_project_by_host_and_path(&state.db, &host_id, main_path)
+                            .await?
+                            .id
+                    };
+                    let main_path_owned = main_path.clone();
+                    let parent_info = tokio::task::spawn_blocking(move || {
+                        ProjectScanner::detect_at(Path::new(&main_path_owned))
+                    })
+                    .await
+                    .map_err(|e| {
+                        AppError::Internal(format!("parent detection task failed: {e}"))
+                    })?;
+                    if let Some(parent_info) = parent_info {
+                        metadata::update_from_info(&state.db, &canonical_parent_id, &parent_info)
+                            .await?;
+                    }
+                    Some(canonical_parent_id)
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        None => None,
+    };
+
+    let inserted = if parent_project_id.is_some() {
+        q::insert_project_with_parent(
+            &state.db,
+            &project_id,
+            &host_id,
+            &body.path,
+            &name,
+            parent_project_id.as_deref(),
+            "worktree",
+        )
+        .await?
+    } else {
+        q::insert_project(&state.db, &project_id, &host_id, &body.path, &name).await?
+    };
     if !inserted {
         return Err(AppError::Conflict(
             "project path already exists".to_string(),
         ));
     }
 
-    // Update project info if detected
+    // Update project metadata from detection
     if let Some(ref info) = info {
-        let remotes_json = info
-            .git_info
-            .as_ref()
-            .map(|g| serde_json::to_string(&g.remotes).unwrap_or_default());
-        let now = chrono::Utc::now().to_rfc3339();
-        let frameworks_json = serde_json::to_string(&info.frameworks).unwrap_or_default();
-        let architecture_str = info
-            .architecture
-            .as_ref()
-            .and_then(|a| serde_json::to_value(a).ok())
-            .and_then(|v| v.as_str().map(String::from));
-        let conventions_json = serde_json::to_string(&info.conventions).unwrap_or_default();
-
-        sqlx::query(
-            "UPDATE projects SET project_type = ?, has_claude_config = ?, has_zremote_config = ?, \
-             git_branch = ?, git_commit_hash = ?, git_commit_message = ?, \
-             git_is_dirty = ?, git_ahead = ?, git_behind = ?, git_remotes = ?, git_updated_at = ?, \
-             frameworks = ?, architecture = ?, conventions = ?, package_manager = ? \
-             WHERE id = ?",
-        )
-        .bind(&info.project_type)
-        .bind(info.has_claude_config)
-        .bind(info.has_zremote_config)
-        .bind(info.git_info.as_ref().and_then(|g| g.branch.as_deref()))
-        .bind(
-            info.git_info
-                .as_ref()
-                .and_then(|g| g.commit_hash.as_deref()),
-        )
-        .bind(
-            info.git_info
-                .as_ref()
-                .and_then(|g| g.commit_message.as_deref()),
-        )
-        .bind(info.git_info.as_ref().is_some_and(|g| g.is_dirty))
-        .bind(info.git_info.as_ref().map_or(0, |g| g.ahead))
-        .bind(info.git_info.as_ref().map_or(0, |g| g.behind))
-        .bind(&remotes_json)
-        .bind(&now)
-        .bind(&frameworks_json)
-        .bind(&architecture_str)
-        .bind(&conventions_json)
-        .bind(&info.package_manager)
-        .bind(&project_id)
-        .execute(&state.db)
-        .await
-        .map_err(AppError::Database)?;
+        metadata::update_from_info(&state.db, &project_id, info).await?;
     }
 
     let project = q::get_project_by_host_and_path(&state.db, &host_id, &body.path).await?;

--- a/crates/zremote-agent/src/local/routes/projects/scan.rs
+++ b/crates/zremote-agent/src/local/routes/projects/scan.rs
@@ -9,6 +9,7 @@ use zremote_core::queries::projects as q;
 use zremote_core::state::ServerEvent;
 
 use crate::local::state::LocalAppState;
+use crate::project::metadata;
 use crate::project::scanner::ProjectScanner;
 
 use super::parse_host_id;
@@ -28,65 +29,94 @@ pub async fn trigger_scan(
     .await
     .map_err(|e| AppError::Internal(format!("scan task failed: {e}")))?;
 
-    // Upsert each discovered project into the database
-    for info in &projects {
+    // Partition main repos and linked worktrees; insert main repos first so
+    // worktrees can resolve their parent_project_id.
+    let (worktrees, main_repos): (Vec<_>, Vec<_>) = projects
+        .iter()
+        .partition(|info| info.main_repo_path.is_some());
+
+    for info in &main_repos {
         let pid = Uuid::new_v5(
             &Uuid::NAMESPACE_URL,
             format!("{}:{}", host_id, info.path).as_bytes(),
         )
         .to_string();
 
+        // INSERT OR IGNORE: on a pre-existing row the returned `pid` may not
+        // match the stored row's id (e.g. legacy UUIDv4 insert). Re-fetch the
+        // canonical id so the metadata UPDATE hits the real row.
         q::insert_project(&state.db, &pid, &host_id, &info.path, &info.name).await?;
+        let canonical_id = q::get_project_by_host_and_path(&state.db, &host_id, &info.path)
+            .await?
+            .id;
+        metadata::update_from_info(&state.db, &canonical_id, info).await?;
+    }
 
-        // Update project metadata
-        let remotes_json = info
-            .git_info
-            .as_ref()
-            .map(|g| serde_json::to_string(&g.remotes).unwrap_or_default());
-        let now = chrono::Utc::now().to_rfc3339();
+    for info in &worktrees {
+        let pid = Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            format!("{}:{}", host_id, info.path).as_bytes(),
+        )
+        .to_string();
 
-        let frameworks_json = serde_json::to_string(&info.frameworks).unwrap_or_default();
-        let architecture_str = info
-            .architecture
-            .as_ref()
-            .and_then(|a| serde_json::to_value(a).ok())
-            .and_then(|v| v.as_str().map(String::from));
-        let conventions_json = serde_json::to_string(&info.conventions).unwrap_or_default();
+        let parent_id = match info.main_repo_path.as_ref() {
+            Some(mp) => match q::get_project_by_host_and_path(&state.db, &host_id, mp).await {
+                Ok(p) => Some(p.id),
+                Err(AppError::Database(sqlx::Error::RowNotFound)) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        worktree_path = %info.path,
+                        main_path = %mp,
+                        error = %e,
+                        "transient error resolving parent project for linked worktree during scan"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
 
-        sqlx::query(
-            "UPDATE projects SET project_type = ?, has_claude_config = ?, has_zremote_config = ?, \
-             git_branch = ?, git_commit_hash = ?, git_commit_message = ?, \
-             git_is_dirty = ?, git_ahead = ?, git_behind = ?, git_remotes = ?, git_updated_at = ?, \
-             frameworks = ?, architecture = ?, conventions = ?, package_manager = ? \
-             WHERE id = ?",
-        )
-        .bind(&info.project_type)
-        .bind(info.has_claude_config)
-        .bind(info.has_zremote_config)
-        .bind(info.git_info.as_ref().and_then(|g| g.branch.as_deref()))
-        .bind(
-            info.git_info
-                .as_ref()
-                .and_then(|g| g.commit_hash.as_deref()),
-        )
-        .bind(
-            info.git_info
-                .as_ref()
-                .and_then(|g| g.commit_message.as_deref()),
-        )
-        .bind(info.git_info.as_ref().is_some_and(|g| g.is_dirty))
-        .bind(info.git_info.as_ref().map_or(0, |g| g.ahead))
-        .bind(info.git_info.as_ref().map_or(0, |g| g.behind))
-        .bind(&remotes_json)
-        .bind(&now)
-        .bind(&frameworks_json)
-        .bind(&architecture_str)
-        .bind(&conventions_json)
-        .bind(&info.package_manager)
-        .bind(&pid)
-        .execute(&state.db)
-        .await
-        .map_err(AppError::Database)?;
+        if parent_id.is_some() {
+            q::insert_project_with_parent(
+                &state.db,
+                &pid,
+                &host_id,
+                &info.path,
+                &info.name,
+                parent_id.as_deref(),
+                "worktree",
+            )
+            .await?;
+        } else {
+            q::insert_project(&state.db, &pid, &host_id, &info.path, &info.name).await?;
+        }
+
+        // Re-fetch canonical id (INSERT OR IGNORE may have skipped on pre-existing row).
+        let canonical_id = q::get_project_by_host_and_path(&state.db, &host_id, &info.path)
+            .await?
+            .id;
+
+        // Backfill parent linkage on rows inserted before the main repo was
+        // known — only when the DB row still has no parent, so we don't
+        // clobber a manually-set or previously-correct parent.
+        if let Some(pid_parent) = parent_id.as_deref() {
+            let needs_link = q::get_project(&state.db, &canonical_id)
+                .await
+                .map(|row| row.parent_project_id.is_none())
+                .unwrap_or(false);
+            if needs_link
+                && let Err(e) =
+                    q::set_parent_project_id(&state.db, &canonical_id, pid_parent, "worktree").await
+            {
+                tracing::warn!(
+                    worktree_path = %info.path,
+                    error = %e,
+                    "failed to backfill parent linkage during scan"
+                );
+            }
+        }
+
+        metadata::update_from_info(&state.db, &canonical_id, info).await?;
     }
 
     // Broadcast event

--- a/crates/zremote-agent/src/local/routes/projects/tests.rs
+++ b/crates/zremote-agent/src/local/routes/projects/tests.rs
@@ -1667,6 +1667,228 @@ async fn resolve_action_inputs_success() {
     assert_eq!(options.len(), 2);
 }
 
+/// Init main git repo + `git worktree add` a linked worktree under `main_path/../wt_name`.
+/// Returns (main_path, worktree_path) with both containing a Cargo.toml marker.
+fn init_main_and_worktree(
+    parent: &std::path::Path,
+    main_name: &str,
+    wt_name: &str,
+    branch: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let main = parent.join(main_name);
+    std::fs::create_dir_all(&main).unwrap();
+    init_isolated_git_repo(&main);
+    std::fs::write(main.join("Cargo.toml"), "[package]\nname = \"main\"").unwrap();
+
+    let wt = parent.join(wt_name);
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "-b", branch, wt.to_str().unwrap()])
+        .current_dir(&main)
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", &main)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("git worktree add");
+    assert!(
+        output.status.success(),
+        "git worktree add failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::write(wt.join("Cargo.toml"), "[package]\nname = \"wt\"").unwrap();
+
+    (main, wt)
+}
+
+async fn post_add_project(app: &Router, host_id: &str, path: &str) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/hosts/{host_id}/projects"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({ "path": path })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn add_worktree_links_to_existing_parent() {
+    let state = test_state().await;
+    let host_id = state.host_id.to_string();
+    let tmp = tempfile::tempdir().unwrap();
+    let (main, wt) = init_main_and_worktree(tmp.path(), "main", "wt", "feature");
+    let main_path = std::fs::canonicalize(&main)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let wt_path = std::fs::canonicalize(&wt)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let app = build_test_router(state.clone());
+
+    let r = post_add_project(&app, &host_id, &main_path).await;
+    assert_eq!(r.status(), StatusCode::CREATED);
+    let parent = q::get_project_by_host_and_path(&state.db, &host_id, &main_path)
+        .await
+        .unwrap();
+
+    let r = post_add_project(&app, &host_id, &wt_path).await;
+    assert_eq!(r.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(r.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["parent_project_id"], parent.id);
+    assert_eq!(json["project_type"], "worktree");
+}
+
+#[tokio::test]
+async fn add_worktree_auto_registers_parent() {
+    let state = test_state().await;
+    let host_id = state.host_id.to_string();
+    let tmp = tempfile::tempdir().unwrap();
+    let (main, wt) = init_main_and_worktree(tmp.path(), "main", "wt", "feature");
+    let main_path = std::fs::canonicalize(&main)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let wt_path = std::fs::canonicalize(&wt)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let app = build_test_router(state.clone());
+
+    // Register ONLY the worktree; parent must be auto-created.
+    let r = post_add_project(&app, &host_id, &wt_path).await;
+    assert_eq!(r.status(), StatusCode::CREATED);
+
+    let parent = q::get_project_by_host_and_path(&state.db, &host_id, &main_path)
+        .await
+        .expect("parent should be auto-registered");
+    let wt_row = q::get_project_by_host_and_path(&state.db, &host_id, &wt_path)
+        .await
+        .unwrap();
+    assert_eq!(
+        wt_row.parent_project_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(wt_row.project_type, "worktree");
+}
+
+#[tokio::test]
+async fn add_regular_project_still_works() {
+    let state = test_state().await;
+    let host_id = state.host_id.to_string();
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("plain");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("Cargo.toml"), "[package]\nname = \"plain\"").unwrap();
+    let path = dir.to_string_lossy().to_string();
+
+    let app = build_test_router(state.clone());
+    let r = post_add_project(&app, &host_id, &path).await;
+    assert_eq!(r.status(), StatusCode::CREATED);
+
+    let row = q::get_project_by_host_and_path(&state.db, &host_id, &path)
+        .await
+        .unwrap();
+    assert!(row.parent_project_id.is_none());
+    assert_eq!(row.project_type, "rust");
+}
+
+#[tokio::test]
+async fn scan_links_worktrees_to_main_repos() {
+    // Exercise the same ordering/linking logic the /scan handler uses, without
+    // mutating process env (Rust 2024 marks std::env::set_var as unsafe and
+    // the workspace denies unsafe_code).
+    use crate::project::metadata;
+    use crate::project::scanner::ProjectScanner;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (main, wt) = init_main_and_worktree(tmp.path(), "main", "wt", "feature");
+    let main_path = std::fs::canonicalize(&main)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let wt_path = std::fs::canonicalize(&wt)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let state = test_state().await;
+    let host_id = state.host_id.to_string();
+
+    let main_info =
+        ProjectScanner::detect_at(std::path::Path::new(&main_path)).expect("detect main repo");
+    let wt_info =
+        ProjectScanner::detect_at(std::path::Path::new(&wt_path)).expect("detect worktree");
+
+    // Same ordering as trigger_scan: main repos first, then worktrees.
+    let main_id = Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("{}:{}", host_id, main_info.path).as_bytes(),
+    )
+    .to_string();
+    q::insert_project(
+        &state.db,
+        &main_id,
+        &host_id,
+        &main_info.path,
+        &main_info.name,
+    )
+    .await
+    .unwrap();
+    metadata::update_from_info(&state.db, &main_id, &main_info)
+        .await
+        .unwrap();
+
+    let wt_id = Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("{}:{}", host_id, wt_info.path).as_bytes(),
+    )
+    .to_string();
+    let parent = q::get_project_by_host_and_path(
+        &state.db,
+        &host_id,
+        wt_info.main_repo_path.as_deref().unwrap(),
+    )
+    .await
+    .expect("parent resolvable");
+    q::insert_project_with_parent(
+        &state.db,
+        &wt_id,
+        &host_id,
+        &wt_info.path,
+        &wt_info.name,
+        Some(&parent.id),
+        "worktree",
+    )
+    .await
+    .unwrap();
+    metadata::update_from_info(&state.db, &wt_id, &wt_info)
+        .await
+        .unwrap();
+
+    let wt_row = q::get_project_by_host_and_path(&state.db, &host_id, &wt_path)
+        .await
+        .unwrap();
+    assert_eq!(
+        wt_row.parent_project_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(wt_row.project_type, "worktree");
+    assert!(wt_info.main_repo_path.is_some());
+}
+
 #[tokio::test]
 async fn run_action_with_custom_inputs() {
     let state = test_state().await;

--- a/crates/zremote-agent/src/local/routes/projects/worktree.rs
+++ b/crates/zremote-agent/src/local/routes/projects/worktree.rs
@@ -110,15 +110,15 @@ pub async fn create_worktree(
                                             .next()
                                             .unwrap_or("worktree")
                                             .to_string();
-                                        let _ = sqlx::query(
-                                            "INSERT OR IGNORE INTO projects (id, host_id, path, name, parent_project_id, project_type) VALUES (?, ?, ?, ?, ?, 'worktree')"
+                                        let _ = q::insert_project_with_parent(
+                                            &db,
+                                            &wt_id,
+                                            &hid,
+                                            &wt.path,
+                                            &wt_name,
+                                            Some(&pid),
+                                            "worktree",
                                         )
-                                        .bind(&wt_id)
-                                        .bind(&hid)
-                                        .bind(&wt.path)
-                                        .bind(&wt_name)
-                                        .bind(&pid)
-                                        .execute(&db)
                                         .await;
 
                                         let _ = sqlx::query("UPDATE projects SET git_branch = ?, git_commit_hash = ? WHERE id = ?")
@@ -214,18 +214,16 @@ pub async fn create_worktree(
         .unwrap_or("worktree")
         .to_string();
 
-    sqlx::query(
-        "INSERT OR IGNORE INTO projects (id, host_id, path, name, parent_project_id, project_type) \
-         VALUES (?, ?, ?, ?, ?, 'worktree')",
+    q::insert_project_with_parent(
+        &state.db,
+        &wt_id,
+        &host_id_str,
+        &result.path,
+        &wt_name,
+        Some(&project_id),
+        "worktree",
     )
-    .bind(&wt_id)
-    .bind(&host_id_str)
-    .bind(&result.path)
-    .bind(&wt_name)
-    .bind(&project_id)
-    .execute(&state.db)
-    .await
-    .map_err(AppError::Database)?;
+    .await?;
 
     // Update git info on the new worktree
     sqlx::query("UPDATE projects SET git_branch = ?, git_commit_hash = ? WHERE id = ?")

--- a/crates/zremote-agent/src/project/git.rs
+++ b/crates/zremote-agent/src/project/git.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use zremote_protocol::project::{GitInfo, GitRemote, WorktreeInfo};
@@ -287,6 +287,83 @@ impl GitInspector {
     }
 }
 
+/// If `path` is a linked git worktree, return the absolute path of its main
+/// repository (top-level of the main worktree). Returns None if not a linked
+/// worktree, if it's a submodule, or if git inspection fails.
+pub fn main_repo_path_for_worktree(path: &Path) -> Option<PathBuf> {
+    let git_entry = path.join(".git");
+    // A main repo has `.git` as a directory; a linked worktree has `.git` as a file.
+    if !git_entry.is_file() {
+        return None;
+    }
+
+    // Cap the read to 4 KiB — legitimate `.git` pointer files are ~70 bytes.
+    // Prevents a malicious large regular file from driving memory pressure.
+    let mut buf = [0u8; 4096];
+    let n = {
+        use std::io::Read;
+        let mut f = std::fs::File::open(&git_entry).ok()?;
+        f.read(&mut buf).ok()?
+    };
+    let contents = std::str::from_utf8(&buf[..n]).ok()?;
+    let gitdir_line = contents
+        .lines()
+        .find_map(|l| l.strip_prefix("gitdir:").map(str::trim))?;
+
+    // Submodules: gitdir points into `.git/modules/<name>`. Not a worktree.
+    if gitdir_line.contains("/modules/") {
+        return None;
+    }
+
+    // Linked worktrees: gitdir ends with `/.git/worktrees/<name>`.
+    if !gitdir_line.contains("/worktrees/") {
+        return None;
+    }
+
+    // Resolve the gitdir path (may be relative to the worktree dir).
+    let gitdir_path = Path::new(gitdir_line);
+    let absolute_gitdir = if gitdir_path.is_absolute() {
+        gitdir_path.to_path_buf()
+    } else {
+        path.join(gitdir_path)
+    };
+
+    // Try canonicalizing first; fall back to lexical cleanup if that fails
+    // (e.g., the worktree metadata moved but the main repo still exists).
+    let gitdir_resolved = std::fs::canonicalize(&absolute_gitdir).unwrap_or(absolute_gitdir);
+
+    // Strip trailing `/worktrees/<name>` → `<something>/.git`.
+    let dot_git = gitdir_resolved
+        .parent()
+        .and_then(|p| p.parent())
+        .map(Path::to_path_buf)?;
+
+    // Defense in depth: `gitdir:` content is user-controlled (any file the
+    // scanner walks). A crafted `gitdir: /etc/worktrees/x` passes the
+    // `/worktrees/` filter above; verify that the stripped path actually
+    // ends in a `.git` component before treating it as a real repo root.
+    if dot_git.file_name().and_then(|n| n.to_str()) != Some(".git") {
+        return None;
+    }
+
+    // Strip trailing `.git` → main repo working tree.
+    let main_repo = dot_git.parent().map(Path::to_path_buf)?;
+
+    let canonical_main = std::fs::canonicalize(&main_repo).unwrap_or(main_repo);
+
+    if !canonical_main.is_dir() {
+        return None;
+    }
+
+    // Make sure the main repo isn't the same directory as `path`.
+    let canonical_self = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if canonical_main == canonical_self {
+        return None;
+    }
+
+    Some(canonical_main)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,5 +590,52 @@ upstream\tgit@github.com:org/repo.git (push)
     fn run_git_nonexistent_path() {
         let result = run_git(Path::new("/nonexistent/path/xyz"), &["status"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn main_repo_path_for_worktree_returns_main_for_linked_worktree() {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        fs::create_dir_all(&main).unwrap();
+        init_git_repo(&main);
+
+        let wt = tmp.path().join("wt");
+        run_git(
+            &main,
+            &["worktree", "add", "-b", "feat", wt.to_str().unwrap()],
+        )
+        .expect("git worktree add");
+
+        let result = main_repo_path_for_worktree(&wt).expect("should detect main repo");
+        let expected = fs::canonicalize(&main).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn main_repo_path_for_worktree_returns_none_for_main_repo() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        assert!(main_repo_path_for_worktree(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn main_repo_path_for_worktree_returns_none_for_non_git_dir() {
+        let tmp = TempDir::new().unwrap();
+        assert!(main_repo_path_for_worktree(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn main_repo_path_for_worktree_returns_none_for_submodule() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".git"), "gitdir: ../../.git/modules/foo\n").unwrap();
+        assert!(main_repo_path_for_worktree(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn main_repo_path_for_worktree_returns_none_for_missing_git_entry() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        assert!(main_repo_path_for_worktree(&sub).is_none());
     }
 }

--- a/crates/zremote-agent/src/project/metadata.rs
+++ b/crates/zremote-agent/src/project/metadata.rs
@@ -1,0 +1,15 @@
+use sqlx::SqlitePool;
+use zremote_core::error::AppError;
+use zremote_core::queries::projects as q;
+use zremote_protocol::ProjectInfo;
+
+/// Update a projects row with detected metadata from `ProjectInfo`.
+/// Thin wrapper over the shared helper in `zremote-core` so agent and server
+/// share the same UPDATE SQL (including "worktree" project_type preservation).
+pub async fn update_from_info(
+    db: &SqlitePool,
+    project_id: &str,
+    info: &ProjectInfo,
+) -> Result<(), AppError> {
+    q::update_project_metadata_from_info(db, project_id, info).await
+}

--- a/crates/zremote-agent/src/project/mod.rs
+++ b/crates/zremote-agent/src/project/mod.rs
@@ -4,7 +4,9 @@ pub mod configure;
 pub mod git;
 pub mod hooks;
 pub mod intelligence;
+pub mod metadata;
 pub mod prompts;
+pub mod repair;
 pub mod scanner;
 pub mod settings;
 

--- a/crates/zremote-agent/src/project/repair.rs
+++ b/crates/zremote-agent/src/project/repair.rs
@@ -1,0 +1,215 @@
+use std::path::Path;
+
+use sqlx::SqlitePool;
+use zremote_core::error::AppError;
+use zremote_core::queries::projects as q;
+
+use super::git::main_repo_path_for_worktree;
+
+/// One-time idempotent repair at agent startup: find projects in the DB that
+/// are actually linked git worktrees but lack `parent_project_id`, and
+/// re-link them to their main repository's project row if that row exists.
+///
+/// Skips rows whose path does not exist on disk, is not a linked worktree, or
+/// whose main repo is not yet registered in the DB. Logs a summary.
+pub async fn repair_orphaned_worktrees(db: &SqlitePool) -> Result<(), AppError> {
+    let rows: Vec<(String, String, String)> =
+        sqlx::query_as("SELECT id, host_id, path FROM projects WHERE parent_project_id IS NULL")
+            .fetch_all(db)
+            .await?;
+
+    let total = rows.len();
+    let mut fixed: u32 = 0;
+
+    // Inspect all paths on a blocking thread so we don't stall the async
+    // runtime with `std::fs` / `git rev-parse` for each orphan row.
+    let inspected: Vec<(String, String, Option<String>)> = tokio::task::spawn_blocking(move || {
+        rows.into_iter()
+            .map(|(id, host_id, path)| {
+                let p = Path::new(&path);
+                let main = if p.join(".git").is_file() {
+                    main_repo_path_for_worktree(p).and_then(|mp| mp.to_str().map(String::from))
+                } else {
+                    None
+                };
+                (id, host_id, main)
+            })
+            .collect()
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("repair inspection task failed: {e}")))?;
+
+    for (id, host_id, main_path_opt) in inspected {
+        let Some(main_path_str) = main_path_opt else {
+            continue;
+        };
+        match q::get_project_by_host_and_path(db, &host_id, &main_path_str).await {
+            Ok(parent) => {
+                if parent.id == id {
+                    continue;
+                }
+                match q::set_parent_project_id(db, &id, &parent.id, "worktree").await {
+                    Ok(affected) if affected > 0 => fixed += 1,
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(error = %e, project_id = %id, "failed to link worktree to parent");
+                    }
+                }
+            }
+            Err(AppError::Database(sqlx::Error::RowNotFound)) => continue,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    project_id = %id,
+                    main_repo_path = %main_path_str,
+                    "transient error looking up main repo during repair",
+                );
+            }
+        }
+    }
+
+    tracing::info!(fixed, total, "repair_orphaned_worktrees: completed");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Run a git command directly (mirror of `project::git::run_git` test helper),
+    /// used by the test setup to build a real main repo + linked worktree.
+    fn run_git(path: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env("GIT_CEILING_DIRECTORIES", path)
+            .output()
+            .expect("git command");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn init_git_repo(dir: &Path) {
+        run_git(dir, &["init"]);
+        run_git(dir, &["config", "user.email", "test@test.com"]);
+        run_git(dir, &["config", "user.name", "Test"]);
+        run_git(dir, &["config", "commit.gpgsign", "false"]);
+        fs::write(dir.join("README.md"), "# Test").expect("write README");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "--no-verify", "-m", "initial"]);
+    }
+
+    async fn setup_pool_with_host() -> SqlitePool {
+        let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "INSERT INTO hosts (id, name, hostname, auth_token_hash, status) \
+             VALUES ('h1', 'test', 'test-host', 'hash', 'online')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    /// Build a tempdir with `main/` repo and a linked worktree `wt/`.
+    /// Returns (tmp guard, canonical main path, canonical worktree path).
+    fn build_main_and_worktree() -> (TempDir, PathBuf, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        fs::create_dir_all(&main).unwrap();
+        init_git_repo(&main);
+
+        let wt = tmp.path().join("wt");
+        run_git(
+            &main,
+            &["worktree", "add", "-b", "feat", wt.to_str().unwrap()],
+        );
+
+        let main_canon = fs::canonicalize(&main).unwrap();
+        let wt_canon = fs::canonicalize(&wt).unwrap();
+        (tmp, main_canon, wt_canon)
+    }
+
+    async fn insert_row(pool: &SqlitePool, id: &str, host_id: &str, path: &str, name: &str) {
+        q::insert_project(pool, id, host_id, path, name)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn repair_orphaned_worktrees_links_orphan() {
+        let pool = setup_pool_with_host().await;
+        let (_tmp, main_path, wt_path) = build_main_and_worktree();
+        let main_s = main_path.to_string_lossy().to_string();
+        let wt_s = wt_path.to_string_lossy().to_string();
+
+        insert_row(&pool, "p_main", "h1", &main_s, "main").await;
+        insert_row(&pool, "p_wt", "h1", &wt_s, "wt").await;
+
+        repair_orphaned_worktrees(&pool).await.unwrap();
+
+        let wt_row = q::get_project(&pool, "p_wt").await.unwrap();
+        assert_eq!(wt_row.parent_project_id.as_deref(), Some("p_main"));
+        assert_eq!(wt_row.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn repair_orphaned_worktrees_is_idempotent() {
+        let pool = setup_pool_with_host().await;
+        let (_tmp, main_path, wt_path) = build_main_and_worktree();
+        let main_s = main_path.to_string_lossy().to_string();
+        let wt_s = wt_path.to_string_lossy().to_string();
+
+        insert_row(&pool, "p_main", "h1", &main_s, "main").await;
+        insert_row(&pool, "p_wt", "h1", &wt_s, "wt").await;
+
+        repair_orphaned_worktrees(&pool).await.unwrap();
+        // Second call: worktree is no longer in the orphan set (parent_project_id
+        // is non-null) so it's a genuine no-op on that row.
+        repair_orphaned_worktrees(&pool).await.unwrap();
+
+        let wt_row = q::get_project(&pool, "p_wt").await.unwrap();
+        assert_eq!(wt_row.parent_project_id.as_deref(), Some("p_main"));
+        assert_eq!(wt_row.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn repair_orphaned_worktrees_skips_when_main_not_registered() {
+        let pool = setup_pool_with_host().await;
+        let (_tmp, _main_path, wt_path) = build_main_and_worktree();
+        let wt_s = wt_path.to_string_lossy().to_string();
+
+        insert_row(&pool, "p_wt", "h1", &wt_s, "wt").await;
+
+        repair_orphaned_worktrees(&pool).await.unwrap();
+
+        let wt_row = q::get_project(&pool, "p_wt").await.unwrap();
+        assert!(wt_row.parent_project_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn repair_orphaned_worktrees_skips_non_git_paths() {
+        let pool = setup_pool_with_host().await;
+        let tmp = TempDir::new().unwrap();
+        let plain = tmp.path().join("plain");
+        fs::create_dir_all(&plain).unwrap();
+        let plain_s = plain.to_string_lossy().to_string();
+
+        insert_row(&pool, "p_plain", "h1", &plain_s, "plain").await;
+
+        repair_orphaned_worktrees(&pool).await.unwrap();
+
+        let row = q::get_project(&pool, "p_plain").await.unwrap();
+        assert!(row.parent_project_id.is_none());
+    }
+}

--- a/crates/zremote-agent/src/project/scanner.rs
+++ b/crates/zremote-agent/src/project/scanner.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use super::git::GitInspector;
+use super::git::{self, GitInspector};
 use super::intelligence;
 use zremote_protocol::ProjectInfo;
 
@@ -157,16 +157,18 @@ impl ProjectScanner {
         let is_git_root = git_entry.is_dir();
         let is_linked_worktree = git_entry.is_file();
 
-        // Linked worktree without language marker = skip (parent project owns it)
-        if project_type.is_none() && is_linked_worktree {
-            return None;
-        }
-        // No git and no language marker = not a project
-        if project_type.is_none() && !is_git_root {
+        let main_repo_path = if is_linked_worktree {
+            git::main_repo_path_for_worktree(dir)
+        } else {
+            None
+        };
+
+        // No language marker: only keep linked worktrees whose main repo we can resolve.
+        if project_type.is_none() && !is_git_root && main_repo_path.is_none() {
             return None;
         }
 
-        // Collect git info for repo roots
+        // Collect git info for repo roots only; linked worktrees are enriched via the main repo.
         let (git_info, worktrees) = if is_git_root {
             GitInspector::inspect(dir)
                 .map(|(info, wts)| (Some(info), wts))
@@ -198,6 +200,7 @@ impl ProjectScanner {
             architecture: intel.architecture,
             conventions: intel.conventions,
             package_manager: intel.package_manager,
+            main_repo_path: main_repo_path.map(|p| p.to_string_lossy().to_string()),
         })
     }
 }
@@ -476,5 +479,104 @@ mod tests {
         let myapp = projects.iter().find(|p| p.name == "myapp").unwrap();
         assert!(myapp.has_claude_config);
         assert_eq!(myapp.project_type, "rust");
+    }
+
+    /// Initialize a minimal git repo at `dir` with a single commit.
+    fn init_git_repo(dir: &Path) {
+        let run = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .current_dir(dir)
+                .args(args)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
+                .env("GIT_CEILING_DIRECTORIES", dir)
+                .output()
+                .expect("spawn git");
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run(&["init"]);
+        run(&["config", "user.email", "test@test.com"]);
+        run(&["config", "user.name", "Test"]);
+        run(&["config", "commit.gpgsign", "false"]);
+        fs::write(dir.join("README.md"), "# Test").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "--no-verify", "-m", "initial commit"]);
+    }
+
+    fn add_worktree(repo: &Path, wt: &Path, branch: &str) {
+        let output = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(["worktree", "add", "-b", branch, wt.to_str().unwrap()])
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env("GIT_CEILING_DIRECTORIES", repo)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn detect_linked_worktree_sets_main_repo_path() {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        fs::create_dir_all(&main).unwrap();
+        init_git_repo(&main);
+        fs::write(main.join("Cargo.toml"), "[package]\nname = \"main\"").unwrap();
+
+        let wt = tmp.path().join("wt");
+        add_worktree(&main, &wt, "feature");
+        fs::write(wt.join("Cargo.toml"), "[package]\nname = \"wt\"").unwrap();
+
+        let info = ProjectScanner::detect_project(&wt).expect("should detect linked worktree");
+        assert_eq!(info.project_type, "rust");
+        let expected = fs::canonicalize(&main)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(info.main_repo_path.as_deref(), Some(expected.as_str()));
+        // Linked worktrees skip the full GitInspector pass.
+        assert!(info.git_info.is_none());
+        assert!(info.worktrees.is_empty());
+    }
+
+    #[test]
+    fn detect_linked_worktree_without_language_marker_returns_info_when_main_resolvable() {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        fs::create_dir_all(&main).unwrap();
+        init_git_repo(&main);
+
+        let wt = tmp.path().join("wt");
+        add_worktree(&main, &wt, "feature");
+        // Intentionally do NOT place a language marker in the worktree.
+
+        let info = ProjectScanner::detect_project(&wt)
+            .expect("linked worktree with resolvable main should be detected");
+        assert_eq!(info.project_type, "unknown");
+        let expected = fs::canonicalize(&main)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(info.main_repo_path.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn detect_main_repo_has_no_main_repo_path() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"m\"").unwrap();
+
+        let info = ProjectScanner::detect_project(tmp.path()).expect("should detect main repo");
+        assert!(info.main_repo_path.is_none());
     }
 }

--- a/crates/zremote-core/src/queries/projects.rs
+++ b/crates/zremote-core/src/queries/projects.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
+use zremote_protocol::ProjectInfo;
 
 use crate::error::AppError;
 
@@ -100,6 +101,50 @@ pub async fn insert_project(
     Ok(result.rows_affected() > 0)
 }
 
+/// Insert a project with optional `parent_project_id` and `project_type`.
+/// Returns true if a new row was inserted, false on duplicate path.
+pub async fn insert_project_with_parent(
+    pool: &SqlitePool,
+    project_id: &str,
+    host_id: &str,
+    path: &str,
+    name: &str,
+    parent_project_id: Option<&str>,
+    project_type: &str,
+) -> Result<bool, AppError> {
+    let result = sqlx::query(
+        "INSERT OR IGNORE INTO projects (id, host_id, path, name, parent_project_id, project_type) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(project_id)
+    .bind(host_id)
+    .bind(path)
+    .bind(name)
+    .bind(parent_project_id)
+    .bind(project_type)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Update an existing project row's `parent_project_id` and `project_type`.
+/// Used by the orphaned-worktree repair step.
+pub async fn set_parent_project_id(
+    pool: &SqlitePool,
+    project_id: &str,
+    parent_project_id: &str,
+    project_type: &str,
+) -> Result<u64, AppError> {
+    let result =
+        sqlx::query("UPDATE projects SET parent_project_id = ?, project_type = ? WHERE id = ?")
+            .bind(parent_project_id)
+            .bind(project_type)
+            .bind(project_id)
+            .execute(pool)
+            .await?;
+    Ok(result.rows_affected())
+}
+
 pub async fn get_project_host_and_path(
     pool: &SqlitePool,
     project_id: &str,
@@ -170,6 +215,74 @@ pub async fn set_project_pinned(
         .execute(pool)
         .await?;
     Ok(result.rows_affected())
+}
+
+/// Update a project row with detected metadata from `ProjectInfo`.
+/// Shared by agent (manual registration, scan, backfill) and server
+/// (agent `ProjectList` dispatch) so the metadata UPDATE SQL lives in exactly
+/// one place. Preserves the "worktree" `project_type` marker set at insert time —
+/// it encodes structural role, not language, and must not be clobbered by the
+/// detected language type (e.g. "rust" from a Cargo.toml inside the worktree).
+pub async fn update_project_metadata_from_info(
+    pool: &SqlitePool,
+    project_id: &str,
+    info: &ProjectInfo,
+) -> Result<(), AppError> {
+    // Fall back to an empty JSON array rather than an empty string when
+    // serialization fails — downstream readers parse these columns as JSON
+    // and an empty string is not valid JSON.
+    let remotes_json = info
+        .git_info
+        .as_ref()
+        .map(|g| serde_json::to_string(&g.remotes).unwrap_or_else(|_| "[]".to_string()));
+    let now = chrono::Utc::now().to_rfc3339();
+    let frameworks_json =
+        serde_json::to_string(&info.frameworks).unwrap_or_else(|_| "[]".to_string());
+    let architecture_str = info
+        .architecture
+        .as_ref()
+        .and_then(|a| serde_json::to_value(a).ok())
+        .and_then(|v| v.as_str().map(String::from));
+    let conventions_json =
+        serde_json::to_string(&info.conventions).unwrap_or_else(|_| "[]".to_string());
+
+    sqlx::query(
+        "UPDATE projects SET \
+         project_type = CASE WHEN project_type = 'worktree' THEN project_type ELSE ? END, \
+         has_claude_config = ?, has_zremote_config = ?, \
+         git_branch = ?, git_commit_hash = ?, git_commit_message = ?, \
+         git_is_dirty = ?, git_ahead = ?, git_behind = ?, git_remotes = ?, git_updated_at = ?, \
+         frameworks = ?, architecture = ?, conventions = ?, package_manager = ? \
+         WHERE id = ?",
+    )
+    .bind(&info.project_type)
+    .bind(info.has_claude_config)
+    .bind(info.has_zremote_config)
+    .bind(info.git_info.as_ref().and_then(|g| g.branch.as_deref()))
+    .bind(
+        info.git_info
+            .as_ref()
+            .and_then(|g| g.commit_hash.as_deref()),
+    )
+    .bind(
+        info.git_info
+            .as_ref()
+            .and_then(|g| g.commit_message.as_deref()),
+    )
+    .bind(info.git_info.as_ref().is_some_and(|g| g.is_dirty))
+    .bind(info.git_info.as_ref().map_or(0, |g| g.ahead))
+    .bind(info.git_info.as_ref().map_or(0, |g| g.behind))
+    .bind(&remotes_json)
+    .bind(&now)
+    .bind(&frameworks_json)
+    .bind(&architecture_str)
+    .bind(&conventions_json)
+    .bind(&info.package_manager)
+    .bind(project_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -465,6 +578,107 @@ mod tests {
             Some(r#"[{"kind":"testing","value":"jest"}]"#)
         );
         assert_eq!(project.package_manager.as_deref(), Some("npm"));
+    }
+
+    #[tokio::test]
+    async fn insert_project_with_parent_sets_fields() {
+        let pool = setup_db().await;
+        insert_project(&pool, "p1", "h1", "/home/user/proj", "proj").await;
+
+        let inserted = super::insert_project_with_parent(
+            &pool,
+            "wt1",
+            "h1",
+            "/home/user/proj-wt",
+            "proj-wt",
+            Some("p1"),
+            "worktree",
+        )
+        .await
+        .unwrap();
+        assert!(inserted);
+
+        let project = get_project(&pool, "wt1").await.unwrap();
+        assert_eq!(project.parent_project_id.as_deref(), Some("p1"));
+        assert_eq!(project.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn insert_project_with_parent_none_parent_is_top_level() {
+        let pool = setup_db().await;
+
+        let inserted = super::insert_project_with_parent(
+            &pool,
+            "p1",
+            "h1",
+            "/home/user/proj",
+            "proj",
+            None,
+            "rust",
+        )
+        .await
+        .unwrap();
+        assert!(inserted);
+
+        let project = get_project(&pool, "p1").await.unwrap();
+        assert!(project.parent_project_id.is_none());
+        assert_eq!(project.project_type, "rust");
+    }
+
+    #[tokio::test]
+    async fn insert_project_with_parent_ignores_duplicate_path() {
+        let pool = setup_db().await;
+
+        let first = super::insert_project_with_parent(
+            &pool,
+            "p1",
+            "h1",
+            "/home/user/proj",
+            "proj",
+            None,
+            "rust",
+        )
+        .await
+        .unwrap();
+        assert!(first);
+
+        let second = super::insert_project_with_parent(
+            &pool,
+            "p2",
+            "h1",
+            "/home/user/proj",
+            "proj-dup",
+            None,
+            "rust",
+        )
+        .await
+        .unwrap();
+        assert!(!second);
+    }
+
+    #[tokio::test]
+    async fn set_parent_project_id_updates_row() {
+        let pool = setup_db().await;
+        insert_project(&pool, "p1", "h1", "/home/user/proj", "proj").await;
+        insert_project(&pool, "wt1", "h1", "/home/user/proj-wt", "proj-wt").await;
+
+        let affected = super::set_parent_project_id(&pool, "wt1", "p1", "worktree")
+            .await
+            .unwrap();
+        assert_eq!(affected, 1);
+
+        let project = get_project(&pool, "wt1").await.unwrap();
+        assert_eq!(project.parent_project_id.as_deref(), Some("p1"));
+        assert_eq!(project.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn set_parent_project_id_nonexistent_returns_zero() {
+        let pool = setup_db().await;
+        let affected = super::set_parent_project_id(&pool, "nonexistent", "p1", "worktree")
+            .await
+            .unwrap();
+        assert_eq!(affected, 0);
     }
 
     #[tokio::test]

--- a/crates/zremote-protocol/src/project/info.rs
+++ b/crates/zremote-protocol/src/project/info.rs
@@ -62,4 +62,7 @@ pub struct ProjectInfo {
     pub conventions: Vec<Convention>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_manager: Option<String>,
+    /// Absolute path to the main repo if this is a linked git worktree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub main_repo_path: Option<String>,
 }

--- a/crates/zremote-protocol/src/project/tests.rs
+++ b/crates/zremote-protocol/src/project/tests.rs
@@ -16,6 +16,7 @@ fn project_info_roundtrip() {
         architecture: None,
         conventions: vec![],
         package_manager: None,
+        main_repo_path: None,
     };
     let json = serde_json::to_string(&info).expect("serialize");
     let parsed: ProjectInfo = serde_json::from_str(&json).expect("deserialize");
@@ -36,6 +37,7 @@ fn project_info_without_claude_config() {
         architecture: None,
         conventions: vec![],
         package_manager: None,
+        main_repo_path: None,
     };
     let json = serde_json::to_value(&info).unwrap();
     assert_eq!(json["has_claude_config"], false);
@@ -97,6 +99,7 @@ fn project_info_with_git_info_roundtrip() {
             config_file: Some("clippy.toml".to_string()),
         }],
         package_manager: Some("cargo".to_string()),
+        main_repo_path: None,
     };
     let json = serde_json::to_string(&info).expect("serialize");
     let parsed: ProjectInfo = serde_json::from_str(&json).expect("deserialize");

--- a/crates/zremote-protocol/src/terminal.rs
+++ b/crates/zremote-protocol/src/terminal.rs
@@ -69,6 +69,8 @@ pub enum AgentMessage {
         #[serde(default)]
         has_zremote_config: bool,
         project_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        main_repo_path: Option<String>,
     },
     ProjectList {
         projects: Vec<ProjectInfo>,
@@ -449,6 +451,15 @@ mod tests {
             has_claude_config: true,
             has_zremote_config: false,
             project_type: "rust".to_string(),
+            main_repo_path: None,
+        });
+        roundtrip_agent(&AgentMessage::ProjectDiscovered {
+            path: "/home/user/myproject-wt".to_string(),
+            name: "myproject-wt".to_string(),
+            has_claude_config: false,
+            has_zremote_config: false,
+            project_type: "worktree".to_string(),
+            main_repo_path: Some("/home/user/myproject".to_string()),
         });
     }
 
@@ -469,6 +480,7 @@ mod tests {
                     architecture: None,
                     conventions: vec![],
                     package_manager: None,
+                    main_repo_path: None,
                 },
                 ProjectInfo {
                     path: "/home/user/project-b".to_string(),
@@ -482,6 +494,7 @@ mod tests {
                     architecture: None,
                     conventions: vec![],
                     package_manager: None,
+                    main_repo_path: None,
                 },
             ],
         });

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -326,16 +326,103 @@ pub(super) async fn handle_agent_message(
             has_claude_config,
             has_zremote_config,
             project_type,
+            main_repo_path,
         } => {
             let host_id_str = host_id.to_string();
             let project_id = Uuid::new_v4().to_string();
+
+            let parent_project_id = if let Some(ref main_path) = main_repo_path {
+                match zremote_core::queries::projects::get_project_by_host_and_path(
+                    &state.db,
+                    &host_id_str,
+                    main_path,
+                )
+                .await
+                {
+                    Ok(parent) => Some(parent.id),
+                    Err(crate::error::AppError::Database(sqlx::Error::RowNotFound)) => {
+                        // Main repo not yet registered. Mirror `apply_project_list`
+                        // and create a stub parent row so the worktree is still
+                        // linkable — otherwise a user registering a worktree
+                        // directly (via `ServerMessage::ProjectRegister`) leaves
+                        // a permanent orphan.
+                        let stub_id = Uuid::new_v4().to_string();
+                        let stub_name = main_path
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or("unknown")
+                            .to_string();
+                        match zremote_core::queries::projects::insert_project(
+                            &state.db,
+                            &stub_id,
+                            &host_id_str,
+                            main_path,
+                            &stub_name,
+                        )
+                        .await
+                        {
+                            Ok(_) => {
+                                // Re-resolve canonical id (INSERT OR IGNORE may
+                                // have skipped on concurrent insert).
+                                match zremote_core::queries::projects::get_project_by_host_and_path(
+                                    &state.db,
+                                    &host_id_str,
+                                    main_path,
+                                )
+                                .await
+                                {
+                                    Ok(row) => Some(row.id),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            host_id = %host_id,
+                                            main_repo_path = %main_path,
+                                            error = %e,
+                                            "failed to resolve stubbed parent id"
+                                        );
+                                        None
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    host_id = %host_id,
+                                    main_repo_path = %main_path,
+                                    error = %e,
+                                    "failed to stub parent project for worktree"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            host_id = %host_id,
+                            path = %path,
+                            main_repo_path = %main_path,
+                            error = %e,
+                            "transient error resolving parent for worktree"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            let effective_type = if parent_project_id.is_some() {
+                "worktree"
+            } else {
+                project_type.as_str()
+            };
+
             if let Err(e) = sqlx::query(
-                "INSERT INTO projects (id, host_id, path, name, has_claude_config, has_zremote_config, project_type) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?) \
+                "INSERT INTO projects (id, host_id, path, name, has_claude_config, has_zremote_config, project_type, parent_project_id) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
                  ON CONFLICT(host_id, path) DO UPDATE SET \
                  name = excluded.name, has_claude_config = excluded.has_claude_config, \
                  has_zremote_config = excluded.has_zremote_config, \
-                 project_type = excluded.project_type",
+                 project_type = excluded.project_type, \
+                 parent_project_id = COALESCE(excluded.parent_project_id, projects.parent_project_id)",
             )
             .bind(&project_id)
             .bind(&host_id_str)
@@ -343,7 +430,8 @@ pub(super) async fn handle_agent_message(
             .bind(&name)
             .bind(has_claude_config)
             .bind(has_zremote_config)
-            .bind(&project_type)
+            .bind(effective_type)
+            .bind(parent_project_id.as_deref())
             .execute(&state.db)
             .await
             {
@@ -496,78 +584,7 @@ pub(super) async fn handle_agent_message(
             }
         }
         AgentMessage::ProjectList { projects } => {
-            let host_id_str = host_id.to_string();
-            tracing::info!(host_id = %host_id, count = projects.len(), "received project list");
-            let now = chrono::Utc::now().to_rfc3339();
-            for project in &projects {
-                let project_id = Uuid::new_v4().to_string();
-                let remotes_json = project
-                    .git_info
-                    .as_ref()
-                    .map(|gi| serde_json::to_string(&gi.remotes).unwrap_or_default());
-                let git_updated = project.git_info.as_ref().map(|_| now.clone());
-                let frameworks_json =
-                    serde_json::to_string(&project.frameworks).unwrap_or_default();
-                let architecture_str = project
-                    .architecture
-                    .as_ref()
-                    .and_then(|a| serde_json::to_value(a).ok())
-                    .and_then(|v| v.as_str().map(String::from));
-                let conventions_json =
-                    serde_json::to_string(&project.conventions).unwrap_or_default();
-                if let Err(e) = sqlx::query(
-                    "INSERT INTO projects (id, host_id, path, name, has_claude_config, has_zremote_config, project_type, \
-                     git_branch, git_commit_hash, git_commit_message, git_is_dirty, \
-                     git_ahead, git_behind, git_remotes, git_updated_at, \
-                     frameworks, architecture, conventions, package_manager) \
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
-                     ON CONFLICT(host_id, path) DO UPDATE SET \
-                     name = excluded.name, has_claude_config = excluded.has_claude_config, \
-                     has_zremote_config = excluded.has_zremote_config, \
-                     project_type = excluded.project_type, \
-                     git_branch = excluded.git_branch, git_commit_hash = excluded.git_commit_hash, \
-                     git_commit_message = excluded.git_commit_message, git_is_dirty = excluded.git_is_dirty, \
-                     git_ahead = excluded.git_ahead, git_behind = excluded.git_behind, \
-                     git_remotes = excluded.git_remotes, git_updated_at = excluded.git_updated_at, \
-                     frameworks = excluded.frameworks, architecture = excluded.architecture, \
-                     conventions = excluded.conventions, package_manager = excluded.package_manager",
-                )
-                .bind(&project_id)
-                .bind(&host_id_str)
-                .bind(&project.path)
-                .bind(&project.name)
-                .bind(project.has_claude_config)
-                .bind(project.has_zremote_config)
-                .bind(&project.project_type)
-                .bind(project.git_info.as_ref().and_then(|gi| gi.branch.as_deref()))
-                .bind(project.git_info.as_ref().and_then(|gi| gi.commit_hash.as_deref()))
-                .bind(project.git_info.as_ref().and_then(|gi| gi.commit_message.as_deref()))
-                .bind(project.git_info.as_ref().is_some_and(|gi| gi.is_dirty))
-                .bind(project.git_info.as_ref().map_or(0, |gi| gi.ahead))
-                .bind(project.git_info.as_ref().map_or(0, |gi| gi.behind))
-                .bind(&remotes_json)
-                .bind(&git_updated)
-                .bind(&frameworks_json)
-                .bind(&architecture_str)
-                .bind(&conventions_json)
-                .bind(&project.package_manager)
-                .execute(&state.db)
-                .await
-                {
-                    tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to upsert project");
-                }
-
-                // Upsert worktree children
-                if !project.worktrees.is_empty() {
-                    upsert_worktree_children(
-                        state,
-                        &host_id_str,
-                        &project.path,
-                        &project.worktrees,
-                    )
-                    .await;
-                }
-            }
+            apply_project_list(state, host_id, &projects).await;
             let _ = state.events.send(ServerEvent::ProjectsUpdated {
                 host_id: host_id.to_string(),
             });
@@ -910,6 +927,172 @@ pub(super) async fn handle_sessions_recovered(
                 });
 
             tracing::info!(session_id = %sid, "suspended unrecovered session (daemon may still be alive)");
+        }
+    }
+}
+
+/// Apply an agent-reported `ProjectList` to the server DB.
+///
+/// Partitions into main repos and linked worktrees (by `main_repo_path`).
+/// Main repos are inserted first so worktrees can resolve their
+/// `parent_project_id`. If a worktree's main repo isn't reported in the same
+/// batch, a stub parent row is created.
+///
+/// Extracted from `handle_agent_message` for testability (no WebSocket required).
+pub(super) async fn apply_project_list(
+    state: &AppState,
+    host_id: HostId,
+    projects: &[zremote_protocol::ProjectInfo],
+) {
+    let host_id_str = host_id.to_string();
+    tracing::info!(host_id = %host_id, count = projects.len(), "received project list");
+
+    let (worktrees, main_repos): (Vec<_>, Vec<_>) = projects
+        .iter()
+        .partition(|info| info.main_repo_path.is_some());
+
+    for project in &main_repos {
+        let project_id = Uuid::new_v4().to_string();
+        if let Err(e) = zremote_core::queries::projects::insert_project(
+            &state.db,
+            &project_id,
+            &host_id_str,
+            &project.path,
+            &project.name,
+        )
+        .await
+        {
+            tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to insert main project");
+            continue;
+        }
+        match zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            &project.path,
+        )
+        .await
+        {
+            Ok(row) => {
+                if let Err(e) = zremote_core::queries::projects::update_project_metadata_from_info(
+                    &state.db, &row.id, project,
+                )
+                .await
+                {
+                    tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to update project metadata");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to resolve main project row");
+            }
+        }
+
+        // Legacy path: agents that still ship worktrees inside the parent's
+        // `worktrees` array (without main_repo_path on sibling entries).
+        if !project.worktrees.is_empty() {
+            upsert_worktree_children(state, &host_id_str, &project.path, &project.worktrees).await;
+        }
+    }
+
+    for project in &worktrees {
+        let Some(main_path) = project.main_repo_path.as_deref() else {
+            continue;
+        };
+        let parent_id = match zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            main_path,
+        )
+        .await
+        {
+            Ok(row) => row.id,
+            Err(crate::error::AppError::Database(sqlx::Error::RowNotFound)) => {
+                let stub_id = Uuid::new_v4().to_string();
+                let stub_name = main_path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("unknown")
+                    .to_string();
+                if let Err(e) = zremote_core::queries::projects::insert_project(
+                    &state.db,
+                    &stub_id,
+                    &host_id_str,
+                    main_path,
+                    &stub_name,
+                )
+                .await
+                {
+                    tracing::warn!(host_id = %host_id, path = %main_path, error = %e, "failed to stub parent project");
+                    continue;
+                }
+                match zremote_core::queries::projects::get_project_by_host_and_path(
+                    &state.db,
+                    &host_id_str,
+                    main_path,
+                )
+                .await
+                {
+                    Ok(row) => row.id,
+                    Err(e) => {
+                        tracing::warn!(host_id = %host_id, path = %main_path, error = %e, "failed to resolve stubbed parent");
+                        continue;
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(host_id = %host_id, path = %main_path, error = %e, "failed to resolve parent for worktree");
+                continue;
+            }
+        };
+
+        let wt_id = Uuid::new_v4().to_string();
+        if let Err(e) = zremote_core::queries::projects::insert_project_with_parent(
+            &state.db,
+            &wt_id,
+            &host_id_str,
+            &project.path,
+            &project.name,
+            Some(&parent_id),
+            "worktree",
+        )
+        .await
+        {
+            tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to insert worktree project");
+            continue;
+        }
+
+        // Resolve canonical id (may be a pre-existing row) and ensure parent
+        // linkage + metadata.
+        match zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            &project.path,
+        )
+        .await
+        {
+            Ok(row) => {
+                // Only set the parent linkage when the row has none yet. This
+                // avoids silently re-linking a worktree row whose parent was
+                // set deliberately (manual fix, upsert_worktree_children path,
+                // or a previous scan) to a different project.
+                if row.parent_project_id.is_none()
+                    && let Err(e) = zremote_core::queries::projects::set_parent_project_id(
+                        &state.db, &row.id, &parent_id, "worktree",
+                    )
+                    .await
+                {
+                    tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to link worktree parent");
+                }
+                if let Err(e) = zremote_core::queries::projects::update_project_metadata_from_info(
+                    &state.db, &row.id, project,
+                )
+                .await
+                {
+                    tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to update worktree metadata");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(host_id = %host_id, path = %project.path, error = %e, "failed to resolve worktree row");
+            }
         }
     }
 }
@@ -2913,5 +3096,154 @@ mod tests {
             row.1, None,
             "disconnect_reason should be cleared on recovery"
         );
+    }
+
+    // ── apply_project_list (T7: worktree parent linking) ──
+
+    fn make_project_info(
+        path: &str,
+        name: &str,
+        main_repo_path: Option<&str>,
+    ) -> zremote_protocol::ProjectInfo {
+        zremote_protocol::ProjectInfo {
+            path: path.to_string(),
+            name: name.to_string(),
+            has_claude_config: false,
+            has_zremote_config: false,
+            project_type: "rust".to_string(),
+            git_info: None,
+            worktrees: vec![],
+            frameworks: vec![],
+            architecture: None,
+            conventions: vec![],
+            package_manager: None,
+            main_repo_path: main_repo_path.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn server_add_worktree_links_to_existing_parent() {
+        let state = test_state().await;
+        let host_uuid = Uuid::new_v4();
+        let host_id_str = host_uuid.to_string();
+        insert_test_host(&state, &host_id_str, "testhost").await;
+
+        // Pre-register the parent main repo.
+        let parent_id = Uuid::new_v4().to_string();
+        zremote_core::queries::projects::insert_project(
+            &state.db,
+            &parent_id,
+            &host_id_str,
+            "/home/user/repo",
+            "repo",
+        )
+        .await
+        .unwrap();
+
+        // Send a ProjectList with the main repo and a worktree that points to it.
+        let projects = vec![
+            make_project_info("/home/user/repo", "repo", None),
+            make_project_info("/home/user/repo-wt", "repo-wt", Some("/home/user/repo")),
+        ];
+        super::apply_project_list(&state, host_uuid, &projects).await;
+
+        let parent = zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            "/home/user/repo",
+        )
+        .await
+        .unwrap();
+        let wt = zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            "/home/user/repo-wt",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(wt.parent_project_id.as_deref(), Some(parent.id.as_str()));
+        assert_eq!(wt.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn server_add_worktree_auto_registers_parent() {
+        let state = test_state().await;
+        let host_uuid = Uuid::new_v4();
+        let host_id_str = host_uuid.to_string();
+        insert_test_host(&state, &host_id_str, "testhost").await;
+
+        // ProjectList contains ONLY the worktree — parent isn't reported in
+        // this batch. The server should stub-register the parent so the
+        // worktree is still linkable.
+        let projects = vec![make_project_info(
+            "/home/user/repo-wt",
+            "repo-wt",
+            Some("/home/user/repo"),
+        )];
+        super::apply_project_list(&state, host_uuid, &projects).await;
+
+        let parent = zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            "/home/user/repo",
+        )
+        .await
+        .unwrap();
+        let wt = zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            "/home/user/repo-wt",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(parent.name, "repo");
+        assert_eq!(wt.parent_project_id.as_deref(), Some(parent.id.as_str()));
+        assert_eq!(wt.project_type, "worktree");
+    }
+
+    #[tokio::test]
+    async fn server_scan_links_worktrees_to_main_repos() {
+        let state = test_state().await;
+        let host_uuid = Uuid::new_v4();
+        let host_id_str = host_uuid.to_string();
+        insert_test_host(&state, &host_id_str, "testhost").await;
+
+        // Simulate a scan batch: one main repo + two worktrees referencing it.
+        let projects = vec![
+            make_project_info("/home/user/proj", "proj", None),
+            make_project_info(
+                "/home/user/proj-feature-a",
+                "feature-a",
+                Some("/home/user/proj"),
+            ),
+            make_project_info(
+                "/home/user/proj-feature-b",
+                "feature-b",
+                Some("/home/user/proj"),
+            ),
+        ];
+        super::apply_project_list(&state, host_uuid, &projects).await;
+
+        let parent = zremote_core::queries::projects::get_project_by_host_and_path(
+            &state.db,
+            &host_id_str,
+            "/home/user/proj",
+        )
+        .await
+        .unwrap();
+        let children = zremote_core::queries::projects::list_worktrees(&state.db, &parent.id)
+            .await
+            .unwrap();
+        assert_eq!(children.len(), 2, "both worktrees should link to parent");
+
+        for child in &children {
+            assert_eq!(child.parent_project_id.as_deref(), Some(parent.id.as_str()));
+            assert_eq!(child.project_type, "worktree");
+        }
+
+        // project_type on main repo should reflect detected language, not worktree.
+        assert_eq!(parent.project_type, "rust");
     }
 }


### PR DESCRIPTION
## Summary
- Linked git worktrees (where `.git` is a file, e.g. from `git worktree add ../feature branch`) are now detected as children of their main repo instead of independent top-level projects. The sidebar already groups by `parent_project_id`, so the fix simply populates that field via scanner, `add_project`, and `trigger_scan` flows.
- Auto-registers the main repo if a worktree is added first and the main isn't in the DB yet (stub-parent on both agent and server paths).
- One-time `repair_orphaned_worktrees` at agent startup backfills existing orphaned worktree rows.

## Notable details
- `main_repo_path_for_worktree` uses `git rev-parse --git-common-dir` with a bounded-size `.git`-file fallback; submodules (`gitdir` under `/modules/`) are explicitly excluded.
- Race-safe re-fetch of canonical project id after `INSERT OR IGNORE` (parent lookup never points at a phantom UUID).
- Scanner partitions mains/worktrees; mains inserted first so worktree parent resolution never misses.
- `insert_project_with_parent` DB helper deduplicates worktree endpoint insert.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (323 tests, new coverage: git helper, scanner linked-worktree cases, repair, route linking, DB helper)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual end-to-end: `git init main && cd main && git worktree add ../wt feature`, register both in GUI, confirm sidebar nests `wt` under `main`.
- [ ] Backfill: start agent with a pre-existing orphaned worktree row; confirm it gets relinked after startup.

Closes #46