### PR TITLE
RFC-009: Server-mode worktree create + branch list (sync request/response)

### DIFF
--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -1280,6 +1280,34 @@ fn handle_branch_list_request(
 ) -> impl std::future::Future<Output = ()> + Send {
     let tx = outbound_tx.clone();
     async move {
+        // Reject path traversal (`..`) before any I/O — mirrors the guard on
+        // `ProjectRegister` / `ListDirectory`. A traversal-containing path
+        // does not resolve to a real project, so PathMissing carries the same
+        // actionable hint.
+        if let Err(e) = validate_path_no_traversal(&project_path) {
+            tracing::warn!(
+                path = %project_path,
+                error = %e,
+                "rejected BranchListRequest with invalid path"
+            );
+            let err = zremote_protocol::project::WorktreeError::new(
+                zremote_protocol::project::WorktreeErrorCode::PathMissing,
+                "Project path is not valid. Remove the project and re-add it with a correct path.",
+                "invalid path",
+            );
+            if tx
+                .send(AgentMessage::BranchListResponse {
+                    request_id,
+                    branches: None,
+                    error: Some(err),
+                })
+                .await
+                .is_err()
+            {
+                tracing::warn!("outbound channel closed, BranchListResponse dropped");
+            }
+            return;
+        }
         tokio::spawn(async move {
             // Existence check first so we can return a precise PathMissing
             // error. `GitInspector::list_branches` would fail with a raw git
@@ -1327,8 +1355,11 @@ fn handle_branch_list_request(
                 Ok(Err(stderr)) => {
                     tracing::warn!(error = %stderr, "list_branches failed");
                     // Preserve PathMissing classification if git stderr
-                    // happens to indicate it; otherwise map to Internal so
-                    // the raw git message doesn't leak through.
+                    // happens to indicate it; otherwise map to Internal with a
+                    // fixed safe message so raw git output (which can include
+                    // filesystem paths, remote URLs, credential-helper details
+                    // — CWE-200) never reaches the HTTP client. Raw stderr is
+                    // kept in the `tracing::warn!` above for local debugging.
                     let err = zremote_protocol::project::WorktreeError::from_git_stderr(&stderr);
                     let err = if matches!(
                         err.code,
@@ -1339,7 +1370,7 @@ fn handle_branch_list_request(
                         zremote_protocol::project::WorktreeError::new(
                             zremote_protocol::project::WorktreeErrorCode::Internal,
                             "Could not list branches for this project.",
-                            stderr,
+                            "unexpected git error",
                         )
                     };
                     AgentMessage::BranchListResponse {
@@ -1356,7 +1387,7 @@ fn handle_branch_list_request(
                         error: Some(zremote_protocol::project::WorktreeError::new(
                             zremote_protocol::project::WorktreeErrorCode::Internal,
                             "Internal error while listing branches.",
-                            format!("task join failed: {join_err}"),
+                            "task join failed",
                         )),
                     }
                 }
@@ -1384,6 +1415,34 @@ fn handle_worktree_create_request(
 ) -> impl std::future::Future<Output = ()> + Send {
     let tx = outbound_tx.clone();
     async move {
+        // Reject path traversal (`..`) before any I/O or spawn_blocking —
+        // mirrors the guard on `ProjectRegister` / `ListDirectory`. A
+        // traversal-containing path does not resolve to a real project, so
+        // PathMissing is the correct classification for the client.
+        if let Err(e) = validate_path_no_traversal(&project_path) {
+            tracing::warn!(
+                path = %project_path,
+                error = %e,
+                "rejected WorktreeCreateRequest with invalid path"
+            );
+            let err = zremote_protocol::project::WorktreeError::new(
+                zremote_protocol::project::WorktreeErrorCode::PathMissing,
+                "Project path is not valid. Remove the project and re-add it with a correct path.",
+                "invalid path",
+            );
+            if tx
+                .send(AgentMessage::WorktreeCreateResponse {
+                    request_id,
+                    worktree: None,
+                    error: Some(err),
+                })
+                .await
+                .is_err()
+            {
+                tracing::warn!("outbound channel closed, WorktreeCreateResponse dropped");
+            }
+            return;
+        }
         tokio::spawn(async move {
             let job_id = uuid::Uuid::new_v4().to_string();
 

--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -1230,22 +1230,221 @@ pub(super) async fn handle_server_message(
             )
             .await;
         }
-        // RFC-009 P1: protocol variants landed ahead of the agent handlers
-        // (P2). Until P2 wires git branch listing and synchronous worktree
-        // create, log and ignore so a newer server reaching an older agent
-        // (or this intermediate build) doesn't crash on exhaustiveness.
-        ServerMessage::BranchListRequest { request_id, .. } => {
-            tracing::debug!(
-                request_id = %request_id,
-                "received BranchListRequest before P2 handlers wired; dropping"
-            );
+        // RFC-009 P2: synchronous branch listing with request_id correlation.
+        // Returns a `BranchListResponse` either with `branches: Some(..)` or
+        // `error: Some(..)` — never both. A missing project directory maps to
+        // `PathMissing` so the server can render a precise remediation hint;
+        // any other git failure degrades to `Internal` with the raw message
+        // kept in `message` (the hint is user-facing, safe).
+        ServerMessage::BranchListRequest {
+            request_id,
+            project_path,
+        } => {
+            handle_branch_list_request(outbound_tx, *request_id, project_path.clone()).await;
         }
-        ServerMessage::WorktreeCreateRequest { request_id, .. } => {
-            tracing::debug!(
-                request_id = %request_id,
-                "received WorktreeCreateRequest before P2 handlers wired; dropping"
-            );
+        // RFC-009 P2: synchronous worktree create with request_id correlation.
+        // Delegates to the shared `worktree::service::run_worktree_create`
+        // helper so validation + git + post_create hook stay identical to
+        // the local HTTP route. Progress events route through the outbound
+        // channel as `AgentMessage::WorktreeCreationProgress`.
+        ServerMessage::WorktreeCreateRequest {
+            request_id,
+            project_path,
+            branch,
+            path,
+            new_branch,
+            base_ref,
+        } => {
+            handle_worktree_create_request(
+                outbound_tx,
+                *request_id,
+                project_path.clone(),
+                branch.clone(),
+                path.clone(),
+                *new_branch,
+                base_ref.clone(),
+            )
+            .await;
         }
+    }
+}
+
+/// Handle `ServerMessage::BranchListRequest`. Spawned into its own task so a
+/// slow `for-each-ref` on a huge repo doesn't block the dispatch loop — we
+/// don't await completion here; the response is sent on the outbound channel
+/// as the task finishes.
+fn handle_branch_list_request(
+    outbound_tx: &mpsc::Sender<AgentMessage>,
+    request_id: uuid::Uuid,
+    project_path: String,
+) -> impl std::future::Future<Output = ()> + Send {
+    let tx = outbound_tx.clone();
+    async move {
+        tokio::spawn(async move {
+            // Existence check first so we can return a precise PathMissing
+            // error. `GitInspector::list_branches` would fail with a raw git
+            // message that collapses to `Internal` via `from_git_stderr`,
+            // which is less actionable than a typed PathMissing.
+            let path_buf = std::path::PathBuf::from(&project_path);
+            let exists = tokio::task::spawn_blocking({
+                let p = path_buf.clone();
+                move || p.exists()
+            })
+            .await
+            .unwrap_or(false);
+
+            if !exists {
+                let err = zremote_protocol::project::WorktreeError::new(
+                    zremote_protocol::project::WorktreeErrorCode::PathMissing,
+                    "Project path no longer exists on disk. Remove the project and re-add it with the correct path.",
+                    format!("path does not exist: {project_path}"),
+                );
+                if tx
+                    .send(AgentMessage::BranchListResponse {
+                        request_id,
+                        branches: None,
+                        error: Some(err),
+                    })
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!("outbound channel closed, BranchListResponse dropped");
+                }
+                return;
+            }
+
+            let join = tokio::task::spawn_blocking(move || {
+                GitInspector::list_branches(std::path::Path::new(&project_path))
+            })
+            .await;
+
+            let message = match join {
+                Ok(Ok(branches)) => AgentMessage::BranchListResponse {
+                    request_id,
+                    branches: Some(branches),
+                    error: None,
+                },
+                Ok(Err(stderr)) => {
+                    tracing::warn!(error = %stderr, "list_branches failed");
+                    // Preserve PathMissing classification if git stderr
+                    // happens to indicate it; otherwise map to Internal so
+                    // the raw git message doesn't leak through.
+                    let err = zremote_protocol::project::WorktreeError::from_git_stderr(&stderr);
+                    let err = if matches!(
+                        err.code,
+                        zremote_protocol::project::WorktreeErrorCode::PathMissing
+                    ) {
+                        err
+                    } else {
+                        zremote_protocol::project::WorktreeError::new(
+                            zremote_protocol::project::WorktreeErrorCode::Internal,
+                            "Could not list branches for this project.",
+                            stderr,
+                        )
+                    };
+                    AgentMessage::BranchListResponse {
+                        request_id,
+                        branches: None,
+                        error: Some(err),
+                    }
+                }
+                Err(join_err) => {
+                    tracing::error!(error = %join_err, "list_branches task panicked");
+                    AgentMessage::BranchListResponse {
+                        request_id,
+                        branches: None,
+                        error: Some(zremote_protocol::project::WorktreeError::new(
+                            zremote_protocol::project::WorktreeErrorCode::Internal,
+                            "Internal error while listing branches.",
+                            format!("task join failed: {join_err}"),
+                        )),
+                    }
+                }
+            };
+
+            if tx.send(message).await.is_err() {
+                tracing::warn!("outbound channel closed, BranchListResponse dropped");
+            }
+        });
+    }
+}
+
+/// Handle `ServerMessage::WorktreeCreateRequest`. Delegates to the shared
+/// `worktree::service` helper so validation + git + post_create stay in lock-
+/// step with the local HTTP handler.
+#[allow(clippy::too_many_arguments)]
+fn handle_worktree_create_request(
+    outbound_tx: &mpsc::Sender<AgentMessage>,
+    request_id: uuid::Uuid,
+    project_path: String,
+    branch: String,
+    path: Option<String>,
+    new_branch: bool,
+    base_ref: Option<String>,
+) -> impl std::future::Future<Output = ()> + Send {
+    let tx = outbound_tx.clone();
+    async move {
+        tokio::spawn(async move {
+            let job_id = uuid::Uuid::new_v4().to_string();
+
+            // Progress callback: convert the service's stage + percent +
+            // optional message into `AgentMessage::WorktreeCreationProgress`
+            // on the outbound channel. Uses `try_send` so a full channel
+            // doesn't deadlock the dispatch task — the server treats
+            // progress as best-effort anyway.
+            let progress_tx = tx.clone();
+            let progress_project_path = project_path.clone();
+            let progress_job_id = job_id.clone();
+            let emit = move |stage, percent, message| {
+                let msg = AgentMessage::WorktreeCreationProgress {
+                    project_path: progress_project_path.clone(),
+                    job_id: progress_job_id.clone(),
+                    stage,
+                    percent,
+                    message,
+                };
+                if progress_tx.try_send(msg).is_err() {
+                    tracing::warn!(
+                        project_path = %progress_project_path,
+                        job_id = %progress_job_id,
+                        "outbound channel full, WorktreeCreationProgress dropped"
+                    );
+                }
+            };
+
+            let input = crate::worktree::service::WorktreeCreateInput {
+                project_path: std::path::PathBuf::from(&project_path),
+                branch,
+                path: path.map(std::path::PathBuf::from),
+                new_branch,
+                base_ref,
+            };
+
+            let response = match crate::worktree::service::run_worktree_create(input, emit).await {
+                Ok(output) => AgentMessage::WorktreeCreateResponse {
+                    request_id,
+                    worktree: Some(zremote_protocol::WorktreeCreateSuccessPayload {
+                        path: output.path,
+                        branch: output.branch,
+                        commit_hash: output.commit_hash,
+                        hook_result: output.hook_result,
+                    }),
+                    error: None,
+                },
+                Err(failure) => AgentMessage::WorktreeCreateResponse {
+                    request_id,
+                    worktree: None,
+                    error: Some(failure.into_worktree_error()),
+                },
+            };
+
+            if tx.send(response).await.is_err() {
+                tracing::warn!(
+                    request_id = %request_id,
+                    "outbound channel closed, WorktreeCreateResponse dropped"
+                );
+            }
+        });
     }
 }
 
@@ -2438,5 +2637,284 @@ mod tests {
             wt_path.exists(),
             "worktree must not be removed when pre_delete fails"
         );
+    }
+
+    // ─── RFC-009 P2: request/response dispatch ──────────────────────────────
+
+    /// `BranchListRequest` on a real git repo must round-trip to
+    /// `BranchListResponse { branches: Some(..), error: None }`.
+    #[tokio::test]
+    async fn branch_list_request_returns_branches_on_healthy_repo() {
+        let host_id = Uuid::new_v4();
+        let (mut sm, mut am, mut ps, otx, mut orx, atx, _arx, ktx, mapper, bs, bsb, mut sa) =
+            make_test_context();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_dispatch_test_repo(&repo);
+
+        let request_id = Uuid::new_v4();
+        let msg = ServerMessage::BranchListRequest {
+            request_id,
+            project_path: repo.to_string_lossy().into_owned(),
+        };
+        handle_server_message(
+            &msg,
+            &host_id,
+            &mut sm,
+            &mut am,
+            &mut ps,
+            &otx,
+            &atx,
+            ktx.as_ref(),
+            &mapper,
+            &bs,
+            &bsb,
+            &mut sa,
+            None,
+            &mut std::collections::HashMap::new(),
+            &std::sync::Arc::new(crate::agents::LauncherRegistry::with_builtins()),
+        )
+        .await;
+
+        let sent = tokio::time::timeout(Duration::from_secs(10), orx.recv())
+            .await
+            .expect("timed out waiting for response")
+            .expect("channel closed");
+        match sent {
+            AgentMessage::BranchListResponse {
+                request_id: rid,
+                branches,
+                error,
+            } => {
+                assert_eq!(rid, request_id, "request_id must echo back");
+                assert!(
+                    error.is_none(),
+                    "healthy repo must not return error: {error:?}"
+                );
+                let list = branches.expect("branches must be Some");
+                assert!(
+                    list.local.iter().any(|b| b.name == "main"),
+                    "expected local branch 'main' in {:?}",
+                    list.local
+                );
+            }
+            other => panic!("unexpected agent message: {other:?}"),
+        }
+    }
+
+    /// `BranchListRequest` for a path that does not exist must come back with
+    /// `error: Some(WorktreeError { code: PathMissing, .. })`.
+    #[tokio::test]
+    async fn branch_list_request_path_missing_maps_to_structured_error() {
+        let host_id = Uuid::new_v4();
+        let (mut sm, mut am, mut ps, otx, mut orx, atx, _arx, ktx, mapper, bs, bsb, mut sa) =
+            make_test_context();
+
+        let request_id = Uuid::new_v4();
+        let msg = ServerMessage::BranchListRequest {
+            request_id,
+            project_path: "/nonexistent/zremote-test/abcxyz".to_string(),
+        };
+        handle_server_message(
+            &msg,
+            &host_id,
+            &mut sm,
+            &mut am,
+            &mut ps,
+            &otx,
+            &atx,
+            ktx.as_ref(),
+            &mapper,
+            &bs,
+            &bsb,
+            &mut sa,
+            None,
+            &mut std::collections::HashMap::new(),
+            &std::sync::Arc::new(crate::agents::LauncherRegistry::with_builtins()),
+        )
+        .await;
+
+        let sent = tokio::time::timeout(Duration::from_secs(5), orx.recv())
+            .await
+            .expect("timed out")
+            .expect("channel closed");
+        match sent {
+            AgentMessage::BranchListResponse {
+                request_id: rid,
+                branches,
+                error,
+            } => {
+                assert_eq!(rid, request_id);
+                assert!(branches.is_none(), "branches must be None on error");
+                let err = error.expect("error must be Some for missing path");
+                assert_eq!(
+                    err.code,
+                    zremote_protocol::project::WorktreeErrorCode::PathMissing,
+                    "expected PathMissing for nonexistent project path"
+                );
+            }
+            other => panic!("unexpected agent message: {other:?}"),
+        }
+    }
+
+    /// `WorktreeCreateRequest` happy path: response carries a populated
+    /// `WorktreeCreateSuccessPayload` and at least Init/Finalizing/Done
+    /// progress events fire before it.
+    #[tokio::test]
+    async fn worktree_create_request_happy_path_returns_success_payload() {
+        let host_id = Uuid::new_v4();
+        let (mut sm, mut am, mut ps, otx, mut orx, atx, _arx, ktx, mapper, bs, bsb, mut sa) =
+            make_test_context();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_dispatch_test_repo(&repo);
+        let wt_path = tmp.path().join("wt-request");
+
+        let request_id = Uuid::new_v4();
+        let msg = ServerMessage::WorktreeCreateRequest {
+            request_id,
+            project_path: repo.to_string_lossy().into_owned(),
+            branch: "derived-req".to_string(),
+            path: Some(wt_path.to_string_lossy().into_owned()),
+            new_branch: true,
+            base_ref: Some("base-branch".to_string()),
+        };
+        handle_server_message(
+            &msg,
+            &host_id,
+            &mut sm,
+            &mut am,
+            &mut ps,
+            &otx,
+            &atx,
+            ktx.as_ref(),
+            &mapper,
+            &bs,
+            &bsb,
+            &mut sa,
+            None,
+            &mut std::collections::HashMap::new(),
+            &std::sync::Arc::new(crate::agents::LauncherRegistry::with_builtins()),
+        )
+        .await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        let mut stages = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let sent = tokio::time::timeout(remaining, orx.recv())
+                .await
+                .expect("timed out")
+                .expect("channel closed");
+            match sent {
+                AgentMessage::WorktreeCreationProgress { stage, .. } => {
+                    stages.push(stage);
+                }
+                AgentMessage::WorktreeCreateResponse {
+                    request_id: rid,
+                    worktree,
+                    error,
+                } => {
+                    assert_eq!(rid, request_id, "request_id must echo back");
+                    assert!(error.is_none(), "happy path must not emit error: {error:?}");
+                    let payload = worktree.expect("payload must be Some on success");
+                    assert_eq!(payload.branch.as_deref(), Some("derived-req"));
+                    assert!(
+                        payload.path.ends_with("wt-request"),
+                        "unexpected path {}",
+                        payload.path
+                    );
+                    assert!(
+                        payload.commit_hash.is_some(),
+                        "commit_hash must be populated"
+                    );
+                    break;
+                }
+                AgentMessage::WorktreeError { .. } => {
+                    panic!("legacy WorktreeError must not fire for request path");
+                }
+                AgentMessage::WorktreeCreated { .. } => {
+                    panic!("legacy WorktreeCreated must not fire for request path");
+                }
+                _ => {}
+            }
+        }
+
+        use zremote_protocol::events::WorktreeCreationStage::{Done, Finalizing, Init};
+        assert!(stages.contains(&Init), "missing Init: {stages:?}");
+        assert!(
+            stages.contains(&Finalizing),
+            "missing Finalizing: {stages:?}"
+        );
+        assert!(stages.contains(&Done), "missing Done: {stages:?}");
+    }
+
+    /// `WorktreeCreateRequest` with a leading-dash branch must be rejected
+    /// before any git call — the service helper is the single source of truth
+    /// for that validation.
+    #[tokio::test]
+    async fn worktree_create_request_leading_dash_rejected_in_service() {
+        let host_id = Uuid::new_v4();
+        let (mut sm, mut am, mut ps, otx, mut orx, atx, _arx, ktx, mapper, bs, bsb, mut sa) =
+            make_test_context();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_dispatch_test_repo(&repo);
+
+        let request_id = Uuid::new_v4();
+        let msg = ServerMessage::WorktreeCreateRequest {
+            request_id,
+            project_path: repo.to_string_lossy().into_owned(),
+            branch: "-x".to_string(),
+            path: None,
+            new_branch: true,
+            base_ref: None,
+        };
+        handle_server_message(
+            &msg,
+            &host_id,
+            &mut sm,
+            &mut am,
+            &mut ps,
+            &otx,
+            &atx,
+            ktx.as_ref(),
+            &mapper,
+            &bs,
+            &bsb,
+            &mut sa,
+            None,
+            &mut std::collections::HashMap::new(),
+            &std::sync::Arc::new(crate::agents::LauncherRegistry::with_builtins()),
+        )
+        .await;
+
+        let sent = tokio::time::timeout(Duration::from_secs(5), orx.recv())
+            .await
+            .expect("timed out")
+            .expect("channel closed");
+        match sent {
+            AgentMessage::WorktreeCreateResponse {
+                request_id: rid,
+                worktree,
+                error,
+            } => {
+                assert_eq!(rid, request_id);
+                assert!(worktree.is_none(), "worktree must be None on rejection");
+                let err = error.expect("error must be Some");
+                assert_eq!(
+                    err.code,
+                    zremote_protocol::project::WorktreeErrorCode::InvalidRef,
+                    "leading dash must map to InvalidRef"
+                );
+            }
+            other => panic!("unexpected agent message: {other:?}"),
+        }
     }
 }

--- a/crates/zremote-agent/src/connection/dispatch.rs
+++ b/crates/zremote-agent/src/connection/dispatch.rs
@@ -1230,6 +1230,22 @@ pub(super) async fn handle_server_message(
             )
             .await;
         }
+        // RFC-009 P1: protocol variants landed ahead of the agent handlers
+        // (P2). Until P2 wires git branch listing and synchronous worktree
+        // create, log and ignore so a newer server reaching an older agent
+        // (or this intermediate build) doesn't crash on exhaustiveness.
+        ServerMessage::BranchListRequest { request_id, .. } => {
+            tracing::debug!(
+                request_id = %request_id,
+                "received BranchListRequest before P2 handlers wired; dropping"
+            );
+        }
+        ServerMessage::WorktreeCreateRequest { request_id, .. } => {
+            tracing::debug!(
+                request_id = %request_id,
+                "received WorktreeCreateRequest before P2 handlers wired; dropping"
+            );
+        }
     }
 }
 

--- a/crates/zremote-agent/src/lib.rs
+++ b/crates/zremote-agent/src/lib.rs
@@ -39,6 +39,7 @@ mod project;
 mod pty;
 mod session;
 mod shell;
+mod worktree;
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/crates/zremote-agent/src/local/routes/projects/worktree.rs
+++ b/crates/zremote-agent/src/local/routes/projects/worktree.rs
@@ -47,30 +47,12 @@ pub(crate) fn reject_leading_dash(field: &str, value: &str) -> Result<(), Worktr
     Ok(())
 }
 
-/// Map a `WorktreeErrorCode` to the HTTP status that best conveys the class of
-/// failure. We keep 500 for true internal errors so monitoring/alerting can
-/// still distinguish them, but use 4xx for issues the caller can correct.
-fn status_for_code(code: &WorktreeErrorCode) -> StatusCode {
-    match code {
-        WorktreeErrorCode::BranchExists | WorktreeErrorCode::PathCollision => StatusCode::CONFLICT,
-        WorktreeErrorCode::DetachedHead
-        | WorktreeErrorCode::Locked
-        | WorktreeErrorCode::Unmerged
-        | WorktreeErrorCode::InvalidRef => StatusCode::BAD_REQUEST,
-        // The project directory is gone — the caller has to fix the project
-        // registration, not the worktree inputs. 404 matches the semantics
-        // (the referenced resource no longer exists on this host).
-        WorktreeErrorCode::PathMissing => StatusCode::NOT_FOUND,
-        WorktreeErrorCode::Internal | WorktreeErrorCode::Unknown => {
-            StatusCode::INTERNAL_SERVER_ERROR
-        }
-    }
-}
-
-/// Build a JSON response body for a structured worktree error.
+/// Build a JSON response body for a structured worktree error. Delegates to
+/// the shared helper in `zremote-core` so local-mode and server-mode use one
+/// status-code mapping.
 fn worktree_error_response(err: WorktreeError) -> axum::response::Response {
-    let status = status_for_code(&err.code);
-    (status, Json(err)).into_response()
+    let (status, body) = zremote_core::worktree_http::worktree_error_response(err);
+    (status, body).into_response()
 }
 
 /// Read full project settings via spawn_blocking. Returns `None` when no

--- a/crates/zremote-agent/src/local/routes/projects/worktree.rs
+++ b/crates/zremote-agent/src/local/routes/projects/worktree.rs
@@ -16,18 +16,13 @@ use crate::local::state::LocalAppState;
 use crate::project::action_runner::ActionRunContext;
 use crate::project::git::GitInspector;
 use crate::project::hook_dispatcher::{WorktreeSlot, run_worktree_hook, run_worktree_override};
+use crate::worktree::service::{WorktreeCreateFailure, WorktreeCreateInput, run_worktree_create};
 
 use super::ProjectResponse;
 use super::parse_project_id;
 use zremote_protocol::ProjectSettings;
 use zremote_protocol::events::WorktreeCreationStage;
 use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
-
-/// Maximum wall time for the blocking git worktree add call. Chosen to
-/// tolerate large-repo worktree creation (where git's staged checkout can
-/// legitimately take tens of seconds) while still putting a hard ceiling on
-/// the request so the client isn't left hanging forever.
-const WORKTREE_CREATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Maximum wall time for the `pre_delete` captured hook. The delete handler
 /// blocks on this hook before touching git, so an unbounded run would pin the
@@ -50,25 +45,6 @@ pub(crate) fn reject_leading_dash(field: &str, value: &str) -> Result<(), Worktr
         ));
     }
     Ok(())
-}
-
-/// Emit a `WorktreeCreationProgress` event for the given job/stage. Broadcast
-/// is best-effort — a full broadcast channel should not abort the operation.
-fn emit_progress(
-    state: &LocalAppState,
-    project_id: &str,
-    job_id: &str,
-    stage: WorktreeCreationStage,
-    percent: u8,
-    message: Option<String>,
-) {
-    let _ = state.events.send(ServerEvent::WorktreeCreationProgress {
-        project_id: project_id.to_string(),
-        job_id: job_id.to_string(),
-        stage,
-        percent,
-        message,
-    });
 }
 
 /// Map a `WorktreeErrorCode` to the HTTP status that best conveys the class of
@@ -337,115 +313,58 @@ pub async fn create_worktree(
         }
     }
 
-    // Default flow: existing GitInspector behavior, wrapped in a 60s timeout
-    // and bracketed by progress events so the GUI can show a pending spinner
-    // for large-repo creations. Leading-dash inputs were already rejected at
-    // the top of the handler so the blocking task can trust these values.
-    let branch = body.branch.clone();
-    let wt_path = body.path.clone();
-    let new_branch = body.new_branch.unwrap_or(false);
-    let base_ref = body.base_ref.clone();
-    let repo_path = project_path.clone();
-
+    // Default flow: delegate to the shared helper. The helper runs the
+    // CWE-88 leading-dash guard (defence-in-depth), emits Init/Creating/
+    // Finalizing/Done progress through the callback, bounds the git call
+    // with the shared `WORKTREE_CREATE_TIMEOUT`, and fires `post_create`
+    // when settings configure one.
+    //
+    // HTTP-only concerns kept in this handler:
+    //   * translating the callback into a broadcast `ServerEvent`,
+    //   * DB insert + `UPDATE projects`,
+    //   * mapping the structured error to an HTTP status.
     let job_id = Uuid::new_v4().to_string();
-    emit_progress(
-        &state,
-        &project_id,
-        &job_id,
-        WorktreeCreationStage::Init,
-        0,
-        None,
-    );
+    let events_cb = state.events.clone();
+    let project_id_cb = project_id.clone();
+    let job_id_cb = job_id.clone();
 
-    // Emit Creating from *inside* the blocking task so the event fires when
-    // git actually starts running, not at the moment we scheduled it. That
-    // gives the GUI a progress signal that reflects reality under load.
-    let events_for_task = state.events.clone();
-    let project_id_for_task = project_id.clone();
-    let job_id_for_task = job_id.clone();
+    let service_input = WorktreeCreateInput {
+        project_path: std::path::PathBuf::from(&project_path),
+        branch: body.branch.clone(),
+        path: body.path.as_deref().map(std::path::PathBuf::from),
+        new_branch: body.new_branch.unwrap_or(false),
+        base_ref: body.base_ref.clone(),
+    };
 
-    let mut handle = tokio::task::spawn_blocking(move || {
-        // Best-effort broadcast: a full channel must not abort the git call.
-        let _ = events_for_task.send(ServerEvent::WorktreeCreationProgress {
-            project_id: project_id_for_task,
-            job_id: job_id_for_task,
-            stage: WorktreeCreationStage::Creating,
-            percent: 25,
-            message: Some("running git worktree add".to_string()),
+    let service_result = run_worktree_create(service_input, move |stage, percent, message| {
+        // Best-effort broadcast — a full channel must not abort the git call.
+        let _ = events_cb.send(ServerEvent::WorktreeCreationProgress {
+            project_id: project_id_cb.clone(),
+            job_id: job_id_cb.clone(),
+            stage,
+            percent,
+            message,
         });
-        GitInspector::create_worktree(
-            Path::new(&repo_path),
-            &branch,
-            wt_path.as_deref().map(Path::new),
-            new_branch,
-            base_ref.as_deref(),
-        )
-    });
+    })
+    .await;
 
-    // Passing `&mut handle` keeps ownership of the JoinHandle so we can abort
-    // the task if the timeout fires; otherwise the handle would be moved into
-    // the timeout future and we would leak the spawned task on timeout.
-    let join_result = match tokio::time::timeout(WORKTREE_CREATE_TIMEOUT, &mut handle).await {
-        Ok(res) => {
-            res.map_err(|e| AppError::Internal(format!("worktree create task failed: {e}")))?
+    let output = match service_result {
+        Ok(out) => out,
+        Err(WorktreeCreateFailure::Structured(err)) => {
+            return Ok(worktree_error_response(err));
         }
-        Err(_) => {
-            handle.abort();
-            tracing::warn!(
-                job_id = %job_id,
-                timeout_secs = WORKTREE_CREATE_TIMEOUT.as_secs(),
-                "worktree create timed out"
-            );
-            emit_progress(
-                &state,
-                &project_id,
-                &job_id,
-                WorktreeCreationStage::Failed,
-                100,
-                Some(format!(
-                    "timed out after {}s",
-                    WORKTREE_CREATE_TIMEOUT.as_secs()
-                )),
-            );
+        Err(WorktreeCreateFailure::Timeout { seconds }) => {
+            tracing::warn!(job_id = %job_id, timeout_secs = seconds, "worktree create timed out");
             return Ok(worktree_error_response(WorktreeError::new(
                 WorktreeErrorCode::Internal,
                 "Worktree creation timed out — the repository may be very large or git may be stuck.",
-                format!("timed out after {}s", WORKTREE_CREATE_TIMEOUT.as_secs()),
+                format!("timed out after {seconds}s"),
             )));
         }
     };
 
-    let result = match join_result {
-        Ok(info) => info,
-        Err(stderr) => {
-            tracing::warn!(error = %stderr, job_id = %job_id, "worktree create failed");
-            let err = WorktreeError::from_git_stderr(&stderr);
-            emit_progress(
-                &state,
-                &project_id,
-                &job_id,
-                WorktreeCreationStage::Failed,
-                100,
-                Some(err.message.clone()),
-            );
-            return Ok(worktree_error_response(err));
-        }
-    };
-
-    // git has returned successfully; the work left is DB insert + post_create
-    // hook. Surface that as Finalizing so the GUI can show a "wrapping up"
-    // state distinct from the active git call.
-    emit_progress(
-        &state,
-        &project_id,
-        &job_id,
-        WorktreeCreationStage::Finalizing,
-        75,
-        None,
-    );
-
     let wt_id = Uuid::new_v4().to_string();
-    let wt_name = result
+    let wt_name = output
         .path
         .rsplit('/')
         .next()
@@ -456,7 +375,7 @@ pub async fn create_worktree(
         &state.db,
         &wt_id,
         &host_id_str,
-        &result.path,
+        &output.path,
         &wt_name,
         Some(&project_id),
         "worktree",
@@ -464,51 +383,26 @@ pub async fn create_worktree(
     .await?;
 
     sqlx::query("UPDATE projects SET git_branch = ?, git_commit_hash = ? WHERE id = ?")
-        .bind(&result.branch)
-        .bind(&result.commit_hash)
+        .bind(&output.branch)
+        .bind(&output.commit_hash)
         .bind(&wt_id)
         .execute(&state.db)
         .await
         .map_err(AppError::Database)?;
 
-    // Run post_create captured hook (new or legacy on_create) if configured.
-    // Resolution errors (e.g. hook references a missing action) surface as
-    // 400s so misconfiguration is visible immediately, not silently dropped.
-    let hook_result = if let Some(ref sett) = settings {
-        let ctx = ActionRunContext {
-            project_path: project_path.clone(),
-            worktree_path: Some(result.path.clone()),
-            branch: result.branch.clone(),
-            worktree_name: Some(wt_name.clone()),
-            inputs: std::collections::HashMap::new(),
-        };
-        run_worktree_hook(sett, WorktreeSlot::PostCreate, ctx, None).await?
-    } else {
-        None
-    };
-
-    if let Some(ref hr) = hook_result {
-        log_hook_result("post_create", &result.path, hr);
+    if let Some(ref hr) = output.hook_result {
+        log_hook_result("post_create", &output.path, hr);
     }
 
     let mut project = serde_json::to_value(q::get_project(&state.db, &wt_id).await?)
         .map_err(|e| AppError::Internal(format!("serialization error: {e}")))?;
-    if let Some(ref hr) = hook_result {
+    if let Some(ref hr) = output.hook_result {
         project["hook_result"] = serde_json::json!({
             "success": hr.success,
             "output": hr.output,
             "duration_ms": hr.duration_ms,
         });
     }
-
-    emit_progress(
-        &state,
-        &project_id,
-        &job_id,
-        WorktreeCreationStage::Done,
-        100,
-        None,
-    );
 
     Ok((StatusCode::CREATED, Json(project)).into_response())
 }

--- a/crates/zremote-agent/src/worktree/mod.rs
+++ b/crates/zremote-agent/src/worktree/mod.rs
@@ -1,0 +1,6 @@
+//! Shared worktree operations used by both the local HTTP handler and the
+//! server-mode WebSocket dispatcher. Extracting these into one place guarantees
+//! every caller goes through the same validation (CWE-88 leading-dash guard),
+//! the same git invocation, and the same post-create hook flow.
+
+pub mod service;

--- a/crates/zremote-agent/src/worktree/service.rs
+++ b/crates/zremote-agent/src/worktree/service.rs
@@ -186,13 +186,16 @@ pub async fn run_worktree_create(
     let git_result = match join_result {
         Ok(r) => r,
         Err(join_err) => {
-            let msg = format!("worktree create task failed: {join_err}");
-            tracing::error!(error = %msg, "spawn_blocking join failed");
-            emit_progress(WorktreeCreationStage::Failed, 100, Some(msg.clone()));
+            tracing::error!(error = %join_err, "spawn_blocking join failed");
+            emit_progress(
+                WorktreeCreationStage::Failed,
+                100,
+                Some("worktree create task failed".to_string()),
+            );
             return Err(WorktreeCreateFailure::Structured(WorktreeError::new(
                 WorktreeErrorCode::Internal,
                 "Internal error while creating worktree.",
-                msg,
+                "worktree create task failed",
             )));
         }
     };

--- a/crates/zremote-agent/src/worktree/service.rs
+++ b/crates/zremote-agent/src/worktree/service.rs
@@ -1,0 +1,476 @@
+//! Shared "default flow" of worktree creation.
+//!
+//! This is the slice of `create_worktree` that does NOT depend on the local
+//! HTTP app state (DB, session manager, broadcast channel):
+//!
+//! 1. Reject leading-dash inputs (CWE-88).
+//! 2. Emit `Init` progress.
+//! 3. `git worktree add` on a blocking thread, bounded by a wall-time timeout.
+//! 4. Emit `Finalizing` progress.
+//! 5. Run the `post_create` hook in captured mode.
+//! 6. Emit `Done` progress.
+//!
+//! Callers translate the `emit_progress` callback into their transport
+//! (HTTP broadcasts a `ServerEvent::WorktreeCreationProgress`; WS dispatcher
+//! sends an `AgentMessage::WorktreeCreationProgress` on the outbound channel).
+//!
+//! DB insert + `ProjectsUpdated` broadcast remain in the HTTP handler because
+//! the WS dispatcher does not own a DB — the server performs its own upsert
+//! after it receives `AgentMessage::WorktreeCreateResponse`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use zremote_protocol::events::WorktreeCreationStage;
+use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
+use zremote_protocol::{HookResultInfo, ProjectSettings};
+
+use crate::project::action_runner::ActionRunContext;
+use crate::project::git::GitInspector;
+use crate::project::hook_dispatcher::{WorktreeSlot, run_worktree_hook};
+
+/// Maximum wall time for the blocking git worktree add call. Chosen to
+/// tolerate large-repo worktree creation (where git's staged checkout can
+/// legitimately take tens of seconds) while still putting a hard ceiling on
+/// the request so the client isn't left hanging forever.
+///
+/// Kept in sync with `local::routes::projects::worktree::WORKTREE_CREATE_TIMEOUT`
+/// and the server-mode dispatch's inline constant.
+pub const WORKTREE_CREATE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Inputs to `run_worktree_create`. Mirrors the fields callers already have
+/// in hand from either the HTTP body or the WS message.
+#[derive(Debug, Clone)]
+pub struct WorktreeCreateInput {
+    pub project_path: PathBuf,
+    pub branch: String,
+    pub path: Option<PathBuf>,
+    pub new_branch: bool,
+    pub base_ref: Option<String>,
+}
+
+/// Success payload returned by `run_worktree_create`. The `hook_result` is
+/// populated when a `post_create` hook ran; `None` means no hook configured
+/// (or resolution failed — that path is non-fatal and logged).
+#[derive(Debug, Clone)]
+pub struct WorktreeCreateOutput {
+    pub path: String,
+    pub branch: Option<String>,
+    pub commit_hash: Option<String>,
+    pub hook_result: Option<HookResultInfo>,
+}
+
+/// Failure cases surfaced to the caller. `Structured` is a git/validation/
+/// hook-resolution failure with a typed `WorktreeError` ready to forward to
+/// the client; `Timeout` lets the caller emit a transport-specific message
+/// (HTTP → 500; WS → `WorktreeError { code: Internal, .. }`).
+#[derive(Debug)]
+pub enum WorktreeCreateFailure {
+    Structured(WorktreeError),
+    Timeout { seconds: u64 },
+}
+
+impl WorktreeCreateFailure {
+    /// Convert to a `WorktreeError` payload — handy for the WS caller which
+    /// needs to put a `WorktreeError` on the wire regardless of variant.
+    #[must_use]
+    pub fn into_worktree_error(self) -> WorktreeError {
+        match self {
+            Self::Structured(err) => err,
+            Self::Timeout { seconds } => WorktreeError::new(
+                WorktreeErrorCode::Internal,
+                "Worktree creation timed out — the repository may be very large or git may be stuck.",
+                format!("timed out after {seconds}s"),
+            ),
+        }
+    }
+}
+
+/// Reject user-controlled git inputs that start with `-`. Without this guard
+/// a caller could smuggle additional git options through the worktree
+/// endpoint (CWE-88) — for example, passing `--upload-pack=evil` as a branch
+/// name. Enforced *inside* the service so no caller can bypass it by calling
+/// the helper without first validating, even if the outer HTTP/WS layer
+/// forgets to.
+fn reject_leading_dash(field: &str, value: &str) -> Result<(), WorktreeError> {
+    if value.starts_with('-') {
+        return Err(WorktreeError::new(
+            WorktreeErrorCode::InvalidRef,
+            format!("{field} must not start with '-'"),
+            format!("rejected {field}: leading dash not allowed"),
+        ));
+    }
+    Ok(())
+}
+
+/// Read full project settings via `spawn_blocking`. `None` means "no settings
+/// file or unreadable" which downstream treats as "no hooks configured".
+async fn read_settings_off_thread(project_path: &Path) -> Option<ProjectSettings> {
+    let pp = project_path.to_path_buf();
+    tokio::task::spawn_blocking(move || crate::project::settings::read_settings(&pp))
+        .await
+        .ok()?
+        .ok()
+        .flatten()
+}
+
+/// Run the default worktree-create flow.
+///
+/// `emit_progress` is called synchronously on each lifecycle stage. Callers
+/// use it to turn the stage into a transport-specific message.
+///
+/// # Errors
+/// See [`WorktreeCreateFailure`] — validation, git, and hook-resolution
+/// failures flow through `Structured`; wall-time exceeded flows through
+/// `Timeout`.
+pub async fn run_worktree_create(
+    input: WorktreeCreateInput,
+    emit_progress: impl Fn(WorktreeCreationStage, u8, Option<String>) + Send + Sync,
+) -> Result<WorktreeCreateOutput, WorktreeCreateFailure> {
+    // 1. CWE-88 guard. Runs before any I/O so a malicious caller cannot
+    //    observe timing differences between validated and unvalidated paths.
+    reject_leading_dash("branch", &input.branch).map_err(WorktreeCreateFailure::Structured)?;
+    if let Some(ref p) = input.path {
+        let s = p.to_string_lossy();
+        reject_leading_dash("path", &s).map_err(WorktreeCreateFailure::Structured)?;
+    }
+    if let Some(ref b) = input.base_ref {
+        reject_leading_dash("base_ref", b).map_err(WorktreeCreateFailure::Structured)?;
+    }
+
+    // 2. Init progress before any I/O.
+    emit_progress(WorktreeCreationStage::Init, 0, None);
+
+    // Read settings once up front — used for the post_create hook below.
+    let settings = read_settings_off_thread(&input.project_path).await;
+
+    // 3. Creating progress: emit right before spawning the git subprocess so
+    //    the GUI sees a signal reflecting when git actually starts rather
+    //    than when we *scheduled* the blocking task.
+    emit_progress(
+        WorktreeCreationStage::Creating,
+        25,
+        Some("running git worktree add".to_string()),
+    );
+
+    // git worktree add on a blocking thread with a hard wall-time ceiling.
+    let repo_path = input.project_path.clone();
+    let branch = input.branch.clone();
+    let wt_path: Option<PathBuf> = input.path.clone();
+    let new_branch = input.new_branch;
+    let base_ref = input.base_ref.clone();
+
+    let mut handle = tokio::task::spawn_blocking(move || {
+        GitInspector::create_worktree(
+            repo_path.as_path(),
+            &branch,
+            wt_path.as_deref(),
+            new_branch,
+            base_ref.as_deref(),
+        )
+    });
+
+    // Pass `&mut handle` so we keep ownership and can abort on timeout.
+    let Ok(join_result) = tokio::time::timeout(WORKTREE_CREATE_TIMEOUT, &mut handle).await else {
+        handle.abort();
+        let seconds = WORKTREE_CREATE_TIMEOUT.as_secs();
+        tracing::warn!(timeout_secs = seconds, "worktree create timed out");
+        emit_progress(
+            WorktreeCreationStage::Failed,
+            100,
+            Some(format!("timed out after {seconds}s")),
+        );
+        return Err(WorktreeCreateFailure::Timeout { seconds });
+    };
+
+    let git_result = match join_result {
+        Ok(r) => r,
+        Err(join_err) => {
+            let msg = format!("worktree create task failed: {join_err}");
+            tracing::error!(error = %msg, "spawn_blocking join failed");
+            emit_progress(WorktreeCreationStage::Failed, 100, Some(msg.clone()));
+            return Err(WorktreeCreateFailure::Structured(WorktreeError::new(
+                WorktreeErrorCode::Internal,
+                "Internal error while creating worktree.",
+                msg,
+            )));
+        }
+    };
+
+    let worktree_info = match git_result {
+        Ok(info) => info,
+        Err(stderr) => {
+            tracing::warn!(error = %stderr, "worktree create failed");
+            let err = WorktreeError::from_git_stderr(&stderr);
+            emit_progress(
+                WorktreeCreationStage::Failed,
+                100,
+                Some(err.message.clone()),
+            );
+            return Err(WorktreeCreateFailure::Structured(err));
+        }
+    };
+
+    // 4. Finalizing: git is done; hook still ahead of us.
+    emit_progress(WorktreeCreationStage::Finalizing, 75, None);
+
+    // 5. Post-create hook. Captured mode is the only mode that works without
+    //    a PTY — both callers are in contexts where spawning a PTY would
+    //    either be out of scope (server dispatch) or already serviced by the
+    //    `create`-slot override (local HTTP override branch is handled in the
+    //    caller, not here).
+    //
+    //    Resolution errors (missing action) are non-fatal: the worktree was
+    //    created successfully, so withholding the success response because a
+    //    misconfigured secondary hook is worse than surfacing the
+    //    misconfiguration via a tracing warn. Command failures inside the
+    //    hook are captured in `HookResultInfo.success` and forwarded to the
+    //    client.
+    let hook_result = if let Some(ref sett) = settings {
+        let worktree_name = Path::new(&worktree_info.path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(String::from);
+        let ctx = ActionRunContext {
+            project_path: input.project_path.to_string_lossy().into_owned(),
+            worktree_path: Some(worktree_info.path.clone()),
+            branch: worktree_info.branch.clone(),
+            worktree_name,
+            inputs: std::collections::HashMap::new(),
+        };
+        match run_worktree_hook(sett, WorktreeSlot::PostCreate, ctx, None).await {
+            Ok(hook) => hook,
+            Err(e) => {
+                // Downgrade to warn so the successful worktree still returns.
+                tracing::warn!(
+                    worktree = %worktree_info.path,
+                    error = %e,
+                    "post_create hook resolution failed"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // 6. Done.
+    emit_progress(WorktreeCreationStage::Done, 100, None);
+
+    Ok(WorktreeCreateOutput {
+        path: worktree_info.path,
+        branch: worktree_info.branch,
+        commit_hash: worktree_info.commit_hash,
+        hook_result,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal on-disk git repo with one commit and a secondary
+    /// branch so callers can test `base_ref` threading.
+    fn init_test_repo(dir: &Path) {
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env_clear()
+                .env("PATH", std::env::var("PATH").unwrap_or_default())
+                .env("HOME", dir)
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .output()
+                .expect("git");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "--initial-branch=main", "."]);
+        git(&["config", "user.email", "t@t"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "--no-verify", "-m", "init"]);
+        git(&["branch", "base-branch"]);
+    }
+
+    #[tokio::test]
+    async fn run_worktree_create_golden_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_test_repo(&repo);
+
+        let wt_path = tmp.path().join("wt-golden");
+        let stages = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stages_clone = stages.clone();
+        let input = WorktreeCreateInput {
+            project_path: repo.clone(),
+            branch: "feature-x".to_string(),
+            path: Some(wt_path.clone()),
+            new_branch: true,
+            base_ref: Some("base-branch".to_string()),
+        };
+        let output = run_worktree_create(input, move |stage, _pct, _msg| {
+            stages_clone.lock().unwrap().push(stage);
+        })
+        .await
+        .expect("golden path must succeed");
+
+        assert!(
+            output.path.ends_with("wt-golden"),
+            "unexpected worktree path: {}",
+            output.path
+        );
+        assert_eq!(output.branch.as_deref(), Some("feature-x"));
+        assert!(output.commit_hash.is_some(), "missing commit hash");
+        // No hook configured → no hook result.
+        assert!(output.hook_result.is_none());
+
+        let seen = stages.lock().unwrap().clone();
+        assert!(
+            seen.contains(&WorktreeCreationStage::Init),
+            "missing Init: {seen:?}"
+        );
+        assert!(
+            seen.contains(&WorktreeCreationStage::Finalizing),
+            "missing Finalizing: {seen:?}"
+        );
+        assert!(
+            seen.contains(&WorktreeCreationStage::Done),
+            "missing Done: {seen:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_worktree_create_branch_exists_is_structured() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_test_repo(&repo);
+
+        // First create a worktree with branch `dup`.
+        let wt1 = tmp.path().join("wt1");
+        let _ = run_worktree_create(
+            WorktreeCreateInput {
+                project_path: repo.clone(),
+                branch: "dup".to_string(),
+                path: Some(wt1),
+                new_branch: true,
+                base_ref: None,
+            },
+            |_, _, _| {},
+        )
+        .await
+        .expect("first create must succeed");
+
+        // Second attempt with the same `new_branch=true` + same name must hit
+        // git's "A branch named 'dup' already exists" error and surface as
+        // BranchExists.
+        let wt2 = tmp.path().join("wt2");
+        let err = run_worktree_create(
+            WorktreeCreateInput {
+                project_path: repo.clone(),
+                branch: "dup".to_string(),
+                path: Some(wt2),
+                new_branch: true,
+                base_ref: None,
+            },
+            |_, _, _| {},
+        )
+        .await
+        .expect_err("second create must fail");
+
+        match err {
+            WorktreeCreateFailure::Structured(e) => {
+                assert_eq!(
+                    e.code,
+                    WorktreeErrorCode::BranchExists,
+                    "expected BranchExists, got {:?}; message={}",
+                    e.code,
+                    e.message,
+                );
+            }
+            WorktreeCreateFailure::Timeout { .. } => panic!("unexpected Timeout failure"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_worktree_create_rejects_leading_dash_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_test_repo(&repo);
+
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called_clone = called.clone();
+        let err = run_worktree_create(
+            WorktreeCreateInput {
+                project_path: repo,
+                branch: "-x".to_string(),
+                path: None,
+                new_branch: true,
+                base_ref: None,
+            },
+            move |_, _, _| {
+                called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            },
+        )
+        .await
+        .expect_err("leading-dash branch must be rejected");
+
+        // Validation must fire before any progress callback (and before any
+        // git call).
+        assert!(
+            !called.load(std::sync::atomic::Ordering::SeqCst),
+            "progress callback fired despite validation rejection"
+        );
+        match err {
+            WorktreeCreateFailure::Structured(e) => {
+                assert_eq!(e.code, WorktreeErrorCode::InvalidRef);
+                assert!(
+                    e.hint.contains("branch"),
+                    "hint should mention branch: {}",
+                    e.hint
+                );
+            }
+            WorktreeCreateFailure::Timeout { .. } => panic!("unexpected Timeout failure"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_worktree_create_rejects_leading_dash_base_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_test_repo(&repo);
+
+        let err = run_worktree_create(
+            WorktreeCreateInput {
+                project_path: repo,
+                branch: "ok".to_string(),
+                path: None,
+                new_branch: true,
+                base_ref: Some("--upload-pack=bad".to_string()),
+            },
+            |_, _, _| {},
+        )
+        .await
+        .expect_err("leading-dash base_ref must be rejected");
+        match err {
+            WorktreeCreateFailure::Structured(e) => {
+                assert_eq!(e.code, WorktreeErrorCode::InvalidRef);
+                assert!(
+                    e.hint.contains("base_ref"),
+                    "hint should mention base_ref: {}",
+                    e.hint
+                );
+            }
+            WorktreeCreateFailure::Timeout { .. } => panic!("unexpected Timeout failure"),
+        }
+    }
+}

--- a/crates/zremote-core/src/lib.rs
+++ b/crates/zremote-core/src/lib.rs
@@ -12,3 +12,5 @@ pub mod state;
 #[cfg(feature = "axum")]
 pub mod terminal_ws;
 pub mod validation;
+#[cfg(feature = "axum")]
+pub mod worktree_http;

--- a/crates/zremote-core/src/worktree_http.rs
+++ b/crates/zremote-core/src/worktree_http.rs
@@ -1,0 +1,93 @@
+//! Shared HTTP helpers for worktree endpoints. Kept here so the local-mode
+//! agent handler and the server-mode proxy handler map
+//! `WorktreeErrorCode` → HTTP status identically.
+
+use axum::Json;
+use axum::http::StatusCode;
+use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
+
+/// Map a `WorktreeErrorCode` to the HTTP status that best conveys the class of
+/// failure. Keep 500 for true internal errors so monitoring can still
+/// distinguish them from user-correctable 4xx.
+#[must_use]
+pub fn status_for_worktree_code(code: &WorktreeErrorCode) -> StatusCode {
+    match code {
+        WorktreeErrorCode::BranchExists
+        | WorktreeErrorCode::PathCollision
+        | WorktreeErrorCode::Locked
+        | WorktreeErrorCode::Unmerged => StatusCode::CONFLICT,
+        WorktreeErrorCode::DetachedHead | WorktreeErrorCode::InvalidRef => StatusCode::BAD_REQUEST,
+        // The project directory is gone — the caller has to fix the project
+        // registration, not the worktree inputs. 404 matches the semantics
+        // (the referenced resource no longer exists on this host).
+        WorktreeErrorCode::PathMissing => StatusCode::NOT_FOUND,
+        WorktreeErrorCode::Internal | WorktreeErrorCode::Unknown => {
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// Build a `(status, Json<WorktreeError>)` pair for a structured worktree
+/// error. Both local-mode and server-mode handlers go through this so the
+/// response shape stays byte-identical.
+pub fn worktree_error_response(err: WorktreeError) -> (StatusCode, Json<WorktreeError>) {
+    let status = status_for_worktree_code(&err.code);
+    (status, Json(err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_mapping_matches_spec() {
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::BranchExists),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::PathCollision),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::Locked),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::Unmerged),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::DetachedHead),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::InvalidRef),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::PathMissing),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::Internal),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            status_for_worktree_code(&WorktreeErrorCode::Unknown),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn worktree_error_response_has_structured_body() {
+        let err = WorktreeError::new(
+            WorktreeErrorCode::BranchExists,
+            "pick another name",
+            "branch exists",
+        );
+        let (status, Json(body)) = worktree_error_response(err.clone());
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body, err);
+    }
+}

--- a/crates/zremote-protocol/src/terminal.rs
+++ b/crates/zremote-protocol/src/terminal.rs
@@ -27,6 +27,20 @@ pub struct HookResultInfo {
     pub duration_ms: u64,
 }
 
+/// Success payload for a request/response `WorktreeCreateResponse`. Mirrors the
+/// shape local-mode's HTTP handler returns today (minus the DB-assigned `id`,
+/// which the server assigns after upsert). New in RFC-009.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorktreeCreateSuccessPayload {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook_result: Option<HookResultInfo>,
+}
+
 /// Messages sent from agent to server (terminal/connection layer).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "payload")]
@@ -114,6 +128,27 @@ pub enum AgentMessage {
     WorktreeError {
         project_path: String,
         message: String,
+    },
+    /// Reply to a `ServerMessage::BranchListRequest`. Exactly one of
+    /// `branches` / `error` is `Some`. New in RFC-009; older servers that
+    /// predate this variant simply ignore it (unknown message type).
+    BranchListResponse {
+        request_id: uuid::Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branches: Option<crate::project::BranchList>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<crate::project::WorktreeError>,
+    },
+    /// Reply to a `ServerMessage::WorktreeCreateRequest`. Exactly one of
+    /// `worktree` / `error` is `Some`. New in RFC-009; the legacy
+    /// `WorktreeCreated` / `WorktreeError` fire-and-forget path stays alive
+    /// so a mixed-version fleet keeps working during rollout.
+    WorktreeCreateResponse {
+        request_id: uuid::Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree: Option<WorktreeCreateSuccessPayload>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<crate::project::WorktreeError>,
     },
     SessionsRecovered {
         sessions: Vec<RecoveredSession>,
@@ -220,6 +255,26 @@ pub enum ServerMessage {
         project_path: String,
         worktree_path: String,
         force: bool,
+    },
+    /// Ask the agent for the branch list of a project. Response:
+    /// `AgentMessage::BranchListResponse`. New in RFC-009.
+    BranchListRequest {
+        request_id: uuid::Uuid,
+        project_path: String,
+    },
+    /// Synchronous worktree-create with reply. Response:
+    /// `AgentMessage::WorktreeCreateResponse`. The existing `WorktreeCreate`
+    /// variant remains for older agents that do not recognise this request.
+    /// New in RFC-009.
+    WorktreeCreateRequest {
+        request_id: uuid::Uuid,
+        project_path: String,
+        branch: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        new_branch: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_ref: Option<String>,
     },
     ListDirectory {
         request_id: uuid::Uuid,
@@ -618,6 +673,158 @@ mod tests {
             project_path: "/home/user/repo".to_string(),
             message: "branch already exists".to_string(),
         });
+    }
+
+    #[test]
+    fn branch_list_request_roundtrip() {
+        roundtrip_server(&ServerMessage::BranchListRequest {
+            request_id: Uuid::new_v4(),
+            project_path: "/home/user/repo".to_string(),
+        });
+    }
+
+    #[test]
+    fn worktree_create_request_roundtrip() {
+        roundtrip_server(&ServerMessage::WorktreeCreateRequest {
+            request_id: Uuid::new_v4(),
+            project_path: "/home/user/repo".to_string(),
+            branch: "feature/new".to_string(),
+            path: Some("/home/user/repo-feature".to_string()),
+            new_branch: true,
+            base_ref: Some("main".to_string()),
+        });
+        roundtrip_server(&ServerMessage::WorktreeCreateRequest {
+            request_id: Uuid::new_v4(),
+            project_path: "/home/user/repo".to_string(),
+            branch: "existing".to_string(),
+            path: None,
+            new_branch: false,
+            base_ref: None,
+        });
+    }
+
+    #[test]
+    fn branch_list_response_roundtrip() {
+        use crate::project::{Branch, BranchList};
+        roundtrip_agent(&AgentMessage::BranchListResponse {
+            request_id: Uuid::new_v4(),
+            branches: Some(BranchList {
+                local: vec![Branch {
+                    name: "main".to_string(),
+                    is_current: true,
+                    ahead: 0,
+                    behind: 0,
+                }],
+                remote: vec![Branch {
+                    name: "origin/main".to_string(),
+                    is_current: false,
+                    ahead: 0,
+                    behind: 2,
+                }],
+                current: "main".to_string(),
+                remote_truncated: false,
+            }),
+            error: None,
+        });
+    }
+
+    #[test]
+    fn branch_list_response_error_roundtrip() {
+        use crate::project::{WorktreeError, WorktreeErrorCode};
+        roundtrip_agent(&AgentMessage::BranchListResponse {
+            request_id: Uuid::new_v4(),
+            branches: None,
+            error: Some(WorktreeError::new(
+                WorktreeErrorCode::PathMissing,
+                "project path gone",
+                "no such directory",
+            )),
+        });
+    }
+
+    #[test]
+    fn worktree_create_response_success_roundtrip() {
+        roundtrip_agent(&AgentMessage::WorktreeCreateResponse {
+            request_id: Uuid::new_v4(),
+            worktree: Some(WorktreeCreateSuccessPayload {
+                path: "/home/user/repo-feat".to_string(),
+                branch: Some("feature/new".to_string()),
+                commit_hash: Some("abc1234".to_string()),
+                hook_result: Some(HookResultInfo {
+                    success: true,
+                    output: Some("npm install done".to_string()),
+                    duration_ms: 2000,
+                }),
+            }),
+            error: None,
+        });
+    }
+
+    #[test]
+    fn worktree_create_response_error_roundtrip() {
+        use crate::project::{WorktreeError, WorktreeErrorCode};
+        roundtrip_agent(&AgentMessage::WorktreeCreateResponse {
+            request_id: Uuid::new_v4(),
+            worktree: None,
+            error: Some(WorktreeError::new(
+                WorktreeErrorCode::BranchExists,
+                "pick another name",
+                "branch already exists",
+            )),
+        });
+    }
+
+    #[test]
+    fn worktree_create_success_payload_hook_result_omitted_when_none() {
+        let payload = WorktreeCreateSuccessPayload {
+            path: "/home/user/repo-feat".to_string(),
+            branch: Some("feature".to_string()),
+            commit_hash: Some("abcdef0".to_string()),
+            hook_result: None,
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        let obj = json.as_object().expect("object");
+        assert!(
+            !obj.contains_key("hook_result"),
+            "hook_result must be omitted when None, got JSON: {json}"
+        );
+        // Round-trip still works when field is absent.
+        let parsed: WorktreeCreateSuccessPayload =
+            serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn worktree_create_success_payload_roundtrip_with_hook() {
+        let payload = WorktreeCreateSuccessPayload {
+            path: "/home/user/repo-feat".to_string(),
+            branch: Some("feature".to_string()),
+            commit_hash: Some("abcdef0".to_string()),
+            hook_result: Some(HookResultInfo {
+                success: false,
+                output: Some("install failed".to_string()),
+                duration_ms: 150,
+            }),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        let parsed: WorktreeCreateSuccessPayload =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn worktree_create_request_accepts_missing_optional_fields() {
+        // Future-proofing: a minimal request with only required fields must
+        // deserialize with `path` and `base_ref` defaulting to None.
+        let json = r#"{"type":"WorktreeCreateRequest","payload":{"request_id":"550e8400-e29b-41d4-a716-446655440000","project_path":"/r","branch":"b","new_branch":true}}"#;
+        let msg: ServerMessage = serde_json::from_str(json).expect("should deserialize");
+        match msg {
+            ServerMessage::WorktreeCreateRequest { path, base_ref, .. } => {
+                assert!(path.is_none(), "path should default to None");
+                assert!(base_ref.is_none(), "base_ref should default to None");
+            }
+            other => panic!("expected WorktreeCreateRequest, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/zremote-server/src/lib.rs
+++ b/crates/zremote-server/src/lib.rs
@@ -160,6 +160,10 @@ fn create_router(state: Arc<AppState>) -> Router {
             post(routes::projects::trigger_git_refresh),
         )
         .route(
+            "/api/projects/{project_id}/git/branches",
+            get(routes::projects::list_branches),
+        )
+        .route(
             "/api/projects/{project_id}/worktrees",
             get(routes::projects::list_worktrees).post(routes::projects::create_worktree),
         )

--- a/crates/zremote-server/src/lib.rs
+++ b/crates/zremote-server/src/lib.rs
@@ -409,6 +409,8 @@ pub async fn run_server(config: ServerConfig) {
     let settings_get_requests = std::sync::Arc::new(dashmap::DashMap::new());
     let settings_save_requests = std::sync::Arc::new(dashmap::DashMap::new());
     let action_inputs_requests = std::sync::Arc::new(dashmap::DashMap::new());
+    let branch_list_requests = std::sync::Arc::new(dashmap::DashMap::new());
+    let worktree_create_requests = std::sync::Arc::new(dashmap::DashMap::new());
 
     let state = Arc::new(AppState {
         db: pool,
@@ -424,6 +426,8 @@ pub async fn run_server(config: ServerConfig) {
         settings_get_requests,
         settings_save_requests,
         action_inputs_requests,
+        branch_list_requests,
+        worktree_create_requests,
     });
 
     // Spawn heartbeat monitor background task
@@ -553,6 +557,8 @@ mod tests {
             settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/agent_profiles.rs
+++ b/crates/zremote-server/src/routes/agent_profiles.rs
@@ -348,6 +348,8 @@ mod tests {
             settings_get_requests: Arc::new(DashMap::new()),
             settings_save_requests: Arc::new(DashMap::new()),
             action_inputs_requests: Arc::new(DashMap::new()),
+            branch_list_requests: Arc::new(DashMap::new()),
+            worktree_create_requests: Arc::new(DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/agent_tasks.rs
+++ b/crates/zremote-server/src/routes/agent_tasks.rs
@@ -202,6 +202,8 @@ mod tests {
             settings_get_requests: Arc::new(DashMap::new()),
             settings_save_requests: Arc::new(DashMap::new()),
             action_inputs_requests: Arc::new(DashMap::new()),
+            branch_list_requests: Arc::new(DashMap::new()),
+            worktree_create_requests: Arc::new(DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/agentic.rs
+++ b/crates/zremote-server/src/routes/agentic.rs
@@ -80,6 +80,8 @@ mod tests {
             settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -74,6 +74,160 @@ pub(super) async fn fetch_loop_info(state: &AppState, loop_id: &str) -> Option<L
     })
 }
 
+/// Upsert a worktree child project row for a successful create. Looks up the
+/// parent project by `(host_id, parent_project_path)`; if missing, the upsert
+/// is skipped and `Ok(None)` is returned (same behaviour as the legacy
+/// `WorktreeCreated` handler -- the agent may report a worktree for a parent
+/// that the server hasn't ingested yet, and we don't want to stub a bogus
+/// parent row here).
+///
+/// Shared between the legacy fire-and-forget `WorktreeCreated` handler and the
+/// RFC-009 request/response `WorktreeCreateResponse` handler so the SQL lives
+/// in exactly one place.
+async fn upsert_worktree_row(
+    state: &AppState,
+    host_id_str: &str,
+    parent_project_path: &str,
+    worktree_path: &str,
+    branch: Option<&str>,
+    commit_hash: Option<&str>,
+) -> Option<String> {
+    let parent: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM projects WHERE host_id = ? AND path = ?")
+            .bind(host_id_str)
+            .bind(parent_project_path)
+            .fetch_optional(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+    let (parent_id,) = parent?;
+    let wt_id = Uuid::new_v4().to_string();
+    let wt_name = std::path::Path::new(worktree_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("worktree")
+        .to_string();
+
+    if let Err(e) = sqlx::query(
+        "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
+         git_branch, git_commit_hash) \
+         VALUES (?, ?, ?, ?, 'worktree', ?, ?, ?) \
+         ON CONFLICT(host_id, path) DO UPDATE SET \
+         git_branch = excluded.git_branch, git_commit_hash = excluded.git_commit_hash",
+    )
+    .bind(&wt_id)
+    .bind(host_id_str)
+    .bind(worktree_path)
+    .bind(&wt_name)
+    .bind(&parent_id)
+    .bind(branch)
+    .bind(commit_hash)
+    .execute(&state.db)
+    .await
+    {
+        tracing::warn!(host_id = %host_id_str, path = %worktree_path, error = %e, "failed to insert worktree child");
+        return None;
+    }
+
+    // On conflict (UPDATE path), the stable id is the pre-existing one, not
+    // `wt_id`. Read back the authoritative id so callers get the right value.
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM projects WHERE host_id = ? AND path = ?")
+            .bind(host_id_str)
+            .bind(worktree_path)
+            .fetch_optional(&state.db)
+            .await
+            .ok()
+            .flatten();
+    row.map(|(id,)| id)
+}
+
+/// Resolve a pending `BranchListRequest` oneshot with the agent's reply.
+/// Extracted from `handle_agent_message` so the logic is unit-testable
+/// without a WebSocket.
+pub(super) fn handle_branch_list_response(
+    state: &AppState,
+    host_id: HostId,
+    request_id: Uuid,
+    branches: Option<zremote_protocol::project::BranchList>,
+    error: Option<zremote_protocol::project::WorktreeError>,
+) {
+    let response = crate::state::BranchListResponse { branches, error };
+    if let Some((_, pending)) = state.branch_list_requests.remove(&request_id) {
+        // Receiver may have been dropped on timeout — swallow.
+        let _ = pending.sender.send(response);
+    } else {
+        // Late reply (HTTP handler already timed out and reaper cleared the
+        // entry) or stray message. Not an error.
+        tracing::debug!(
+            host_id = %host_id,
+            request_id = %request_id,
+            "BranchListResponse for unknown request_id; dropping (likely late reply)"
+        );
+    }
+}
+
+/// Resolve a pending `WorktreeCreateRequest` oneshot, upserting the worktree
+/// child row into the DB and broadcasting `ProjectsUpdated` when the agent
+/// reports a successful create. Extracted from `handle_agent_message` so the
+/// logic is unit-testable without a WebSocket.
+pub(super) async fn handle_worktree_create_response(
+    state: &AppState,
+    host_id: HostId,
+    request_id: Uuid,
+    worktree: Option<zremote_protocol::WorktreeCreateSuccessPayload>,
+    error: Option<zremote_protocol::project::WorktreeError>,
+) {
+    let host_id_str = host_id.to_string();
+    let pending = state.worktree_create_requests.remove(&request_id);
+
+    let project_id = match (&worktree, &pending) {
+        (Some(wt), Some((_, entry))) => {
+            let id = upsert_worktree_row(
+                state,
+                &host_id_str,
+                &entry.parent_project_path,
+                &wt.path,
+                wt.branch.as_deref(),
+                wt.commit_hash.as_deref(),
+            )
+            .await;
+            let _ = state.events.send(ServerEvent::ProjectsUpdated {
+                host_id: host_id_str.clone(),
+            });
+            id
+        }
+        (Some(_), None) => {
+            // Late reply after HTTP timeout: we've lost the parent project
+            // context, so we can't upsert the worktree row here. The agent
+            // will emit a `GitStatusUpdate` / `ProjectList` soon and the
+            // reconciliation path will pick up the new child. Still
+            // broadcast `ProjectsUpdated` so connected GUIs refresh.
+            tracing::debug!(
+                host_id = %host_id,
+                request_id = %request_id,
+                "WorktreeCreateResponse with success payload for unknown request_id; \
+                 skipping DB upsert (no parent context), broadcasting refresh"
+            );
+            let _ = state.events.send(ServerEvent::ProjectsUpdated {
+                host_id: host_id_str.clone(),
+            });
+            None
+        }
+        (None, _) => None,
+    };
+
+    if let Some((_, entry)) = pending {
+        let response = crate::state::WorktreeCreateResponse {
+            worktree,
+            error,
+            project_id,
+        };
+        let _ = entry.sender.send(response);
+    }
+}
+
 /// Handle a single agent message.
 #[allow(clippy::too_many_lines)]
 pub(super) async fn handle_agent_message(
@@ -487,45 +641,15 @@ pub(super) async fn handle_agent_message(
             hook_result: _,
         } => {
             let host_id_str = host_id.to_string();
-
-            // Find parent project id
-            let parent: Option<(String,)> =
-                sqlx::query_as("SELECT id FROM projects WHERE host_id = ? AND path = ?")
-                    .bind(&host_id_str)
-                    .bind(&project_path)
-                    .fetch_optional(&state.db)
-                    .await
-                    .ok()
-                    .flatten();
-
-            if let Some((parent_id,)) = parent {
-                let wt_id = Uuid::new_v4().to_string();
-                let wt_name = std::path::Path::new(&worktree.path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("worktree")
-                    .to_string();
-
-                if let Err(e) = sqlx::query(
-                    "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
-                     git_branch, git_commit_hash) \
-                     VALUES (?, ?, ?, ?, 'worktree', ?, ?, ?) \
-                     ON CONFLICT(host_id, path) DO UPDATE SET \
-                     git_branch = excluded.git_branch, git_commit_hash = excluded.git_commit_hash",
-                )
-                .bind(&wt_id)
-                .bind(&host_id_str)
-                .bind(&worktree.path)
-                .bind(&wt_name)
-                .bind(&parent_id)
-                .bind(&worktree.branch)
-                .bind(&worktree.commit_hash)
-                .execute(&state.db)
-                .await
-                {
-                    tracing::warn!(host_id = %host_id, path = %worktree.path, error = %e, "failed to insert worktree child");
-                }
-            }
+            let _ = upsert_worktree_row(
+                state,
+                &host_id_str,
+                &project_path,
+                &worktree.path,
+                worktree.branch.as_deref(),
+                worktree.commit_hash.as_deref(),
+            )
+            .await;
 
             let _ = state.events.send(ServerEvent::ProjectsUpdated {
                 host_id: host_id.to_string(),
@@ -790,22 +914,19 @@ pub(super) async fn handle_agent_message(
                 }
             }
         }
-        // RFC-009 P1: protocol variants landed ahead of server dispatch (P3).
-        // Until P3 wires the pending maps, drop the response with a debug log
-        // so the agent's reply doesn't crash the server on exhaustiveness.
-        AgentMessage::BranchListResponse { request_id, .. } => {
-            tracing::debug!(
-                host_id = %host_id,
-                request_id = %request_id,
-                "received BranchListResponse before P3 dispatch wired; dropping"
-            );
+        AgentMessage::BranchListResponse {
+            request_id,
+            branches,
+            error,
+        } => {
+            handle_branch_list_response(state, host_id, request_id, branches, error);
         }
-        AgentMessage::WorktreeCreateResponse { request_id, .. } => {
-            tracing::debug!(
-                host_id = %host_id,
-                request_id = %request_id,
-                "received WorktreeCreateResponse before P3 dispatch wired; dropping"
-            );
+        AgentMessage::WorktreeCreateResponse {
+            request_id,
+            worktree,
+            error,
+        } => {
+            handle_worktree_create_response(state, host_id, request_id, worktree, error).await;
         }
     }
     Ok(())
@@ -2213,6 +2334,8 @@ mod tests {
             settings_get_requests: Arc::new(dashmap::DashMap::new()),
             settings_save_requests: Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: Arc::new(dashmap::DashMap::new()),
         })
     }
 
@@ -3295,5 +3418,383 @@ mod tests {
 
         // project_type on main repo should reflect detected language, not worktree.
         assert_eq!(parent.project_type, "rust");
+    }
+
+    // ── RFC-009 P3: handle_branch_list_response / handle_worktree_create_response ──
+
+    async fn insert_test_project(
+        state: &AppState,
+        id: &str,
+        host_id: &str,
+        path: &str,
+        name: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO projects (id, host_id, path, name, project_type) \
+             VALUES (?, ?, ?, ?, 'rust')",
+        )
+        .bind(id)
+        .bind(host_id)
+        .bind(path)
+        .bind(name)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_branch_list_response_resolves_pending_oneshot() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<crate::state::BranchListResponse>();
+        state
+            .branch_list_requests
+            .insert(request_id, crate::state::PendingRequest::new(tx));
+
+        let branches = zremote_protocol::project::BranchList {
+            local: vec![zremote_protocol::project::Branch {
+                name: "main".to_string(),
+                is_current: true,
+                ahead: 0,
+                behind: 0,
+            }],
+            remote: vec![],
+            current: "main".to_string(),
+            remote_truncated: false,
+        };
+
+        handle_branch_list_response(&state, host_id, request_id, Some(branches.clone()), None);
+
+        let resolved = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("oneshot should be resolved")
+            .expect("sender should not have been dropped");
+        assert_eq!(resolved.branches.as_ref(), Some(&branches));
+        assert!(resolved.error.is_none());
+        assert!(
+            state.branch_list_requests.get(&request_id).is_none(),
+            "pending entry should be consumed"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_branch_list_response_unknown_request_id_is_noop() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        // No pending entry registered.
+        handle_branch_list_response(&state, host_id, request_id, None, None);
+        // No panic, no entry added.
+        assert!(state.branch_list_requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_worktree_create_response_success_upserts_and_broadcasts() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        let parent_path = "/srv/repos/acme";
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        let parent_id = Uuid::new_v4().to_string();
+        insert_test_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+        let mut events_rx = state.events.subscribe();
+
+        let request_id = Uuid::new_v4();
+        let (tx, rx) = tokio::sync::oneshot::channel::<crate::state::WorktreeCreateResponse>();
+        state.worktree_create_requests.insert(
+            request_id,
+            crate::state::PendingWorktreeCreate::new(tx, parent_path.to_string()),
+        );
+
+        let payload = zremote_protocol::WorktreeCreateSuccessPayload {
+            path: "/srv/repos/acme-wt/feature".to_string(),
+            branch: Some("feature/x".to_string()),
+            commit_hash: Some("abc1234".to_string()),
+            hook_result: None,
+        };
+
+        handle_worktree_create_response(&state, host_id, request_id, Some(payload.clone()), None)
+            .await;
+
+        let resolved = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("oneshot resolved")
+            .expect("sender not dropped");
+        assert_eq!(resolved.worktree.as_ref(), Some(&payload));
+        assert!(resolved.error.is_none());
+        assert!(
+            resolved.project_id.is_some(),
+            "upsert should have returned a project_id"
+        );
+        assert!(state.worktree_create_requests.is_empty());
+
+        // DB row inserted
+        let row: (
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+        ) = sqlx::query_as(
+            "SELECT id, path, git_branch, git_commit_hash, parent_project_id, project_type \
+                 FROM projects WHERE host_id = ? AND path = ?",
+        )
+        .bind(&host_id_str)
+        .bind(&payload.path)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(row.1, payload.path);
+        assert_eq!(row.2.as_deref(), Some("feature/x"));
+        assert_eq!(row.3.as_deref(), Some("abc1234"));
+        assert_eq!(row.4.as_deref(), Some(parent_id.as_str()));
+        assert_eq!(row.5, "worktree");
+        assert_eq!(
+            resolved.project_id.as_deref(),
+            Some(row.0.as_str()),
+            "returned project_id matches DB row id"
+        );
+
+        // ProjectsUpdated broadcast
+        let evt = tokio::time::timeout(std::time::Duration::from_secs(1), events_rx.recv())
+            .await
+            .expect("event received in time")
+            .expect("event channel open");
+        match evt {
+            ServerEvent::ProjectsUpdated { host_id: h } => assert_eq!(h, host_id_str),
+            other => panic!("expected ProjectsUpdated, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_worktree_create_response_error_resolves_without_db_write() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        let parent_path = "/srv/repos/acme";
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        insert_test_project(
+            &state,
+            &Uuid::new_v4().to_string(),
+            &host_id_str,
+            parent_path,
+            "acme",
+        )
+        .await;
+
+        let request_id = Uuid::new_v4();
+        let (tx, rx) = tokio::sync::oneshot::channel::<crate::state::WorktreeCreateResponse>();
+        state.worktree_create_requests.insert(
+            request_id,
+            crate::state::PendingWorktreeCreate::new(tx, parent_path.to_string()),
+        );
+
+        let err = zremote_protocol::project::WorktreeError::new(
+            zremote_protocol::project::WorktreeErrorCode::BranchExists,
+            "Pick a different branch name",
+            "branch already exists",
+        );
+        handle_worktree_create_response(&state, host_id, request_id, None, Some(err.clone())).await;
+
+        let resolved = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("oneshot resolved")
+            .expect("sender not dropped");
+        assert!(resolved.worktree.is_none());
+        assert_eq!(resolved.error.as_ref(), Some(&err));
+        assert!(resolved.project_id.is_none());
+
+        // No worktree child inserted
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM projects WHERE parent_project_id IS NOT NULL")
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn handle_worktree_create_response_unknown_request_with_success_still_broadcasts() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        let mut events_rx = state.events.subscribe();
+
+        // No pending entry registered -- simulates a late reply after HTTP timeout.
+        let payload = zremote_protocol::WorktreeCreateSuccessPayload {
+            path: "/srv/repos/acme-wt/feature".to_string(),
+            branch: Some("feature/x".to_string()),
+            commit_hash: Some("abc1234".to_string()),
+            hook_result: None,
+        };
+        handle_worktree_create_response(
+            &state,
+            host_id,
+            Uuid::new_v4(),
+            Some(payload.clone()),
+            None,
+        )
+        .await;
+
+        // DB should NOT have the worktree row (no parent context available).
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM projects WHERE host_id = ? AND path = ?")
+                .bind(&host_id_str)
+                .bind(&payload.path)
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(count.0, 0, "no upsert when parent context is lost");
+
+        // ProjectsUpdated should still fire so GUIs refresh.
+        let evt = tokio::time::timeout(std::time::Duration::from_secs(1), events_rx.recv())
+            .await
+            .expect("event received")
+            .expect("channel open");
+        assert!(matches!(evt, ServerEvent::ProjectsUpdated { .. }));
+    }
+
+    #[tokio::test]
+    async fn handle_worktree_create_response_unknown_request_with_error_is_silent() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        insert_test_host(&state, &host_id_str, "test-host").await;
+
+        let mut events_rx = state.events.subscribe();
+
+        let err = zremote_protocol::project::WorktreeError::new(
+            zremote_protocol::project::WorktreeErrorCode::Internal,
+            "try again",
+            "boom",
+        );
+        handle_worktree_create_response(&state, host_id, Uuid::new_v4(), None, Some(err)).await;
+
+        // No event, no DB change.
+        let got =
+            tokio::time::timeout(std::time::Duration::from_millis(50), events_rx.recv()).await;
+        assert!(
+            got.is_err(),
+            "no event should fire for late error-only replies"
+        );
+    }
+
+    // Regression: the legacy WorktreeCreated handler still works after the
+    // SQL was extracted into `upsert_worktree_row`.
+    #[tokio::test]
+    async fn legacy_worktree_created_still_upserts_via_shared_helper() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        let parent_path = "/srv/repos/acme";
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        let parent_id = Uuid::new_v4().to_string();
+        insert_test_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+        let wt_path = "/srv/repos/acme-wt/legacy";
+        let project_id = upsert_worktree_row(
+            &state,
+            &host_id_str,
+            parent_path,
+            wt_path,
+            Some("legacy-branch"),
+            Some("deadbee"),
+        )
+        .await;
+        assert!(project_id.is_some());
+
+        let row: (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+        ) = sqlx::query_as(
+            "SELECT id, git_branch, git_commit_hash, parent_project_id, project_type \
+                 FROM projects WHERE host_id = ? AND path = ?",
+        )
+        .bind(&host_id_str)
+        .bind(wt_path)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(row.1.as_deref(), Some("legacy-branch"));
+        assert_eq!(row.2.as_deref(), Some("deadbee"));
+        assert_eq!(row.3.as_deref(), Some(parent_id.as_str()));
+        assert_eq!(row.4, "worktree");
+    }
+
+    #[tokio::test]
+    async fn upsert_worktree_row_without_parent_returns_none() {
+        let state = test_state().await;
+        let host_id_str = Uuid::new_v4().to_string();
+
+        // No parent project row in DB — helper should skip and return None.
+        let result = upsert_worktree_row(
+            &state,
+            &host_id_str,
+            "/nonexistent/parent",
+            "/nonexistent/parent-wt/x",
+            Some("b"),
+            Some("c"),
+        )
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn upsert_worktree_row_conflict_updates_existing_branch_and_hash() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        let parent_path = "/srv/repos/acme";
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        let parent_id = Uuid::new_v4().to_string();
+        insert_test_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+        let wt_path = "/srv/repos/acme-wt/a";
+
+        let first_id = upsert_worktree_row(
+            &state,
+            &host_id_str,
+            parent_path,
+            wt_path,
+            Some("v1"),
+            Some("h1"),
+        )
+        .await
+        .unwrap();
+        let second_id = upsert_worktree_row(
+            &state,
+            &host_id_str,
+            parent_path,
+            wt_path,
+            Some("v2"),
+            Some("h2"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first_id, second_id, "stable id across upserts");
+
+        let row: (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT git_branch, git_commit_hash FROM projects WHERE host_id = ? AND path = ?",
+        )
+        .bind(&host_id_str)
+        .bind(wt_path)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some("v2"));
+        assert_eq!(row.1.as_deref(), Some("h2"));
     }
 }

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -109,12 +109,18 @@ async fn upsert_worktree_row(
         .unwrap_or("worktree")
         .to_string();
 
+    // Preserve `parent_project_id` on conflict via COALESCE — if both the
+    // legacy `WorktreeCreated` path and the new `WorktreeCreateResponse` path
+    // write the same row (or they happen out of order), an incoming NULL must
+    // not clobber a previously-linked parent. See FIX 1 in the RFC-009 review.
     if let Err(e) = sqlx::query(
         "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
          git_branch, git_commit_hash) \
          VALUES (?, ?, ?, ?, 'worktree', ?, ?, ?) \
          ON CONFLICT(host_id, path) DO UPDATE SET \
-         git_branch = excluded.git_branch, git_commit_hash = excluded.git_commit_hash",
+         git_branch = excluded.git_branch, \
+         git_commit_hash = excluded.git_commit_hash, \
+         parent_project_id = COALESCE(excluded.parent_project_id, projects.parent_project_id)",
     )
     .bind(&wt_id)
     .bind(host_id_str)
@@ -3749,6 +3755,96 @@ mod tests {
         )
         .await;
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_worktree_create_response_preserves_parent_project_id_on_conflict() {
+        // Regression: a second WorktreeCreateResponse (or a legacy
+        // WorktreeCreated) arriving after the row has already been linked to
+        // its parent must NOT clobber `parent_project_id` with NULL.
+        // Exercises FIX 1 in the RFC-009 review.
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let host_id_str = host_id.to_string();
+        let parent_path = "/srv/repos/acme";
+        let wt_path = "/srv/repos/acme-wt/feature";
+
+        insert_test_host(&state, &host_id_str, "test-host").await;
+        let parent_id = Uuid::new_v4().to_string();
+        insert_test_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+        // Pre-insert the worktree row with a linked parent (simulates the
+        // state after a successful first pass — legacy WorktreeCreated or an
+        // earlier WorktreeCreateResponse).
+        let existing_wt_id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
+             git_branch, git_commit_hash) \
+             VALUES (?, ?, ?, ?, 'worktree', ?, 'old-branch', 'oldhash')",
+        )
+        .bind(&existing_wt_id)
+        .bind(&host_id_str)
+        .bind(wt_path)
+        .bind("feature")
+        .bind(&parent_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        // Arrange: dispatch a WorktreeCreateResponse whose upsert call would
+        // produce `parent_project_id = NULL` for some reason (e.g. the
+        // dispatch helper resolved the parent from a now-removed project row
+        // between the insert and the upsert). We simulate that by passing a
+        // parent_project_path that does NOT match any row in `projects`, so
+        // `upsert_worktree_row` returns early (None, no DB write) — then
+        // independently we re-run upsert with the real parent to prove the
+        // COALESCE logic: use the legacy WorktreeCreated path (matching
+        // parent) and the conflict must preserve the pre-existing parent.
+        //
+        // Concretely: call `upsert_worktree_row` twice in order, second one
+        // with the legacy path that actually carries a parent, and assert the
+        // row's parent stays set. To actually exercise the "excluded NULL"
+        // branch of COALESCE we bypass the helper (which never passes NULL
+        // because it early-returns) and drive the raw SQL via a dedicated
+        // upsert whose `parent_project_id` param is NULL.
+        let wt_id2 = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
+             git_branch, git_commit_hash) \
+             VALUES (?, ?, ?, ?, 'worktree', NULL, ?, ?) \
+             ON CONFLICT(host_id, path) DO UPDATE SET \
+             git_branch = excluded.git_branch, \
+             git_commit_hash = excluded.git_commit_hash, \
+             parent_project_id = COALESCE(excluded.parent_project_id, projects.parent_project_id)",
+        )
+        .bind(&wt_id2)
+        .bind(&host_id_str)
+        .bind(wt_path)
+        .bind("feature")
+        .bind("new-branch")
+        .bind("newhash")
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        // Assert: parent is still set to the original parent_id.
+        let row: (Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT parent_project_id, git_branch, git_commit_hash FROM projects \
+             WHERE host_id = ? AND path = ?",
+        )
+        .bind(&host_id_str)
+        .bind(wt_path)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0.as_deref(),
+            Some(parent_id.as_str()),
+            "COALESCE must preserve the pre-existing parent_project_id when excluded is NULL"
+        );
+        // And the updatable columns were overwritten as expected.
+        assert_eq!(row.1.as_deref(), Some("new-branch"));
+        assert_eq!(row.2.as_deref(), Some("newhash"));
     }
 
     #[tokio::test]

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -790,6 +790,23 @@ pub(super) async fn handle_agent_message(
                 }
             }
         }
+        // RFC-009 P1: protocol variants landed ahead of server dispatch (P3).
+        // Until P3 wires the pending maps, drop the response with a debug log
+        // so the agent's reply doesn't crash the server on exhaustiveness.
+        AgentMessage::BranchListResponse { request_id, .. } => {
+            tracing::debug!(
+                host_id = %host_id,
+                request_id = %request_id,
+                "received BranchListResponse before P3 dispatch wired; dropping"
+            );
+        }
+        AgentMessage::WorktreeCreateResponse { request_id, .. } => {
+            tracing::debug!(
+                host_id = %host_id,
+                request_id = %request_id,
+                "received WorktreeCreateResponse before P3 dispatch wired; dropping"
+            );
+        }
     }
     Ok(())
 }

--- a/crates/zremote-server/src/routes/agents/mod.rs
+++ b/crates/zremote-server/src/routes/agents/mod.rs
@@ -239,6 +239,8 @@ mod tests {
             settings_get_requests: Arc::new(dashmap::DashMap::new()),
             settings_save_requests: Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/channel.rs
+++ b/crates/zremote-server/src/routes/channel.rs
@@ -217,6 +217,8 @@ mod tests {
             settings_get_requests: Arc::new(dashmap::DashMap::new()),
             settings_save_requests: Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/claude_sessions.rs
+++ b/crates/zremote-server/src/routes/claude_sessions.rs
@@ -605,6 +605,8 @@ mod tests {
             settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/config.rs
+++ b/crates/zremote-server/src/routes/config.rs
@@ -130,6 +130,8 @@ mod tests {
             settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/health.rs
+++ b/crates/zremote-server/src/routes/health.rs
@@ -59,6 +59,8 @@ mod tests {
             settings_get_requests: Arc::new(dashmap::DashMap::new()),
             settings_save_requests: Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/knowledge.rs
+++ b/crates/zremote-server/src/routes/knowledge.rs
@@ -524,6 +524,8 @@ mod tests {
             settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/routes/projects/git.rs
+++ b/crates/zremote-server/src/routes/projects/git.rs
@@ -1,16 +1,27 @@
 use std::sync::Arc;
+use std::time::Duration;
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use uuid::Uuid;
 use zremote_core::queries::projects as q;
+use zremote_core::worktree_http::worktree_error_response;
 use zremote_protocol::ServerMessage;
+use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
 
 use crate::error::AppError;
-use crate::state::AppState;
+use crate::state::{AppState, BranchListResponse, PendingRequest};
 
 use super::parse_project_id;
+
+/// Wall-clock timeout for awaiting the agent's `BranchListResponse`. The agent
+/// side bounds its own git call with a shorter timeout; this ceiling is our
+/// safety net against a silently-wedged agent that accepted the request but
+/// never replies. Kept at or below `BRANCH_LIST_STALE_THRESHOLD` (30s) so the
+/// pending-entry reaper doesn't race with us.
+const BRANCH_LIST_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// `POST /api/projects/:project_id/git/refresh` - trigger git status refresh.
 pub async fn trigger_git_refresh(
@@ -39,4 +50,111 @@ pub async fn trigger_git_refresh(
         .map_err(|_| AppError::Conflict("failed to send git refresh to agent".to_string()))?;
 
     Ok(StatusCode::ACCEPTED)
+}
+
+/// `GET /api/projects/:project_id/git/branches` — proxy the agent's branch
+/// listing through the server's WebSocket. Mirrors the response shape of
+/// local-mode's handler: `200 { local, remote, current, remote_truncated }`
+/// on success, structured `WorktreeError` JSON on classified failures, or
+/// `504` with a structured Internal error on timeout.
+pub async fn list_branches(
+    State(state): State<Arc<AppState>>,
+    Path(project_id): Path<String>,
+) -> Result<axum::response::Response, AppError> {
+    list_branches_with_timeout(state, project_id, BRANCH_LIST_RESPONSE_TIMEOUT).await
+}
+
+/// Inner implementation parameterised by timeout so tests can exercise the
+/// 504 path without waiting 30 real seconds. Production callers go through
+/// `list_branches` which supplies `BRANCH_LIST_RESPONSE_TIMEOUT`.
+pub(crate) async fn list_branches_with_timeout(
+    state: Arc<AppState>,
+    project_id: String,
+    response_timeout: Duration,
+) -> Result<axum::response::Response, AppError> {
+    let project_id = parse_project_id(&project_id)?.to_string();
+
+    let (host_id_str, project_path) = q::get_project_host_and_path(&state.db, &project_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("project {project_id} not found")))?;
+
+    let host_id: Uuid = host_id_str
+        .parse()
+        .map_err(|_| AppError::Internal("invalid host_id in database".to_string()))?;
+
+    let sender = state
+        .connections
+        .get_sender(&host_id)
+        .await
+        .ok_or_else(|| AppError::Conflict("host is offline".to_string()))?;
+
+    let request_id = Uuid::new_v4();
+    let (tx, rx) = tokio::sync::oneshot::channel::<BranchListResponse>();
+    state
+        .branch_list_requests
+        .insert(request_id, PendingRequest::new(tx));
+
+    if let Err(send_err) = sender
+        .send(ServerMessage::BranchListRequest {
+            request_id,
+            project_path,
+        })
+        .await
+    {
+        // Clean up the pending entry so a future request_id collision (or the
+        // reaper) doesn't see a stale entry.
+        state.branch_list_requests.remove(&request_id);
+        tracing::warn!(
+            host_id = %host_id,
+            request_id = %request_id,
+            error = %send_err,
+            "failed to send BranchListRequest to agent (outbound channel closed)"
+        );
+        return Err(AppError::Conflict(
+            "failed to send branch list request".to_string(),
+        ));
+    }
+
+    match tokio::time::timeout(response_timeout, rx).await {
+        Ok(Ok(BranchListResponse {
+            branches: Some(list),
+            error: None,
+        })) => Ok(Json(list).into_response()),
+        Ok(Ok(BranchListResponse {
+            error: Some(err), ..
+        })) => {
+            let (status, body) = worktree_error_response(err);
+            Ok((status, body).into_response())
+        }
+        Ok(Ok(BranchListResponse {
+            branches: None,
+            error: None,
+        })) => {
+            // Agent returned neither branches nor error — treat as an internal
+            // protocol violation rather than silently returning an empty list.
+            Err(AppError::Internal(
+                "agent returned an empty BranchListResponse (no branches, no error)".to_string(),
+            ))
+        }
+        Ok(Err(_recv)) => Err(AppError::Internal(
+            "branch list response channel closed".to_string(),
+        )),
+        Err(_timeout) => {
+            // Drop the pending entry so a late reply doesn't fire into a dead
+            // oneshot; the reaper would catch it eventually but explicit
+            // cleanup keeps the map small under repeated timeouts.
+            state.branch_list_requests.remove(&request_id);
+            tracing::warn!(
+                host_id = %host_id,
+                request_id = %request_id,
+                "BranchListRequest timed out waiting for agent response"
+            );
+            let err = WorktreeError::new(
+                WorktreeErrorCode::Internal,
+                "Branch list timed out — the agent did not respond in 30s.",
+                "agent response timeout",
+            );
+            Ok((StatusCode::GATEWAY_TIMEOUT, Json(err)).into_response())
+        }
+    }
 }

--- a/crates/zremote-server/src/routes/projects/git.rs
+++ b/crates/zremote-server/src/routes/projects/git.rs
@@ -12,7 +12,7 @@ use zremote_protocol::ServerMessage;
 use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
 
 use crate::error::AppError;
-use crate::state::{AppState, BranchListResponse, PendingRequest};
+use crate::state::{AppState, BranchListResponse, MAX_PENDING_BRANCH_LIST, PendingRequest};
 
 use super::parse_project_id;
 
@@ -88,6 +88,23 @@ pub(crate) async fn list_branches_with_timeout(
         .await
         .ok_or_else(|| AppError::Conflict("host is offline".to_string()))?;
 
+    // DoS mitigation (complements future REST auth middleware): refuse new
+    // requests once the pending map is saturated so a misbehaving or
+    // unauthenticated caller cannot grow it without bound.
+    if state.branch_list_requests.len() >= MAX_PENDING_BRANCH_LIST {
+        tracing::warn!(
+            host_id = %host_id,
+            pending = state.branch_list_requests.len(),
+            "branch_list_requests map saturated, rejecting"
+        );
+        let err = WorktreeError::new(
+            WorktreeErrorCode::Internal,
+            "Server temporarily overloaded — try again shortly.",
+            "pending-map cap reached",
+        );
+        return Ok((StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response());
+    }
+
     let request_id = Uuid::new_v4();
     let (tx, rx) = tokio::sync::oneshot::channel::<BranchListResponse>();
     state
@@ -151,8 +168,11 @@ pub(crate) async fn list_branches_with_timeout(
             );
             let err = WorktreeError::new(
                 WorktreeErrorCode::Internal,
-                "Branch list timed out — the agent did not respond in 30s.",
-                "agent response timeout",
+                "Branch list timed out — the agent may still be working or may have disconnected. Reopen the modal to try again.",
+                format!(
+                    "agent response timeout after {}s",
+                    response_timeout.as_secs()
+                ),
             );
             Ok((StatusCode::GATEWAY_TIMEOUT, Json(err)).into_response())
         }

--- a/crates/zremote-server/src/routes/projects/mod.rs
+++ b/crates/zremote-server/src/routes/projects/mod.rs
@@ -7,7 +7,7 @@ mod worktree;
 pub use crud::{
     add_project, delete_project, get_project, list_project_sessions, list_projects, update_project,
 };
-pub use git::trigger_git_refresh;
+pub use git::{list_branches, trigger_git_refresh};
 pub use scan::trigger_scan;
 pub use settings::{
     browse_directory, configure_with_claude, get_settings, list_actions, resolve_action_inputs,

--- a/crates/zremote-server/src/routes/projects/tests.rs
+++ b/crates/zremote-server/src/routes/projects/tests.rs
@@ -36,6 +36,8 @@ async fn test_state() -> Arc<AppState> {
         settings_get_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         settings_save_requests: std::sync::Arc::new(dashmap::DashMap::new()),
         action_inputs_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+        branch_list_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+        worktree_create_requests: std::sync::Arc::new(dashmap::DashMap::new()),
     })
 }
 

--- a/crates/zremote-server/src/routes/projects/tests.rs
+++ b/crates/zremote-server/src/routes/projects/tests.rs
@@ -87,6 +87,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             post(trigger_git_refresh),
         )
         .route(
+            "/api/projects/{project_id}/git/branches",
+            get(list_branches),
+        )
+        .route(
             "/api/projects/{project_id}/worktrees",
             get(list_worktrees).post(create_worktree),
         )
@@ -1020,4 +1024,552 @@ async fn run_action_with_custom_inputs() {
         .unwrap();
     // Host is offline, so we get CONFLICT -- but the request parsed successfully
     assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RFC-009 P4: GET /git/branches + POST /worktrees (synchronous proxy)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Spawn a task that simulates the agent-dispatch side of a branch-list
+/// request/response round-trip. For the first `BranchListRequest` it sees on
+/// the outbound channel, it pops the matching pending entry and resolves the
+/// oneshot with `scripted`. Any other outbound message is ignored so unrelated
+/// tests don't have to drain the receiver.
+fn spawn_branch_list_fake_agent(
+    state: Arc<AppState>,
+    mut rx: tokio::sync::mpsc::Receiver<zremote_protocol::ServerMessage>,
+    scripted: crate::state::BranchListResponse,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            if let zremote_protocol::ServerMessage::BranchListRequest { request_id, .. } = msg {
+                if let Some((_, pending)) = state.branch_list_requests.remove(&request_id) {
+                    let _ = pending.sender.send(scripted);
+                }
+                return;
+            }
+        }
+    })
+}
+
+/// Same idea for worktree create. The closure `script` owns the full dispatch
+/// simulation — it can upsert the DB row, flip `project_id`, etc. — so each
+/// test can exercise a different success/error shape.
+fn spawn_worktree_create_fake_agent<F>(
+    state: Arc<AppState>,
+    mut rx: tokio::sync::mpsc::Receiver<zremote_protocol::ServerMessage>,
+    script: F,
+) -> tokio::task::JoinHandle<()>
+where
+    F: FnOnce(
+            Arc<AppState>,
+            zremote_protocol::ServerMessage,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        + Send
+        + 'static,
+{
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            if matches!(
+                msg,
+                zremote_protocol::ServerMessage::WorktreeCreateRequest { .. }
+            ) {
+                script(state, msg).await;
+                return;
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn list_branches_happy_path_returns_branch_list() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let proj_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &proj_id, &host_id_str, "/srv/acme", "acme").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    let scripted = zremote_protocol::project::BranchList {
+        local: vec![zremote_protocol::project::Branch {
+            name: "main".to_string(),
+            is_current: true,
+            ahead: 0,
+            behind: 0,
+        }],
+        remote: vec![],
+        current: "main".to_string(),
+        remote_truncated: false,
+    };
+    let _agent = spawn_branch_list_fake_agent(
+        Arc::clone(&state),
+        rx,
+        crate::state::BranchListResponse {
+            branches: Some(scripted.clone()),
+            error: None,
+        },
+    );
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/projects/{proj_id}/git/branches"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: zremote_protocol::project::BranchList = serde_json::from_slice(&body).unwrap();
+    assert_eq!(got, scripted);
+}
+
+#[tokio::test]
+async fn list_branches_structured_error_path_missing_returns_404() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let proj_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &proj_id, &host_id_str, "/nope", "nope").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    let err = zremote_protocol::project::WorktreeError::new(
+        zremote_protocol::project::WorktreeErrorCode::PathMissing,
+        "Project path no longer exists",
+        "path does not exist: /nope",
+    );
+    let _agent = spawn_branch_list_fake_agent(
+        Arc::clone(&state),
+        rx,
+        crate::state::BranchListResponse {
+            branches: None,
+            error: Some(err.clone()),
+        },
+    );
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/projects/{proj_id}/git/branches"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: zremote_protocol::project::WorktreeError = serde_json::from_slice(&body).unwrap();
+    assert_eq!(got, err);
+}
+
+#[tokio::test]
+async fn list_branches_host_offline_returns_409() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4().to_string();
+    let proj_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id).await;
+    insert_project(&state, &proj_id, &host_id, "/srv/acme", "acme").await;
+
+    // No connection registered.
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/projects/{proj_id}/git/branches"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn list_branches_project_not_found_returns_404() {
+    let state = test_state().await;
+    let proj_id = Uuid::new_v4().to_string();
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/api/projects/{proj_id}/git/branches"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn list_branches_invalid_project_id_returns_400() {
+    let state = test_state().await;
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/api/projects/not-a-uuid/git/branches")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_branches_agent_timeout_returns_504() {
+    // Drive the inner `_with_timeout` variant with a tiny duration so the 504
+    // branch fires without stalling the test suite on the 30s production
+    // ceiling. The fake agent drains the outbound channel but never replies,
+    // mirroring a wedged agent.
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let proj_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &proj_id, &host_id_str, "/srv/acme", "acme").await;
+
+    let mut rx = register_host_connection(&state, host_id).await;
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let resp = super::git::list_branches_with_timeout(
+        Arc::clone(&state),
+        proj_id,
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .expect("handler returns a response even on timeout");
+
+    assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: zremote_protocol::project::WorktreeError = serde_json::from_slice(&body).unwrap();
+    assert!(matches!(
+        got.code,
+        zremote_protocol::project::WorktreeErrorCode::Internal
+    ));
+}
+
+#[tokio::test]
+async fn create_worktree_happy_path_returns_201_with_project_row() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    let parent_path = "/srv/repos/acme";
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    // Simulate the dispatch handler: insert the worktree row and resolve the
+    // oneshot with the fresh project_id.
+    let state_for_agent = Arc::clone(&state);
+    let host_id_for_agent = host_id_str.clone();
+    let parent_id_for_agent = parent_id.clone();
+    let _agent = spawn_worktree_create_fake_agent(state_for_agent, rx, move |state, msg| {
+        Box::pin(async move {
+            let zremote_protocol::ServerMessage::WorktreeCreateRequest { request_id, .. } = msg
+            else {
+                unreachable!()
+            };
+
+            let payload = zremote_protocol::WorktreeCreateSuccessPayload {
+                path: "/srv/repos/acme-wt/feature".to_string(),
+                branch: Some("feature/x".to_string()),
+                commit_hash: Some("abc1234".to_string()),
+                hook_result: Some(zremote_protocol::HookResultInfo {
+                    success: true,
+                    output: Some("done".to_string()),
+                    duration_ms: 42,
+                }),
+            };
+
+            let new_id = Uuid::new_v4().to_string();
+            sqlx::query(
+                "INSERT INTO projects (id, host_id, path, name, project_type, parent_project_id, \
+                 git_branch, git_commit_hash) VALUES (?, ?, ?, ?, 'worktree', ?, ?, ?)",
+            )
+            .bind(&new_id)
+            .bind(&host_id_for_agent)
+            .bind(&payload.path)
+            .bind("feature")
+            .bind(&parent_id_for_agent)
+            .bind(payload.branch.as_deref())
+            .bind(payload.commit_hash.as_deref())
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+            if let Some((_, pending)) = state.worktree_create_requests.remove(&request_id) {
+                let _ = pending.sender.send(crate::state::WorktreeCreateResponse {
+                    worktree: Some(payload),
+                    error: None,
+                    project_id: Some(new_id),
+                });
+            }
+        })
+    });
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"branch":"feature/x","new_branch":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["host_id"], host_id_str);
+    assert_eq!(json["path"], "/srv/repos/acme-wt/feature");
+    assert_eq!(json["parent_project_id"], parent_id);
+    assert_eq!(json["project_type"], "worktree");
+    assert_eq!(json["git_branch"], "feature/x");
+    assert_eq!(json["git_commit_hash"], "abc1234");
+    assert!(json["id"].is_string());
+
+    // hook_result injected
+    assert_eq!(json["hook_result"]["success"], true);
+    assert_eq!(json["hook_result"]["output"], "done");
+    assert_eq!(json["hook_result"]["duration_ms"], 42);
+
+    // DB row exists
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM projects WHERE parent_project_id = ?")
+        .bind(&parent_id)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 1);
+}
+
+#[tokio::test]
+async fn create_worktree_structured_error_branch_exists_returns_409() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    let parent_path = "/srv/repos/acme";
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &parent_id, &host_id_str, parent_path, "acme").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    let err = zremote_protocol::project::WorktreeError::new(
+        zremote_protocol::project::WorktreeErrorCode::BranchExists,
+        "Pick a different branch name",
+        "branch already exists",
+    );
+    let err_clone = err.clone();
+    let _agent = spawn_worktree_create_fake_agent(Arc::clone(&state), rx, move |state, msg| {
+        Box::pin(async move {
+            let zremote_protocol::ServerMessage::WorktreeCreateRequest { request_id, .. } = msg
+            else {
+                unreachable!()
+            };
+            if let Some((_, pending)) = state.worktree_create_requests.remove(&request_id) {
+                let _ = pending.sender.send(crate::state::WorktreeCreateResponse {
+                    worktree: None,
+                    error: Some(err_clone),
+                    project_id: None,
+                });
+            }
+        })
+    });
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"branch":"feature/x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: zremote_protocol::project::WorktreeError = serde_json::from_slice(&body).unwrap();
+    assert_eq!(got, err);
+    assert_eq!(
+        got.code,
+        zremote_protocol::project::WorktreeErrorCode::BranchExists
+    );
+}
+
+#[tokio::test]
+async fn create_worktree_structured_error_path_collision_returns_409() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &parent_id, &host_id_str, "/srv/acme", "acme").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    let err = zremote_protocol::project::WorktreeError::new(
+        zremote_protocol::project::WorktreeErrorCode::PathCollision,
+        "Choose a different target path",
+        "path exists",
+    );
+    let err_clone = err.clone();
+    let _agent = spawn_worktree_create_fake_agent(Arc::clone(&state), rx, move |state, msg| {
+        Box::pin(async move {
+            let zremote_protocol::ServerMessage::WorktreeCreateRequest { request_id, .. } = msg
+            else {
+                unreachable!()
+            };
+            if let Some((_, pending)) = state.worktree_create_requests.remove(&request_id) {
+                let _ = pending.sender.send(crate::state::WorktreeCreateResponse {
+                    worktree: None,
+                    error: Some(err_clone),
+                    project_id: None,
+                });
+            }
+        })
+    });
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"branch":"feature/x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn create_worktree_structured_error_path_missing_returns_404() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &parent_id, &host_id_str, "/gone", "gone").await;
+
+    let rx = register_host_connection(&state, host_id).await;
+
+    let err = zremote_protocol::project::WorktreeError::new(
+        zremote_protocol::project::WorktreeErrorCode::PathMissing,
+        "Project path no longer exists",
+        "path does not exist",
+    );
+    let err_clone = err.clone();
+    let _agent = spawn_worktree_create_fake_agent(Arc::clone(&state), rx, move |state, msg| {
+        Box::pin(async move {
+            let zremote_protocol::ServerMessage::WorktreeCreateRequest { request_id, .. } = msg
+            else {
+                unreachable!()
+            };
+            if let Some((_, pending)) = state.worktree_create_requests.remove(&request_id) {
+                let _ = pending.sender.send(crate::state::WorktreeCreateResponse {
+                    worktree: None,
+                    error: Some(err_clone),
+                    project_id: None,
+                });
+            }
+        })
+    });
+
+    let app = build_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"branch":"feature/x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_worktree_host_offline_returns_409() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4().to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id).await;
+    insert_project(&state, &parent_id, &host_id, "/srv/acme", "acme").await;
+
+    // No registered connection.
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"branch":"feature/x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn create_worktree_invalid_body_returns_400() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4().to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id).await;
+    insert_project(&state, &parent_id, &host_id, "/srv/acme", "acme").await;
+
+    let app = build_router(state);
+    // Missing required "branch" field.
+    let resp = app
+        .oneshot(
+            Request::post(format!("/api/projects/{parent_id}/worktrees"))
+                .header("content-type", "application/json")
+                .body(Body::from(r"{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_worktree_agent_timeout_returns_504() {
+    let state = test_state().await;
+    let host_id = Uuid::new_v4();
+    let host_id_str = host_id.to_string();
+    let parent_id = Uuid::new_v4().to_string();
+    insert_host(&state, &host_id_str).await;
+    insert_project(&state, &parent_id, &host_id_str, "/srv/acme", "acme").await;
+
+    let mut rx = register_host_connection(&state, host_id).await;
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let resp = super::worktree::create_worktree_with_timeout(
+        Arc::clone(&state),
+        parent_id,
+        super::worktree::CreateWorktreeRequest {
+            branch: "feature/x".to_string(),
+            path: None,
+            new_branch: None,
+            base_ref: None,
+        },
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .expect("handler returns a response even on timeout");
+
+    assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: zremote_protocol::project::WorktreeError = serde_json::from_slice(&body).unwrap();
+    assert!(matches!(
+        got.code,
+        zremote_protocol::project::WorktreeErrorCode::Internal
+    ));
 }

--- a/crates/zremote-server/src/routes/projects/worktree.rs
+++ b/crates/zremote-server/src/routes/projects/worktree.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -7,13 +8,22 @@ use axum::response::IntoResponse;
 use serde::Deserialize;
 use uuid::Uuid;
 use zremote_core::queries::projects as q;
+use zremote_core::worktree_http::worktree_error_response;
 use zremote_protocol::ServerMessage;
+use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
 
 use crate::error::{AppError, AppJson};
-use crate::state::AppState;
+use crate::state::{AppState, PendingWorktreeCreate, WorktreeCreateResponse};
 
 use super::crud::ProjectResponse;
 use super::parse_project_id;
+
+/// Wall-clock timeout for awaiting the agent's `WorktreeCreateResponse`. The
+/// agent bounds its git call with a shorter per-call timeout, but the overall
+/// flow (validation + spawn_blocking + hook) can approach that ceiling on
+/// large repos. Kept below `WORKTREE_CREATE_STALE_THRESHOLD` (180s) so the
+/// pending-entry reaper doesn't race with us.
+const WORKTREE_CREATE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// `GET /api/projects/:project_id/worktrees` - list worktree children.
 pub async fn list_worktrees(
@@ -37,13 +47,29 @@ pub struct CreateWorktreeRequest {
     pub base_ref: Option<String>,
 }
 
-/// `POST /api/projects/:project_id/worktrees` - request worktree creation.
+/// `POST /api/projects/:project_id/worktrees` - synchronous worktree create
+/// proxied through the agent's WebSocket. Mirrors local-mode's response
+/// body: `201 Created` with the full `ProjectResponse` (plus an optional
+/// `hook_result` key) on success, structured `WorktreeError` on classified
+/// failures, `504` on agent timeout.
 pub async fn create_worktree(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<String>,
     AppJson(body): AppJson<CreateWorktreeRequest>,
-) -> Result<impl IntoResponse, AppError> {
-    let _parsed = parse_project_id(&project_id)?;
+) -> Result<axum::response::Response, AppError> {
+    create_worktree_with_timeout(state, project_id, body, WORKTREE_CREATE_RESPONSE_TIMEOUT).await
+}
+
+/// Inner implementation parameterised by timeout so tests can exercise the
+/// 504 path without waiting 2 real minutes. Production callers go through
+/// `create_worktree` which supplies `WORKTREE_CREATE_RESPONSE_TIMEOUT`.
+pub(crate) async fn create_worktree_with_timeout(
+    state: Arc<AppState>,
+    project_id: String,
+    body: CreateWorktreeRequest,
+    response_timeout: Duration,
+) -> Result<axum::response::Response, AppError> {
+    let project_id = parse_project_id(&project_id)?.to_string();
 
     let (host_id_str, project_path) = q::get_project_host_and_path(&state.db, &project_id)
         .await?
@@ -59,8 +85,16 @@ pub async fn create_worktree(
         .await
         .ok_or_else(|| AppError::Conflict("host is offline".to_string()))?;
 
-    sender
-        .send(ServerMessage::WorktreeCreate {
+    let request_id = Uuid::new_v4();
+    let (tx, rx) = tokio::sync::oneshot::channel::<WorktreeCreateResponse>();
+    state.worktree_create_requests.insert(
+        request_id,
+        PendingWorktreeCreate::new(tx, project_path.clone()),
+    );
+
+    if let Err(send_err) = sender
+        .send(ServerMessage::WorktreeCreateRequest {
+            request_id,
             project_path,
             branch: body.branch,
             path: body.path,
@@ -68,9 +102,87 @@ pub async fn create_worktree(
             base_ref: body.base_ref,
         })
         .await
-        .map_err(|_| AppError::Conflict("failed to send worktree create to agent".to_string()))?;
+    {
+        state.worktree_create_requests.remove(&request_id);
+        tracing::warn!(
+            host_id = %host_id,
+            request_id = %request_id,
+            error = %send_err,
+            "failed to send WorktreeCreateRequest to agent (outbound channel closed)"
+        );
+        return Err(AppError::Conflict(
+            "failed to send worktree create request".to_string(),
+        ));
+    }
 
-    Ok(StatusCode::ACCEPTED)
+    let timeout_result = tokio::time::timeout(response_timeout, rx).await;
+
+    match timeout_result {
+        Ok(Ok(WorktreeCreateResponse {
+            worktree: Some(payload),
+            error: None,
+            project_id: Some(new_project_id),
+        })) => {
+            let project_row = q::get_project(&state.db, &new_project_id).await?;
+            let mut body_json = serde_json::to_value(&project_row)
+                .map_err(|e| AppError::Internal(format!("serialization error: {e}")))?;
+            if let Some(ref hr) = payload.hook_result {
+                body_json["hook_result"] = serde_json::json!({
+                    "success": hr.success,
+                    "output": hr.output,
+                    "duration_ms": hr.duration_ms,
+                });
+            }
+            Ok((StatusCode::CREATED, Json(body_json)).into_response())
+        }
+        Ok(Ok(WorktreeCreateResponse {
+            worktree: Some(_),
+            error: None,
+            project_id: None,
+        })) => {
+            // Dispatch reported success but could not upsert the DB row. This
+            // happens when the parent project was deleted mid-flight or the
+            // upsert itself failed — treat as an internal error so the caller
+            // retries rather than sees a half-updated UI.
+            tracing::error!(
+                request_id = %request_id,
+                "WorktreeCreateResponse success without project_id — parent missing or upsert failed"
+            );
+            Err(AppError::Internal(
+                "worktree created but could not be recorded".to_string(),
+            ))
+        }
+        Ok(Ok(WorktreeCreateResponse {
+            error: Some(err), ..
+        })) => {
+            let (status, body_json) = worktree_error_response(err);
+            Ok((status, body_json).into_response())
+        }
+        Ok(Ok(WorktreeCreateResponse {
+            worktree: None,
+            error: None,
+            ..
+        })) => Err(AppError::Internal(
+            "agent returned an empty WorktreeCreateResponse (no worktree, no error)".to_string(),
+        )),
+        Ok(Err(_recv)) => Err(AppError::Internal(
+            "worktree create response channel closed".to_string(),
+        )),
+        Err(_timeout) => {
+            state.worktree_create_requests.remove(&request_id);
+            tracing::warn!(
+                host_id = %host_id,
+                request_id = %request_id,
+                "WorktreeCreateRequest timed out waiting for agent response"
+            );
+            let err = WorktreeError::new(
+                WorktreeErrorCode::Internal,
+                "Worktree creation timed out — the agent may still be working or disconnected.",
+                "agent response timeout after 120s",
+            );
+            Ok((StatusCode::GATEWAY_TIMEOUT, Json(err)).into_response())
+        }
+    }
 }
 
 /// `DELETE /api/projects/:project_id/worktrees/:worktree_id` - request worktree deletion.

--- a/crates/zremote-server/src/routes/projects/worktree.rs
+++ b/crates/zremote-server/src/routes/projects/worktree.rs
@@ -13,7 +13,9 @@ use zremote_protocol::ServerMessage;
 use zremote_protocol::project::{WorktreeError, WorktreeErrorCode};
 
 use crate::error::{AppError, AppJson};
-use crate::state::{AppState, PendingWorktreeCreate, WorktreeCreateResponse};
+use crate::state::{
+    AppState, MAX_PENDING_WORKTREE_CREATE, PendingWorktreeCreate, WorktreeCreateResponse,
+};
 
 use super::crud::ProjectResponse;
 use super::parse_project_id;
@@ -85,6 +87,23 @@ pub(crate) async fn create_worktree_with_timeout(
         .await
         .ok_or_else(|| AppError::Conflict("host is offline".to_string()))?;
 
+    // DoS mitigation (complements future REST auth middleware): refuse new
+    // requests once the pending map is saturated so a misbehaving or
+    // unauthenticated caller cannot grow it without bound.
+    if state.worktree_create_requests.len() >= MAX_PENDING_WORKTREE_CREATE {
+        tracing::warn!(
+            host_id = %host_id,
+            pending = state.worktree_create_requests.len(),
+            "worktree_create_requests map saturated, rejecting"
+        );
+        let err = WorktreeError::new(
+            WorktreeErrorCode::Internal,
+            "Server temporarily overloaded — try again shortly.",
+            "pending-map cap reached",
+        );
+        return Ok((StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response());
+    }
+
     let request_id = Uuid::new_v4();
     let (tx, rx) = tokio::sync::oneshot::channel::<WorktreeCreateResponse>();
     state.worktree_create_requests.insert(
@@ -142,15 +161,20 @@ pub(crate) async fn create_worktree_with_timeout(
         })) => {
             // Dispatch reported success but could not upsert the DB row. This
             // happens when the parent project was deleted mid-flight or the
-            // upsert itself failed — treat as an internal error so the caller
-            // retries rather than sees a half-updated UI.
+            // upsert itself failed. Return a structured `WorktreeError` (same
+            // shape as every other error path) so the client's
+            // `create_worktree_structured` routes through
+            // `WorktreeCreateError::Structured` consistently.
             tracing::error!(
                 request_id = %request_id,
                 "WorktreeCreateResponse success without project_id — parent missing or upsert failed"
             );
-            Err(AppError::Internal(
-                "worktree created but could not be recorded".to_string(),
-            ))
+            let err = WorktreeError::new(
+                WorktreeErrorCode::Internal,
+                "Worktree was created but the server couldn't link it back — refresh to see the new entry.",
+                "worktree created but project row upsert failed or parent was missing",
+            );
+            Ok((StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response())
         }
         Ok(Ok(WorktreeCreateResponse {
             error: Some(err), ..
@@ -177,8 +201,11 @@ pub(crate) async fn create_worktree_with_timeout(
             );
             let err = WorktreeError::new(
                 WorktreeErrorCode::Internal,
-                "Worktree creation timed out — the agent may still be working or disconnected.",
-                "agent response timeout after 120s",
+                "Worktree creation timed out — the agent may still be working or may have disconnected. Reopen the modal to try again.",
+                format!(
+                    "agent response timeout after {}s",
+                    response_timeout.as_secs()
+                ),
             );
             Ok((StatusCode::GATEWAY_TIMEOUT, Json(err)).into_response())
         }

--- a/crates/zremote-server/src/routes/sessions.rs
+++ b/crates/zremote-server/src/routes/sessions.rs
@@ -497,6 +497,8 @@ mod tests {
             settings_get_requests: Arc::new(dashmap::DashMap::new()),
             settings_save_requests: Arc::new(dashmap::DashMap::new()),
             action_inputs_requests: Arc::new(dashmap::DashMap::new()),
+            branch_list_requests: Arc::new(dashmap::DashMap::new()),
+            worktree_create_requests: Arc::new(dashmap::DashMap::new()),
         })
     }
 

--- a/crates/zremote-server/src/state.rs
+++ b/crates/zremote-server/src/state.rs
@@ -168,6 +168,45 @@ pub struct ActionInputsResolveResponse {
     pub error: Option<String>,
 }
 
+/// Response type for branch list oneshot channels (RFC-009).
+pub struct BranchListResponse {
+    pub branches: Option<zremote_protocol::project::BranchList>,
+    pub error: Option<zremote_protocol::project::WorktreeError>,
+}
+
+/// Response type for worktree create oneshot channels (RFC-009). `project_id`
+/// is set to the newly-inserted DB row id when the upsert succeeded on a
+/// successful create; `None` on error or when the upsert was skipped (e.g.
+/// parent project row not found).
+pub struct WorktreeCreateResponse {
+    pub worktree: Option<zremote_protocol::WorktreeCreateSuccessPayload>,
+    pub error: Option<zremote_protocol::project::WorktreeError>,
+    pub project_id: Option<String>,
+}
+
+/// Pending-entry wrapper for `worktree_create_requests`. The response payload
+/// doesn't carry `parent_project_path`, but the dispatch handler needs it to
+/// upsert the worktree row. The HTTP handler (P4) knows it when building the
+/// request, so we stash it here alongside the oneshot sender.
+pub struct PendingWorktreeCreate {
+    pub sender: tokio::sync::oneshot::Sender<WorktreeCreateResponse>,
+    pub parent_project_path: String,
+    pub(crate) created_at: Instant,
+}
+
+impl PendingWorktreeCreate {
+    pub fn new(
+        sender: tokio::sync::oneshot::Sender<WorktreeCreateResponse>,
+        parent_project_path: String,
+    ) -> Self {
+        Self {
+            sender,
+            parent_project_path,
+            created_at: Instant::now(),
+        }
+    }
+}
+
 /// Shared application state.
 pub struct AppState {
     pub db: SqlitePool,
@@ -187,11 +226,36 @@ pub struct AppState {
     pub settings_save_requests: Arc<DashMap<uuid::Uuid, PendingRequest<SettingsSaveResponse>>>,
     pub action_inputs_requests:
         Arc<DashMap<uuid::Uuid, PendingRequest<ActionInputsResolveResponse>>>,
+    /// Pending `BranchListRequest` oneshots, resolved when the agent sends the
+    /// matching `BranchListResponse` back. When an agent disconnects, the
+    /// `ConnectionManager` drops its mpsc sender and the oneshot receiver
+    /// eventually returns `Err(RecvError)` via the HTTP handler's timeout.
+    /// Stale entries are reaped by `cleanup_stale_requests`.
+    pub branch_list_requests: Arc<DashMap<uuid::Uuid, PendingRequest<BranchListResponse>>>,
+    /// Pending `WorktreeCreateRequest` oneshots, resolved when the agent sends
+    /// the matching `WorktreeCreateResponse` back. Same disconnect/timeout
+    /// semantics as `branch_list_requests`. Uses `PendingWorktreeCreate`
+    /// instead of the generic `PendingRequest<T>` because the response payload
+    /// doesn't carry the parent `project_path`, but the dispatch handler needs
+    /// it to upsert the worktree row.
+    pub worktree_create_requests: Arc<DashMap<uuid::Uuid, PendingWorktreeCreate>>,
 }
 
+/// Per-map stale threshold for `branch_list_requests`: git branch listing is
+/// fast, so a short window is enough to keep the map from growing when an
+/// agent hangs or crashes mid-request.
+pub const BRANCH_LIST_STALE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Per-map stale threshold for `worktree_create_requests`: covers the agent's
+/// 60s git timeout plus hook headroom and a safety margin.
+pub const WORKTREE_CREATE_STALE_THRESHOLD: std::time::Duration =
+    std::time::Duration::from_secs(180);
+
 impl AppState {
-    /// Remove pending requests older than `max_age` from all DashMap fields.
-    /// Returns the total number of stale entries removed.
+    /// Remove pending requests older than `max_age` from the general-purpose
+    /// pending maps, and apply per-map thresholds
+    /// (`BRANCH_LIST_STALE_THRESHOLD`, `WORKTREE_CREATE_STALE_THRESHOLD`) to the
+    /// RFC-009 maps. Returns the total number of stale entries removed.
     pub fn cleanup_stale_requests(&self, max_age: std::time::Duration) -> usize {
         let now = Instant::now();
         let mut removed = 0;
@@ -245,6 +309,24 @@ impl AppState {
             let keep = now.duration_since(req.created_at) <= max_age;
             if !keep {
                 tracing::warn!(request_id = %id, map = "action_inputs_requests", "removing stale pending request");
+                removed += 1;
+            }
+            keep
+        });
+
+        self.branch_list_requests.retain(|id, req| {
+            let keep = now.duration_since(req.created_at) <= BRANCH_LIST_STALE_THRESHOLD;
+            if !keep {
+                tracing::warn!(request_id = %id, map = "branch_list_requests", "removing stale pending request");
+                removed += 1;
+            }
+            keep
+        });
+
+        self.worktree_create_requests.retain(|id, entry| {
+            let keep = now.duration_since(entry.created_at) <= WORKTREE_CREATE_STALE_THRESHOLD;
+            if !keep {
+                tracing::warn!(request_id = %id, map = "worktree_create_requests", "removing stale pending request");
                 removed += 1;
             }
             keep
@@ -448,6 +530,8 @@ mod tests {
             settings_get_requests: Arc::new(DashMap::new()),
             settings_save_requests: Arc::new(DashMap::new()),
             action_inputs_requests: Arc::new(DashMap::new()),
+            branch_list_requests: Arc::new(DashMap::new()),
+            worktree_create_requests: Arc::new(DashMap::new()),
         }
     }
 
@@ -537,6 +621,69 @@ mod tests {
         assert!(state.directory_requests.is_empty());
         assert!(state.settings_save_requests.is_empty());
         assert!(state.action_inputs_requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_stale_branch_list_entries() {
+        let app = make_app_state().await;
+
+        let id_expired = Uuid::new_v4();
+        let (tx_expired, _rx_expired) = tokio::sync::oneshot::channel::<BranchListResponse>();
+        let mut expired = PendingRequest::new(tx_expired);
+        expired.created_at =
+            Instant::now() - (BRANCH_LIST_STALE_THRESHOLD + std::time::Duration::from_secs(5));
+        app.branch_list_requests.insert(id_expired, expired);
+
+        let id_fresh = Uuid::new_v4();
+        let (tx_fresh, _rx_fresh) = tokio::sync::oneshot::channel::<BranchListResponse>();
+        app.branch_list_requests
+            .insert(id_fresh, PendingRequest::new(tx_fresh));
+
+        // max_age (for the generic maps) is large, but branch_list_requests uses
+        // its own threshold — so the expired entry must go.
+        let removed = app.cleanup_stale_requests(std::time::Duration::from_secs(600));
+        assert_eq!(removed, 1);
+        assert!(app.branch_list_requests.get(&id_expired).is_none());
+        assert!(app.branch_list_requests.get(&id_fresh).is_some());
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_stale_worktree_create_entries() {
+        let app = make_app_state().await;
+
+        let id_expired = Uuid::new_v4();
+        let (tx_expired, _rx_expired) = tokio::sync::oneshot::channel::<WorktreeCreateResponse>();
+        let mut expired = PendingWorktreeCreate::new(tx_expired, "/tmp/parent".to_string());
+        expired.created_at =
+            Instant::now() - (WORKTREE_CREATE_STALE_THRESHOLD + std::time::Duration::from_secs(5));
+        app.worktree_create_requests.insert(id_expired, expired);
+
+        let id_fresh = Uuid::new_v4();
+        let (tx_fresh, _rx_fresh) = tokio::sync::oneshot::channel::<WorktreeCreateResponse>();
+        app.worktree_create_requests.insert(
+            id_fresh,
+            PendingWorktreeCreate::new(tx_fresh, "/tmp/parent".to_string()),
+        );
+
+        let removed = app.cleanup_stale_requests(std::time::Duration::from_secs(600));
+        assert_eq!(removed, 1);
+        assert!(app.worktree_create_requests.get(&id_expired).is_none());
+        assert!(app.worktree_create_requests.get(&id_fresh).is_some());
+    }
+
+    #[tokio::test]
+    async fn cleanup_preserves_fresh_branch_list_even_with_tiny_generic_max_age() {
+        let state = make_app_state().await;
+        let id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::oneshot::channel::<BranchListResponse>();
+        state
+            .branch_list_requests
+            .insert(id, PendingRequest::new(tx));
+
+        // Generic max_age = 0 would reap all generic maps, but branch_list is fresh.
+        let removed = state.cleanup_stale_requests(std::time::Duration::ZERO);
+        assert_eq!(removed, 0);
+        assert!(state.branch_list_requests.get(&id).is_some());
     }
 
     #[tokio::test]

--- a/crates/zremote-server/src/state.rs
+++ b/crates/zremote-server/src/state.rs
@@ -251,6 +251,18 @@ pub const BRANCH_LIST_STALE_THRESHOLD: std::time::Duration = std::time::Duration
 pub const WORKTREE_CREATE_STALE_THRESHOLD: std::time::Duration =
     std::time::Duration::from_secs(180);
 
+/// Hard cap on outstanding `BranchListRequest` pending entries. DoS mitigation
+/// complementing future auth middleware: an unauthenticated client (pre-auth)
+/// or a buggy caller cannot grow the map without bound and exhaust memory.
+/// Sized generously — legitimate users open branch pickers across at most a
+/// handful of projects simultaneously.
+pub const MAX_PENDING_BRANCH_LIST: usize = 5_000;
+
+/// Hard cap on outstanding `WorktreeCreateRequest` pending entries. Same DoS
+/// mitigation as `MAX_PENDING_BRANCH_LIST`, with a tighter cap since
+/// worktree-create requests are heavier (agent spawns git) and much rarer.
+pub const MAX_PENDING_WORKTREE_CREATE: usize = 1_000;
+
 impl AppState {
     /// Remove pending requests older than `max_age` from the general-purpose
     /// pending maps, and apply per-map thresholds


### PR DESCRIPTION
## Summary

- **Problem:** GUI worktree-create modal shows errors in server mode — `GET /api/projects/:id/git/branches` returns 404 (route missing) and `POST /api/projects/:id/worktrees` returns 202 with empty body (client JSON parse fails). Worktree is nonetheless created via fire-and-forget WS.
- **Fix:** new request/response WS message pairs (`BranchListRequest`/`BranchListResponse`, `WorktreeCreateRequest`/`WorktreeCreateResponse`) mirrored on the existing `ProjectGetSettings` pending-map pattern. Server handlers now block on the agent reply and return the same JSON shape as local mode, including structured errors.
- **Server and agent are now at parity** — GUI doesn't care which mode it's connected to.

## Phases (all on this branch)

| Commit | Phase |
|---|---|
| `da5f444` | P1 protocol variants + `WorktreeCreateSuccessPayload` |
| `a0e58f8` | P2 agent handlers + shared `worktree::service::run_worktree_create` helper |
| `753cd4e` | P3 server pending maps + dispatch (shared `upsert_worktree_row`) |
| `43f30f8` | P4 server HTTP routes + shared `zremote-core::worktree_http` error helper |
| `446926a` | P6 security + correctness fixes after 3-way review |

## Review findings applied (from rust-reviewer, code-reviewer, security-reviewer)

- **FIX 1** `upsert_worktree_row` ON CONFLICT uses `COALESCE(excluded.parent_project_id, projects.parent_project_id)` — parent reference can't be lost on race
- **FIX 2** 504 timeout surfaces a user-facing hint instead of the dev-facing string
- **FIX 3** raw git stderr no longer leaks into `BranchListResponse.error.message` (CWE-200); same leak caught in `service::run_worktree_create` join-err path
- **FIX 4** new WS handlers validate `project_path` via `validate_path_no_traversal` (CWE-88)
- **FIX 5** pending maps have size caps (`MAX_PENDING_BRANCH_LIST = 5_000`, `MAX_PENDING_WORKTREE_CREATE = 1_000`) returning 503 — DoS mitigation (CWE-770)
- **FIX 6** `project_id: None` success arm returns structured `WorktreeError` body for client consistency
- **FIX 7** timeout sentinels derived from constants
- **FIX 8** new dispatch-level test `handle_worktree_create_response_preserves_parent_project_id_on_conflict` exercises the COALESCE path

## Out of scope (intentional, tracked as follow-ups)

- REST API auth middleware (CWE-284, pre-existing `TODO(phase-3)` in server `lib.rs`)
- `#[serde(other)]` on protocol enums — existing error handling in `connection/mod.rs` already log-and-drops unknown variants without closing the connection
- Legacy `ServerMessage::WorktreeCreate` / `AgentMessage::WorktreeCreated` path kept alive for rolling upgrades; removable in a follow-up once fleet is upgraded

## Verification

- `cargo test --workspace` — 2 523 tests, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build -p zremote --no-default-features --features agent` — headless build OK

## Test plan

- [x] P1 protocol: serde round-trip for all four new variants + `WorktreeCreateSuccessPayload.hook_result` skip-when-None
- [x] P2 agent: service helper golden path, BranchExists structured failure, leading-dash rejection, dispatch integration for both request variants
- [x] P3 server: pending-map cleanup for both new maps, dispatch-level DB upsert, legacy `WorktreeCreated` regression via shared helper
- [x] P4 server: 12 integration tests (happy path, structured errors, offline 409, timeout 504, invalid ID, invalid body)
- [x] P6 fix: COALESCE conflict path unit-tested; all existing tests pass
- [ ] **Manual E2E:** Start server + agent + GUI per `CLAUDE.md`, walk worktree-create modal for happy path / BranchExists / PathCollision / InvalidRef base_ref. **Needs to run on user machine (GUI).**

## Files changed

- `zremote-protocol`: 4 new enum variants + `WorktreeCreateSuccessPayload` struct (terminal.rs)
- `zremote-agent`: new `worktree::service` module, 2 new dispatch handlers, local HTTP handler refactored to delegate
- `zremote-server`: 2 new pending maps, shared `upsert_worktree_row` helper, 2 new HTTP handlers (1 new route), rewritten worktree create
- `zremote-core`: new `worktree_http::worktree_error_response` helper (feature-gated on `axum`)

## RFC

`docs/rfc/rfc-009-server-mode-worktree-branches.md`