### PR TITLE
fix(agent): collapse nested if/match in worktree hook dispatch tests

### DIFF
--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -2173,11 +2173,9 @@ mod tests {
                     success,
                     output,
                     ..
-                } => {
-                    if hook_type == "create" {
-                        assert!(success, "create hook must succeed: {output:?}");
-                        saw_hook_result = true;
-                    }
+                } if hook_type == "create" => {
+                    assert!(success, "create hook must succeed: {output:?}");
+                    saw_hook_result = true;
                 }
                 AgentMessage::WorktreeError { .. } | AgentMessage::WorktreeCreated { .. } => {
                     // Terminal event — whichever arrives, the hook flow
@@ -2406,11 +2404,9 @@ mod tests {
             match sent {
                 AgentMessage::WorktreeHookResult {
                     hook_type, success, ..
-                } => {
-                    if hook_type == "pre_delete" {
-                        assert!(!success, "pre_delete must be reported as failed");
-                        saw_hook_result = true;
-                    }
+                } if hook_type == "pre_delete" => {
+                    assert!(!success, "pre_delete must be reported as failed");
+                    saw_hook_result = true;
                 }
                 AgentMessage::WorktreeError { .. } => {
                     saw_error = true;


### PR DESCRIPTION
## Summary

- Clippy 1.95 promotes `collapsible_match` to deny via `clippy::all`, breaking CI lint on `main`
- Replace two nested `if hook_type == ...` inside `match AgentMessage::WorktreeHookResult { .. } => { .. }` arms in `crates/zremote-agent/src/connection/dispatch.rs` with match guards (`if hook_type == ...`)
- Semantics unchanged: non-matching `hook_type` values still fall through to the `_ => {}` arm exactly as before

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features --exclude zremote-gui --exclude zremote` (matches CI command) — clean
- [x] `cargo test -p zremote-agent --lib` — 1301 passed
- [x] Pre-commit hook (fmt + clippy + test) passed on commit