### PR TITLE
fix(cli): attach session prefix resolution + clean ~. detach

### DIFF
--- a/crates/zremote-agent/src/local/routes/terminal.rs
+++ b/crates/zremote-agent/src/local/routes/terminal.rs
@@ -192,8 +192,27 @@ async fn handle_terminal_connection(
     session_id_str: String,
     state: Arc<LocalAppState>,
 ) {
-    let Ok(session_id) = session_id_str.parse() else {
+    // A UUID is 36 chars; cap the echoed path segment before any allocation
+    // work (format! + JSON) to bound memory on malformed/malicious requests.
+    const MAX_SESSION_ID_LEN: usize = 64;
+    let (parsed, echoed) = if session_id_str.len() > MAX_SESSION_ID_LEN {
+        (Err(()), "<too long>".to_string())
+    } else {
+        (
+            session_id_str.parse::<uuid::Uuid>().map_err(|_| ()),
+            session_id_str.clone(),
+        )
+    };
+    let Ok(session_id) = parsed else {
         let mut socket = socket;
+        let err = BrowserMessage::Error {
+            message: format!("invalid session id '{echoed}': expected UUID"),
+        };
+        if let Ok(json) = serde_json::to_string(&err) {
+            let _ = socket
+                .send(axum::extract::ws::Message::Text(json.into()))
+                .await;
+        }
         let _ = socket.send(axum::extract::ws::Message::Close(None)).await;
         return;
     };

--- a/crates/zremote-cli/src/commands/session.rs
+++ b/crates/zremote-cli/src/commands/session.rs
@@ -130,24 +130,15 @@ pub async fn run(
                 }
             }
         }
-        SessionCommand::Get { session_id } => match client.get_session(&session_id).await {
-            Ok(session) => {
-                println!("{}", fmt.session(&session));
-                0
-            }
-            Err(e) => {
-                eprintln!("Error: {e}");
-                1
-            }
-        },
-        SessionCommand::Rename {
-            session_id,
-            new_name,
-        } => {
-            let req = UpdateSessionRequest {
-                name: Some(new_name),
+        SessionCommand::Get { session_id } => {
+            let full_id = match resolver.resolve_session_id(client, &session_id).await {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    return 1;
+                }
             };
-            match client.update_session(&session_id, &req).await {
+            match client.get_session(&full_id).await {
                 Ok(session) => {
                     println!("{}", fmt.session(&session));
                     0
@@ -158,28 +149,78 @@ pub async fn run(
                 }
             }
         }
-        SessionCommand::Close { session_id } => match client.close_session(&session_id).await {
-            Ok(()) => {
-                println!("Session {session_id} closed.");
-                0
+        SessionCommand::Rename {
+            session_id,
+            new_name,
+        } => {
+            let full_id = match resolver.resolve_session_id(client, &session_id).await {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    return 1;
+                }
+            };
+            let req = UpdateSessionRequest {
+                name: Some(new_name),
+            };
+            match client.update_session(&full_id, &req).await {
+                Ok(session) => {
+                    println!("{}", fmt.session(&session));
+                    0
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
             }
-            Err(e) => {
-                eprintln!("Error: {e}");
-                1
+        }
+        SessionCommand::Close { session_id } => {
+            let full_id = match resolver.resolve_session_id(client, &session_id).await {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    return 1;
+                }
+            };
+            match client.close_session(&full_id).await {
+                Ok(()) => {
+                    println!("Session {full_id} closed.");
+                    0
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
             }
-        },
-        SessionCommand::Purge { session_id } => match client.purge_session(&session_id).await {
-            Ok(()) => {
-                println!("Session {session_id} purged.");
-                0
+        }
+        SessionCommand::Purge { session_id } => {
+            let full_id = match resolver.resolve_session_id(client, &session_id).await {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    return 1;
+                }
+            };
+            match client.purge_session(&full_id).await {
+                Ok(()) => {
+                    println!("Session {full_id} purged.");
+                    0
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
             }
-            Err(e) => {
-                eprintln!("Error: {e}");
-                1
-            }
-        },
+        }
         SessionCommand::Attach { session_id } => {
-            crate::terminal::run_attach(client, &session_id).await
+            let full_id = match resolver.resolve_session_id(client, &session_id).await {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    return 1;
+                }
+            };
+            crate::terminal::run_attach(client, &full_id).await
         }
     }
 }

--- a/crates/zremote-cli/src/connection.rs
+++ b/crates/zremote-cli/src/connection.rs
@@ -1,6 +1,6 @@
 //! Connection resolution: server URL and host ID resolution.
 
-use zremote_client::{ApiClient, ApiError, Host};
+use zremote_client::{ApiClient, ApiError, Host, Session};
 
 use crate::GlobalOpts;
 
@@ -73,6 +73,25 @@ impl ConnectionResolver {
         }
     }
 
+    /// Resolve a session ID or UUID prefix to a full UUID.
+    ///
+    /// Accepts a full UUID or a prefix that uniquely matches one session for the
+    /// resolved host. Mirrors the prefix-matching UX of `session list`, which
+    /// truncates IDs to 8 chars.
+    pub async fn resolve_session_id(
+        &self,
+        client: &ApiClient,
+        input: &str,
+    ) -> Result<String, CliConnectionError> {
+        let host_id = self.resolve_host_id(client).await?;
+        let sessions = client
+            .list_sessions(&host_id)
+            .await
+            .map_err(CliConnectionError::Api)?;
+
+        match_session_prefix(&sessions, input)
+    }
+
     async fn resolve_by_prefix(
         &self,
         client: &ApiClient,
@@ -113,6 +132,25 @@ impl ConnectionResolver {
     }
 }
 
+/// Filter `sessions` by ID prefix (case-insensitive).
+///
+/// Returns `Ok(full_id)` when exactly one session matches, else a typed error.
+fn match_session_prefix(sessions: &[Session], input: &str) -> Result<String, CliConnectionError> {
+    let input_lower = input.to_lowercase();
+    let matches: Vec<&Session> = sessions
+        .iter()
+        .filter(|s| s.id.to_lowercase().starts_with(&input_lower))
+        .collect();
+
+    match matches.len() {
+        0 => Err(CliConnectionError::SessionNotFound(input.to_string())),
+        1 => Ok(matches[0].id.clone()),
+        _ => Err(CliConnectionError::AmbiguousSession {
+            matches: matches.iter().map(|s| s.id.clone()).collect(),
+        }),
+    }
+}
+
 /// Errors specific to connection/host resolution.
 #[derive(Debug)]
 pub enum CliConnectionError {
@@ -121,6 +159,8 @@ pub enum CliConnectionError {
     NoHostsFound,
     HostNotFound(String),
     AmbiguousHost { matches: Vec<String> },
+    SessionNotFound(String),
+    AmbiguousSession { matches: Vec<String> },
 }
 
 impl std::fmt::Display for CliConnectionError {
@@ -141,6 +181,81 @@ impl std::fmt::Display for CliConnectionError {
                 }
                 Ok(())
             }
+            Self::SessionNotFound(prefix) => {
+                write!(f, "no session matching '{prefix}' found")
+            }
+            Self::AmbiguousSession { matches } => {
+                write!(f, "ambiguous session — multiple matches:")?;
+                for m in matches {
+                    write!(f, "\n  {m}")?;
+                }
+                Ok(())
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zremote_client::SessionStatus;
+
+    fn mk_session(id: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            host_id: "host".to_string(),
+            name: None,
+            shell: None,
+            status: SessionStatus::Active,
+            working_dir: None,
+            project_id: None,
+            pid: None,
+            exit_code: None,
+            created_at: String::new(),
+            closed_at: None,
+        }
+    }
+
+    #[test]
+    fn prefix_unique_match() {
+        let sessions = vec![
+            mk_session("de683bd4-1111-2222-3333-444455556666"),
+            mk_session("99999999-aaaa-bbbb-cccc-dddddddddddd"),
+        ];
+        let resolved = match_session_prefix(&sessions, "de683bd4").unwrap();
+        assert_eq!(resolved, "de683bd4-1111-2222-3333-444455556666");
+    }
+
+    #[test]
+    fn prefix_case_insensitive() {
+        let sessions = vec![mk_session("DE683BD4-1111-2222-3333-444455556666")];
+        let resolved = match_session_prefix(&sessions, "de683bd4").unwrap();
+        assert_eq!(resolved, "DE683BD4-1111-2222-3333-444455556666");
+    }
+
+    #[test]
+    fn prefix_no_match() {
+        let sessions = vec![mk_session("de683bd4-1111-2222-3333-444455556666")];
+        let err = match_session_prefix(&sessions, "ffffffff").unwrap_err();
+        assert!(matches!(err, CliConnectionError::SessionNotFound(_)));
+    }
+
+    #[test]
+    fn prefix_ambiguous_match() {
+        let sessions = vec![
+            mk_session("de683bd4-1111-2222-3333-444455556666"),
+            mk_session("de683bd4-ffff-0000-0000-000000000000"),
+        ];
+        let err = match_session_prefix(&sessions, "de683bd4").unwrap_err();
+        match err {
+            CliConnectionError::AmbiguousSession { matches } => assert_eq!(matches.len(), 2),
+            other => panic!("expected AmbiguousSession, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_empty_sessions() {
+        let err = match_session_prefix(&[], "de683bd4").unwrap_err();
+        assert!(matches!(err, CliConnectionError::SessionNotFound(_)));
     }
 }

--- a/crates/zremote-cli/src/terminal.rs
+++ b/crates/zremote-cli/src/terminal.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use futures_util::StreamExt;
-use zremote_client::{ApiClient, TerminalEvent, TerminalInput};
+use zremote_client::{ApiClient, TerminalEvent, TerminalInput, flume};
 
 /// Attach to a terminal session interactively.
 ///
@@ -38,7 +38,7 @@ pub async fn run_attach(client: &ApiClient, session_id: &str) -> i32 {
     let resize_tx = session.resize_tx.clone();
 
     // Input task: read crossterm events and forward to WebSocket
-    let input_handle = tokio::spawn(async move {
+    let mut input_handle = tokio::spawn(async move {
         let mut reader = EventStream::new();
         let mut escape_state = EscapeState::AfterNewline; // start as if after newline
 
@@ -74,50 +74,91 @@ pub async fn run_attach(client: &ApiClient, session_id: &str) -> i32 {
         DetachReason::InputClosed
     });
 
-    // Output loop: read from WebSocket and write to stdout
+    // Output loop: read from WebSocket and write to stdout. Also races the
+    // input task so that a `~.` escape (which makes the input task return
+    // `DetachReason::UserDetach`) tears down the output loop as well —
+    // otherwise the user's terminal would stay attached until the remote
+    // session closed or the WS disconnected.
     let mut stdout = std::io::stdout();
-    let exit_code = loop {
-        match session.output_rx.recv_async().await {
-            Ok(TerminalEvent::Output(data) | TerminalEvent::PaneOutput { data, .. }) => {
-                let _ = stdout.write_all(&data);
-                let _ = stdout.flush();
-            }
-            Ok(TerminalEvent::SessionClosed { exit_code }) => {
-                break exit_code.unwrap_or(0);
-            }
-            Ok(TerminalEvent::Disconnected) | Err(_) => {
-                break 1;
-            }
-            Ok(TerminalEvent::SessionSuspended) => {
-                let msg = b"\r\n[session suspended]\r\n";
-                let _ = stdout.write_all(msg);
-                let _ = stdout.flush();
-            }
-            Ok(TerminalEvent::SessionResumed) => {
-                let msg = b"\r\n[session resumed]\r\n";
-                let _ = stdout.write_all(msg);
-                let _ = stdout.flush();
-            }
-            Ok(TerminalEvent::Error { message }) => {
-                let msg = format!("\r\n[error: {message}]\r\n");
-                let _ = stdout.write_all(msg.as_bytes());
-                let _ = stdout.flush();
-            }
-            Ok(_) => {} // Scrollback, pane events — ignore in CLI
-        }
-    };
+    let outcome = run_output_loop(&session.output_rx, &mut input_handle, &mut stdout).await;
 
-    // Cancel input task
+    // Cancel input task if it is still running (only true for output-driven
+    // exits; a `UserDetach` outcome means the task already completed).
     input_handle.abort();
+    let _ = (&mut input_handle).await;
 
-    // Check if input task requested detach
-    if let Ok(DetachReason::UserDetach) = input_handle.await {
-        let _ = stdout.write_all(b"\r\n[detached]\r\n");
-        let _ = stdout.flush();
-        return 0;
+    match outcome {
+        LoopOutcome::UserDetach => {
+            let _ = stdout.write_all(b"\r\n[detached]\r\n");
+            let _ = stdout.flush();
+            0
+        }
+        LoopOutcome::Exit(code) => code,
     }
+}
 
-    exit_code
+/// Result of the combined output + input-task select loop.
+#[derive(Debug, PartialEq, Eq)]
+enum LoopOutcome {
+    /// User typed `~.` — input task returned `UserDetach`.
+    UserDetach,
+    /// Session ended via WS event, disconnect, or channel error.
+    Exit(i32),
+}
+
+/// Core attach select loop: read terminal events and write to `stdout`,
+/// exiting either when the session terminates or when the input task
+/// completes with `DetachReason::UserDetach`.
+///
+/// Extracted from [`run_attach`] so it can be exercised in unit tests
+/// without a live WebSocket or real stdin. The loop takes a mutable
+/// reference to the input task's `JoinHandle` so the caller retains
+/// ownership for post-loop cleanup (`abort` + `await`).
+async fn run_output_loop<W: Write>(
+    output_rx: &flume::Receiver<TerminalEvent>,
+    input_handle: &mut tokio::task::JoinHandle<DetachReason>,
+    stdout: &mut W,
+) -> LoopOutcome {
+    loop {
+        tokio::select! {
+            biased;
+            // If the input task finishes first with UserDetach, exit the
+            // loop so the outer function can print "[detached]" and return.
+            // An InputClosed / panic falls through to treat as regular exit.
+            join_result = &mut *input_handle => {
+                return match join_result {
+                    Ok(DetachReason::UserDetach) => LoopOutcome::UserDetach,
+                    _ => LoopOutcome::Exit(0),
+                };
+            }
+            recv = output_rx.recv_async() => match recv {
+                Ok(TerminalEvent::Output(data) | TerminalEvent::PaneOutput { data, .. }) => {
+                    let _ = stdout.write_all(&data);
+                    let _ = stdout.flush();
+                }
+                Ok(TerminalEvent::SessionClosed { exit_code }) => {
+                    return LoopOutcome::Exit(exit_code.unwrap_or(0));
+                }
+                Ok(TerminalEvent::Disconnected) | Err(_) => {
+                    return LoopOutcome::Exit(1);
+                }
+                Ok(TerminalEvent::SessionSuspended) => {
+                    let _ = stdout.write_all(b"\r\n[session suspended]\r\n");
+                    let _ = stdout.flush();
+                }
+                Ok(TerminalEvent::SessionResumed) => {
+                    let _ = stdout.write_all(b"\r\n[session resumed]\r\n");
+                    let _ = stdout.flush();
+                }
+                Ok(TerminalEvent::Error { message }) => {
+                    let msg = format!("\r\n[error: {message}]\r\n");
+                    let _ = stdout.write_all(msg.as_bytes());
+                    let _ = stdout.flush();
+                }
+                Ok(_) => {} // Scrollback, pane events — ignore in CLI
+            },
+        }
+    }
 }
 
 /// RAII guard to restore terminal mode on drop.
@@ -510,5 +551,63 @@ mod tests {
         assert_eq!(csi_modifier(KeyModifiers::ALT), 3);
         assert_eq!(csi_modifier(KeyModifiers::CONTROL), 5);
         assert_eq!(csi_modifier(KeyModifiers::SHIFT | KeyModifiers::ALT), 4);
+    }
+
+    // Regression test for the `~.` detach bug: when the input task returns
+    // `DetachReason::UserDetach`, the output loop must exit even though the
+    // output channel is still open and would otherwise block forever.
+    #[tokio::test]
+    async fn output_loop_exits_on_user_detach() {
+        let (tx, rx) = flume::bounded::<TerminalEvent>(8);
+        // Keep the sender alive so the channel does NOT close — this models
+        // the real-world case where the WS is still streaming PTY output
+        // while the user types `~.`.
+        let _keep_alive = tx.clone();
+
+        // Input task that immediately signals a user-initiated detach.
+        let mut input_handle = tokio::spawn(async { DetachReason::UserDetach });
+
+        let mut out: Vec<u8> = Vec::new();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            run_output_loop(&rx, &mut input_handle, &mut out),
+        )
+        .await
+        .expect("run_output_loop must exit when input task returns UserDetach");
+
+        assert_eq!(outcome, LoopOutcome::UserDetach);
+        // No output bytes should have been written for a bare detach.
+        assert!(out.is_empty());
+    }
+
+    // The output loop must still exit on SessionClosed when the input task
+    // is still running (the normal "remote process exited" path).
+    #[tokio::test]
+    async fn output_loop_exits_on_session_closed() {
+        let (tx, rx) = flume::bounded::<TerminalEvent>(8);
+        // Input task that never resolves, so only the output channel can
+        // drive loop termination.
+        let mut input_handle = tokio::spawn(async {
+            futures_util::future::pending::<()>().await;
+            DetachReason::InputClosed
+        });
+
+        tx.send_async(TerminalEvent::SessionClosed {
+            exit_code: Some(42),
+        })
+        .await
+        .unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            run_output_loop(&rx, &mut input_handle, &mut out),
+        )
+        .await
+        .expect("run_output_loop must exit on SessionClosed");
+
+        assert_eq!(outcome, LoopOutcome::Exit(42));
+        input_handle.abort();
+        let _ = input_handle.await;
     }
 }

--- a/crates/zremote-server/src/routes/terminal.rs
+++ b/crates/zremote-server/src/routes/terminal.rs
@@ -153,8 +153,27 @@ async fn handle_terminal_connection(
     session_id_str: String,
     state: Arc<AppState>,
 ) {
-    let Ok(session_id) = session_id_str.parse() else {
+    // A UUID is 36 chars; cap the echoed path segment before any allocation
+    // work (format! + JSON) to bound memory on malformed/malicious requests.
+    const MAX_SESSION_ID_LEN: usize = 64;
+    let (parsed, echoed) = if session_id_str.len() > MAX_SESSION_ID_LEN {
+        (Err(()), "<too long>".to_string())
+    } else {
+        (
+            session_id_str.parse::<uuid::Uuid>().map_err(|_| ()),
+            session_id_str.clone(),
+        )
+    };
+    let Ok(session_id) = parsed else {
         let mut socket = socket;
+        let err = BrowserMessage::Error {
+            message: format!("invalid session id '{echoed}': expected UUID"),
+        };
+        if let Ok(json) = serde_json::to_string(&err) {
+            let _ = socket
+                .send(axum::extract::ws::Message::Text(json.into()))
+                .await;
+        }
         let _ = socket.send(axum::extract::ws::Message::Close(None)).await;
         return;
     };


### PR DESCRIPTION
## Summary

Two independent bugs in `zremote cli session attach`:

1. **UUID prefix not accepted.** `session list` shows 8-char short IDs, but `attach`/`get`/`close`/`rename`/`purge` required a full UUID. Passing the displayed short ID triggered a silent WebSocket close with no error payload.
2. **`~.` detach hung the CLI.** Input task exited on detach but the output loop kept blocking on `recv_async` until the remote session closed or WS disconnected; PTY output still streamed.

## Changes

- `ConnectionResolver::resolve_session_id` — prefix match against `list_sessions` (case-insensitive), typed SessionNotFound / AmbiguousSession errors. Wired into Attach/Get/Close/Rename/Purge.
- Server + local agent WS handlers now send a JSON `{"type":"error"}` text frame before Close so attach failures surface a real message. Echoed session id bounded to 64 bytes.
- `run_output_loop` races output channel against input task's JoinHandle via `tokio::select! { biased; }`. On `DetachReason::UserDetach` the loop returns `LoopOutcome::UserDetach`, prints `[detached]`, exits 0.

## Test plan

- [x] `cargo test -p zremote-cli --lib` — 99 passed (incl. 2 new regression tests for detach/session-closed paths)
- [x] `cargo test --workspace` — all passing via pre-commit
- [x] rust-reviewer: approved, no blocking issues