### PR TITLE
RFC-010: ACP Integration via SessionDriver

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,148 @@
+# ACP Integration Research — Synthesis
+
+**Branch:** `feature/acp` (no implementation yet)
+**Date:** 2026-04-25
+**Sources:** see sister reports in this directory:
+- [`acp-spec.md`](./acp-spec.md) — protocol specification deep-dive
+- [`acp-ecosystem.md`](./acp-ecosystem.md) — clients, agents, SDKs, UX patterns
+- [`zremote-acp-integration-points.md`](./zremote-acp-integration-points.md) — current zremote architecture and integration seams
+
+This document is a *team-lead synthesis* of the three reports above. Read it first; drill into the sister reports for evidence and details.
+
+> **Update 2026-04-25:** see [`driver-architecture.md`](./driver-architecture.md) for a refined target architecture in which ACP is one of several pluggable `SessionDriver`s (alongside PTY-only, CC-hooks, generic-ACP). That framing supersedes §3 and parts of §6 below; the rest of this document remains valid as evidence and protocol reference.
+
+---
+
+## 1. What ACP is, in one paragraph
+
+The **Agent Client Protocol** is an open JSON-RPC 2.0 protocol (newline-delimited, stdio by default) for communication between an **IDE/UI** and a **coding agent** subprocess. It was incubated by Zed, has since been spun out to its own org (Apache-2.0), and is at v1 with stable Rust/TS/Python/Kotlin/Java SDKs (Rust crate `agent-client-protocol = 0.11.1`, 1.4M downloads). The protocol has converged: 6+ editor clients ship today (Zed, all JetBrains IDEs, Neovim plugins, Emacs, marimo) and the **ACP Registry** lists **27 agents** with one-click distribution metadata — Claude Code, OpenAI Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Cline, Goose, OpenCode, JetBrains Junie, Kimi, Qwen, Mistral Vibe, and more.
+
+Mental model: **LSP is editor↔language. MCP is agent↔tool. ACP is editor↔agent.** They compose: a typical stack is `Editor —ACP→ Agent —MCP→ tool servers`, with the language server still riding LSP.
+
+## 2. What it would bring zremote — concrete capabilities
+
+### 2.1 Replace ad-hoc agentic-loop detection with structured events
+
+Today zremote has a three-layer ad-hoc loop detector:
+- **Layer 1**: BFS process-tree scan for the four hard-coded binaries (claude, codex, gemini, aider) — cannot tell working vs waiting (`crates/zremote-agent/src/agentic/detector.rs:11-59`).
+- **Layer 2**: PTY output regex + OSC133 prompt markers — line-buffered, can't see structured tool calls or diffs (`crates/zremote-agent/src/agentic/analyzer.rs:371-588`).
+- **Layer 3**: CC-specific HTTP hooks sidecar — high-fidelity but **only for Claude Code** (`crates/zremote-agent/src/hooks/handler.rs:124-261`).
+
+ACP replaces layers 1+2 with a typed event stream **for any agent that speaks ACP**, regardless of vendor. Layer 3 becomes redundant for CC over ACP (the Claude Code adapter `@zed-industries/claude-agent-acp` already exists and is shipping).
+
+### 2.2 Instant agent catalog (27+ agents, zero per-agent UI work)
+
+By becoming an ACP client, the GPUI app immediately gains access to every registry agent through a single code path. No per-vendor scraping, no provider-specific adapters in `agentic/adapters/{claude,codex,gemini,aider}.rs`. Adding a new agent is a registry entry, not a code change.
+
+### 2.3 Rich UX features that today are impossible
+
+| Capability | Today in zremote | With ACP |
+|---|---|---|
+| Streaming text from the model | line-buffered PTY scrape | token-level `agent_message_chunk` |
+| Tool calls | "tool name appeared in output" | typed `tool_call` with `kind`, `status`, `locations[]` |
+| Diff preview | none | `{type:"diff", path, oldText, newText}` → multi-buffer review |
+| Permission prompts | CC-only via hooks | typed `session/request_permission` for every agent |
+| Plans / task lists | none | `sessionUpdate:"plan"` with priorities and statuses |
+| Terminal embedding in tool cards | none | `terminal/*` provider, live tail in cards |
+| Cancellation | send Ctrl-C bytes | `session/cancel` notification |
+| Slash commands & session resume | CC-specific | uniform protocol across all agents |
+| Session list / history | per-vendor logic | `session/list` + `session/load` / `session/resume` |
+
+### 2.4 The zremote-unique value prop: ACP over the network
+
+ACP today is **stdio-only** (HTTP/WS transport is a draft RFD). That's the protocol's biggest practical limitation: a Zed editor on a laptop cannot drive an agent that lives on a remote server box.
+
+zremote already operates a bidirectional WebSocket tunnel between GUI and remote agents (`crates/zremote-protocol/src/terminal.rs:46-306`). Wrapping ACP frames inside an `AgentMessage::AcpFrame` variant turns zremote into the **first ACP transport that crosses machine boundaries** — the GUI on a laptop drives an agent running on the remote box, with `fs/*` and `terminal/*` operating on the remote filesystem and remote PTY natively. No sshfs, no tmux. This is essentially "Zed for remote hosts" with zero per-agent integration work.
+
+## 3. The three integration shapes — pick (A) first
+
+Three places ACP could land. Numbered by recommended order.
+
+### (A) GPUI as ACP **client** — recommended first phase
+
+**User-facing capability:** users pick "Claude Code (ACP)" / "Codex (ACP)" / etc. in the launcher. The app spawns the chosen ACP agent (locally for standalone, on the remote host for server mode), drives it directly, and renders structured events as native GPUI views.
+
+**What plugs in where:** the existing `AgentLauncher` trait + `LauncherRegistry` from RFC-003 (`crates/zremote-agent/src/agents/mod.rs:94-227`) is exactly the seam ACP needs. Add a `transport: "acp"` flag to `AgentProfileData.settings_json` (no schema migration — the field is already a freeform JSON blob per RFC-003 §1).
+
+**Effort:** **L** (Large; ~3–6 weeks). Wire types via `agent-client-protocol = "=0.11.1"`, GPUI views for tool-call cards / diff hunks / permission modals, launcher integration, profile editor toggle.
+
+**Compatibility:** Forward-compatible — new launcher kinds and `#[serde(other)]` Unknown variants are already the safe-evolution pattern in the codebase.
+
+### (B) `zremote-agent` as ACP **server** — second phase, optional
+
+**User-facing capability:** a Zed editor (or any ACP client) running on the user's laptop connects to a zremote agent and uses it as the agent backend. zremote becomes a remote-execution provider for any ACP client, including non-zremote ones.
+
+**Effort:** **XL**. Bigger because the agent has to *be* an agent loop, not just observe one — conversation state, tool wiring, full permission policy.
+
+**Risk:** double-driver races between CC hooks sidecar and ACP for the same session. Needs a per-launcher transport gate at `connection/mod.rs:368-388`.
+
+### (C) Replace internal GUI↔agent protocol with ACP — defer
+
+The current 50-endpoint REST + tagged-enum WS protocol covers projects, knowledge, linear, worktrees, hooks, channels — most of which has no ACP equivalent. ACP would only cover a slice and replacing the wire is XL with no current user pain. Defer indefinitely.
+
+## 4. Concrete use cases unlocked by (A)
+
+1. **Multi-vendor agent launcher.** "Run this prompt with Claude Code / Codex / Gemini / Goose / Cline / Junie / Cursor / Kimi / OpenCode / etc." with no code changes per vendor.
+2. **Native diff review on the remote project.** Agent emits `(path, oldText, newText)` per edit; GUI renders multi-buffer hunk-level accept/reject — and the file is on the *remote* host because `fs/write_text_file` is implemented agent-side.
+3. **Agent following.** When the agent sets `tool_call.locations[]`, the GUI auto-jumps the terminal/file pane to that path:line — the user literally watches where the agent is reading.
+4. **Permission gating UI.** Every destructive tool call surfaces a typed prompt with Allow once / Allow always / Reject options — driven by the same channel-permission UI we already have, but for any agent.
+5. **Plan tracking sidebar.** `sessionUpdate:"plan"` becomes a checkable task list — exactly the kind of agentic-monitoring feature the existing `docs/rfc/agentic-monitoring.md` envisions, but built from typed events instead of regex scraping.
+6. **Token-stream chat.** Real-time `agent_message_chunk` rendering in a dedicated view — no more "watch the terminal scroll".
+7. **Cancellation that works.** `session/cancel` cleanly aborts the model + tool calls; we keep using `session/prompt` reply with `stopReason:"cancelled"` for state hygiene.
+8. **Session resume across reconnects.** `session/load` (replay history) and `session/resume` (restore without replay) survive agent disconnects — directly relevant to the existing `feedback_daemon_ux.md` memory about agent disconnect/reconnect being broken today.
+
+## 5. What it costs us (gaps a client must fill)
+
+ACP defines schema and lifecycle, not UX. We'd build:
+
+- **Subprocess plumbing**: spawn, env, cwd, signals, restart, stderr capture (the SDK helps; tokio process is straightforward).
+- **stdio framing**: handled by the Rust SDK; we'd just wrap our WS tunnel for server mode.
+- **fs/* handlers**: serve text-file reads/writes against the remote workspace, ideally with a worktree-rooted sandbox (RFC-009 gives us the natural FS root).
+- **terminal/* providers**: map onto our existing PTY layer; we already have create/output/kill — need to add an `outputByteLimit` ring buffer and a `terminalId` namespace separate from our `session_id`.
+- **Permission UX**: render `session/request_permission` and route the outcome — overlaps cleanly with the existing `ChannelAgentAction::PermissionRequest` flow at `crates/zremote-protocol/src/channel.rs:127-131`.
+- **Diff/multi-buffer review UI**: this is the biggest UX build. ACP gives us `(path, oldText, newText)`; the hunk-level reviewer is ours to write. Zed has set the bar high here.
+- **Agent picker**: pull `cdn.agentclientprotocol.com/registry/v1/latest/registry.json`, install via `npx` or signed binary, hook into the existing profile editor.
+- **Session persistence**: decide how we store `sessionId`s and whether we replay (`session/load`) or restore silently (`session/resume`).
+- **Auth UX**: `authenticate` is in the stable response shape; concrete auth payloads are still gated behind `unstable_auth_methods`. Fine to defer.
+
+## 6. Risks (in priority order)
+
+1. **`connection/mod.rs` is already 1000+ lines** with 8+ HashMaps of per-session state. Adding ACP transports without a per-session-struct refactor turns the file unmaintainable. Recommended: extract `SessionState` first.
+2. **Double-driver races.** CC hooks sidecar + ACP-CC on the same session both emit loop events. Per-launcher `transport` gate must skip the hooks install when transport is ACP.
+3. **Server-mode tunneling.** `/ws/agent` multiplexes everything. ACP needs a new `AgentMessage::AcpFrame { session_id, payload: Value }` variant (forward-compatible per CLAUDE.md, but a new wire variant is still risk surface).
+4. **Spec churn.** ACP is young — `unstable_*` cargo features still gate session/list, session/close, session/resume at the type level. We must pin `agent-client-protocol = "=0.11.1"` and explicitly opt into the unstable features we need (recommend `unstable_session_resume` + `unstable_session_close`).
+5. **Permission policy double-source.** zremote has per-project `permission-policy` (`crates/zremote-server/src/routes/channel.rs`) and `ChannelDialogDetector` for auto-approve. ACP has its own `request_permission`. We need a single decision point per session. Recommendation: route ACP requests through the existing channel-permission policy.
+6. **PTY ownership in case (A).** When the GUI talks ACP directly to a child process, the agent's PTY+analyzer pipeline is bypassed. Existing `ExecutionNode` history feed breaks for ACP sessions unless we add a translator that emits `LoopStateUpdate` + `ExecutionNode` from ACP frames so sidebar/activity-panel/Telegram notifications keep working.
+7. **`agentclientprotocol.com/libraries/rust` doc page is misleading.** It still shows `trait Agent` / `trait Client` from older blog sketches. The 0.11 SDK uses a role-typestate (`Client`/`Agent`/`Proxy`/`Conductor` structs + `Builder` + `HandleDispatchFrom<Counterpart>`). Verify against `docs.rs/agent-client-protocol/0.11.1` before writing examples.
+
+## 7. Recommended phasing
+
+| Phase | Scope | Effort | Goal |
+|---|---|---|---|
+| Spike | One external ACP agent (likely Claude Code via `@zed-industries/claude-agent-acp`) running locally as a subprocess driven by the GPUI app, plain-text streaming UI | 1–2 weeks | Validate JSON-RPC stdio transport + version negotiation + SDK ergonomics in our codebase |
+| Phase 1 | ACP launcher in **local mode** only. New `AgentLauncher` impl, `transport:"acp"` on profile, GPUI view with proper text + tool-call + permission UIs | 3–4 weeks | One end-to-end ACP agent in the GUI, no server-mode complications |
+| Phase 2 | **Server mode**. New `AgentMessage::AcpFrame` variant tunnels ACP through `/ws/agent`. Agent spawns the ACP child; frames forwarded both ways | 1–2 weeks | "ACP over the network" — the unique zremote value prop |
+| Phase 3 | `terminal/*` and `fs/*` providers wired into zremote PTY + sandboxed file IO. Worktree path becomes FS root (RFC-009 alignment) | 2–3 weeks | Agents can run shell commands and edit files on the remote host through standard ACP, no per-agent shims |
+| Phase 4 | Translator: ACP `session/update` → `AgenticAgentMessage::LoopStateUpdate` + `ExecutionNode`. Keep existing sidebar / activity panel / Telegram notifications working unchanged | 1–2 weeks | Backwards compatibility for all consumers of the loop-event firehose |
+| Phase 5 | (Optional) **Case (B)**: expose ACP from `zremote-agent` for external editors (Zed, JetBrains, Neovim) | XL | Only if Phase 1–4 succeed and there is user demand |
+| Defer | Case (C): replace internal protocol with ACP | — | No current pain; rewrite cost not justified |
+
+## 8. Open questions for the user
+
+1. **Which external agent first?** Claude Code via ACP would let us replace the CC hooks sidecar entirely. Codex / Gemini / Goose are alternatives and broaden vendor coverage faster but don't simplify existing code.
+2. **Server-mode in v1 or v2?** Standalone-only ACP would ship faster but loses the unique remote-execution angle. Ordering of Phase 1 vs Phase 2 depends on this.
+3. **CC hooks coexistence.** When CC is launched with `transport:"acp"`, do we still install the hooks sidecar (defense in depth) or skip it (cleaner separation)? Recommendation: skip and document.
+4. **Scope of agent-driven terminals.** ACP's `terminal/create` runs commands the agent requests. Do those land in a new visible PTY session in the sidebar (transparency) or hidden (it's the agent's tool, not the user's session)? Recommendation: visible-but-tagged.
+5. **Permission policy unification.** Should the existing per-project `permission-policy` apply to ACP `request_permission`? Recommendation: yes — single decision point.
+6. **Backwards compat for legacy CC tasks.** RFC-003 already softly deprecated `/api/claude-tasks`. Does ACP launch finally retire it, or do we keep three paths (legacy CC, generic launcher, ACP)?
+
+---
+
+## 9. References
+
+- Sister reports: [`acp-spec.md`](./acp-spec.md), [`acp-ecosystem.md`](./acp-ecosystem.md), [`zremote-acp-integration-points.md`](./zremote-acp-integration-points.md)
+- Spec home: [agentclientprotocol.com](https://agentclientprotocol.com)
+- Rust SDK: [`agent-client-protocol = 0.11.1`](https://crates.io/crates/agent-client-protocol)
+- Reference repo: [`agentclientprotocol/agent-client-protocol`](https://github.com/agentclientprotocol/agent-client-protocol)
+- Agent registry JSON: `https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json`
+- Claude Code ACP adapter: [`@zed-industries/claude-agent-acp`](https://github.com/zed-industries/claude-agent-acp)

--- a/docs/research/acp-ecosystem.md
+++ b/docs/research/acp-ecosystem.md
@@ -1,0 +1,291 @@
+# ACP Ecosystem Survey
+
+Researcher: `acp-ecosystem` (team `acp-research`, task #2)
+Date: 2026-04-25
+
+## TL;DR
+
+- ACP (Agent Client Protocol) is Zed's open JSON-RPC-over-stdio protocol for IDE↔coding-agent communication. Spec hosted at `agentclientprotocol.com`, code at `github.com/agentclientprotocol/agent-client-protocol` (originally `zed-industries/agent-client-protocol`, since moved to its own org under Apache 2.0).
+- Latest released versions as of 2026-04-25: Rust crate `agent-client-protocol` **0.11.1** (2026-04-21), npm `@agentclientprotocol/sdk` **0.20.0** (2026-04-23), PyPI `agent-client-protocol` **0.9.0**, Kotlin/Java SDKs official. Repo release **v0.12.2** (2026-04-23).
+- Clients shipping today: Zed, JetBrains IDEs (IntelliJ/PyCharm/WebStorm, all platforms), Neovim (CodeCompanion, agentic.nvim, avante.nvim), Emacs (agent-shell), marimo notebook; in development: Eclipse, Toad, plus AionUi, Sidequery, DeepChat, Tidewave, Obsidian.
+- Agent registry launched **2026-01-28** at `cdn.agentclientprotocol.com/registry/v1/latest/registry.json` — one-click install across clients; registry currently lists **27 agents** including Claude Agent, Codex CLI, Gemini CLI, GitHub Copilot CLI, Goose, Cline, Cursor, OpenCode, Auggie, Kimi, Qwen, Mistral Vibe, Junie, Pi, Goose, Amp.
+- Transport today is **stdio + JSON-RPC 2.0**; Streamable HTTP is in draft. Client launches the agent as a subprocess; lines are newline-delimited UTF-8 JSON; stderr is free for agent logs.
+- Lifecycle: `initialize` → `session/new` (or `session/load`/`session/resume`) → `session/prompt` (loop with `session/update` notifications and optional `session/request_permission` / `session/cancel`) → response with `stopReason`.
+- Client-exposed capabilities the agent can call: `fs/read_text_file`, `fs/write_text_file`, plus the full `terminal/*` family (`create`, `output`, `wait_for_exit`, `kill`, `release`). All gated by capabilities advertised at `initialize`.
+- Speaking ACP gets you for free: rich diff review UI, terminal embedding inside tool cards, plan tracking, streaming text/tool-call updates, permission prompts, MCP server fan-out, and any-editor reach.
+- Spec vs Zed: the protocol is editor-agnostic and only *defines schema*; the multi-buffer review, hunk-level accept/reject, agent panel chrome, login flows, and slash-command UI are **Zed implementation choices**, not ACP requirements.
+
+## Clients (editor side)
+
+Sources: [zed.dev/acp](https://zed.dev/acp), [Zed external-agents docs](https://zed.dev/docs/ai/external-agents), [JetBrains AI ACP docs](https://www.jetbrains.com/help/ai-assistant/acp.html), [CodeCompanion ACP page](https://codecompanion.olimorris.dev/agent-client-protocol), [acp-progress-report](https://zed.dev/blog/acp-progress-report).
+
+| Client | Status | Notes |
+|---|---|---|
+| **Zed** | Stable; reference impl | Native ACP client (Rust). First-class agent panel: thread list, multi-buffer diff review (hunk-level accept/reject, `shift-ctrl-r`), task-list sidebar, `@-mention` files/diagnostics/symbols, slash commands, real-time agent following. External agents installed via ACP Registry. |
+| **JetBrains IDEs** (IntelliJ, PyCharm, WebStorm, etc.) | Stable | "AI Assistant supports the Agent Client Protocol (ACP), allowing you to connect external AI agents and use them in the AI Chat." Cursor agent shipped to JetBrains via ACP on 2026-03-04. |
+| **Neovim — CodeCompanion** | Stable; v17.18.0+ | Implements ACP v1; supports session/list + session/load (`/resume`), dynamic slash commands (`\command`), permission prompts, tool calls. |
+| **Neovim — agentic.nvim** | Stable | Standalone ACP-only Neovim client supporting Claude Code, Gemini, Codex, OpenCode, Cursor-agent. |
+| **Neovim — avante.nvim** | Stable | Listed in progress report as adopted. |
+| **Emacs — agent-shell** | Stable | Mentioned in Zed's progress report. |
+| **marimo** | Stable | Python notebook with ACP client. |
+| **Eclipse** | In development | Mentioned in Zed progress report. |
+| **Toad** | In development | Terminal-based ACP client (mentioned in Zed progress report). |
+| **AionUi, Sidequery, DeepChat, Tidewave, Obsidian, aizen, Web Browser (AI SDK)** | Listed | Per [zed.dev/acp](https://zed.dev/acp) editors panel — status not confirmed individually. |
+
+## Agents (agent side)
+
+Sources: live ACP registry at `https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json` (27 entries), [Zed ACP page](https://zed.dev/acp), [acp-progress-report](https://zed.dev/blog/acp-progress-report).
+
+Integration shape:
+- **Native** = the agent project itself speaks ACP (often behind a `--acp` flag).
+- **Adapter** = first-party adapter wraps the agent's SDK and translates to ACP.
+- **Wrapper** = third-party adapter wraps a non-ACP CLI.
+
+| Agent | Status | Repo / Distribution | Shape |
+|---|---|---|---|
+| **Gemini CLI** | Stable; reference impl | [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli), launch with `gemini --acp` | Native (`--acp` flag in CLI; uses ACP "proxied file system" so reads/writes go through client) |
+| **Claude Agent** (Claude Code SDK) | Stable beta | [zed-industries/claude-code-acp](https://github.com/zed-industries/claude-code-acp), npm `@zed-industries/claude-code-acp` v0.16.2 (2026-03-26); also new `@zed-industries/claude-agent-acp` | Adapter (wraps Claude Code SDK; Apache-2.0; vendored Claude Code CLI) |
+| **Codex CLI** (OpenAI) | Stable | `codex-acp` (auto-installed by Zed v0.208+); [openai/codex](https://github.com/openai/codex) | Adapter |
+| **GitHub Copilot CLI** | Stable | Registry: `copilot-cli` | Native via Copilot CLI |
+| **Cursor** | Stable | Registry entry; shipped to JetBrains 2026-03-04 | Adapter from Cursor team |
+| **Cline** | Stable | Registry entry | Native |
+| **Goose** (Block/Square) | Stable | [block/goose](https://github.com/block/goose); Apache-2.0; AAIF inaugural project | Native (Goose works as ACP server **and** can use other ACP agents as providers) |
+| **OpenCode** | Stable | [sst/opencode](https://github.com/sst/opencode) | Native |
+| **Auggie CLI** (Augment Code) | Stable | npm `@augmentcode/auggie@0.24.0` with `--acp` | Native |
+| **Kimi CLI** (Moonshot) | Stable | Registry entry | Native |
+| **Qwen Code** (Alibaba) | Stable | Registry entry | Native |
+| **Mistral Vibe** | Stable | Registry entry | Native |
+| **JetBrains Junie** | Stable | Registry entry | Native (JetBrains-built) |
+| **Amp** | Stable | [tao12345666333/amp-acp](https://github.com/tao12345666333/amp-acp) v0.7.0 | Wrapper (community ACP wrapper for Amp) |
+| **Autohand Code, Codebuddy Code, Corust, crow-cli, DeepAgents, Factory Droid, fast-agent, Kiro CLI, Kilo, Minion Code, Nova, Pi, Qoder CLI, Stakpak, OpenHands, Docker cagent, AgentPool, Blackbox AI, Code Assistant, VT Code** | Stable (registry/listed) | See registry entries | Mix of native and wrappers |
+| **Aider** | In development | Mentioned by progress report as planned | TBD |
+
+The registry JSON also has an `extensions` key, suggesting non-agent ACP extensions are tracked too (not enumerated here).
+
+Each registry entry has fields: `id`, `name`, `version`, `description`, `repository`, `website` (optional), `authors`, `license`, `icon`, and a `distribution` block. Distribution can be either `binary.<platform>.{archive, cmd}` (signed tarballs per arch) or `npx.{package, args, env}` (Node-based agents). This is what makes one-click install work across editors.
+
+## SDK matrix
+
+| Language | Package | Latest | Repo | Examples |
+|---|---|---|---|---|
+| **Rust** | `agent-client-protocol` (crates.io) | 0.11.1 (2026-04-21) | [agentclientprotocol/rust-sdk](https://github.com/agentclientprotocol/rust-sdk) | `examples/simple_agent.rs`, `examples/yolo_one_shot_client.rs` |
+| **TypeScript** | `@agentclientprotocol/sdk` (npm) | 0.20.0 (2026-04-23) | [agentclientprotocol/typescript-sdk](https://github.com/agentclientprotocol/typescript-sdk) | `src/examples/agent.ts`, `src/examples/client.ts` |
+| **TypeScript (legacy)** | `@zed-industries/agent-client-protocol` (npm) | 0.4.5 (2025-10-10, archived) | Older Zed-namespaced package, superseded by `@agentclientprotocol/sdk` |  |
+| **Python** | `agent-client-protocol` (PyPI) | 0.9.0 | [agentclientprotocol/python-sdk](https://github.com/agentclientprotocol/python-sdk) | `examples/agent.py`, `client.py`, `duet.py`, `echo_agent.py`, `gemini.py` |
+| **Kotlin / JVM** | `acp-kotlin` | (per repo) | [agentclientprotocol/kotlin-sdk](https://github.com/agentclientprotocol/kotlin-sdk) | `samples/kotlin-acp-client-sample/` |
+| **Java** | `java-sdk` | (per repo) | [agentclientprotocol/java-sdk](https://github.com/agentclientprotocol/java-sdk) | `examples/` |
+| **Go** | not found | — | — | — |
+
+Cumulative crates.io downloads: 1.4M for the Rust crate (it is pulled in by Zed and the Claude Code adapter, among others).
+
+## Protocol architecture
+
+Source: [protocol docs (mdx)](https://github.com/agentclientprotocol/agent-client-protocol/tree/main/docs/protocol) — covers `initialization`, `session-setup`, `prompt-turn`, `tool-calls`, `agent-plan`, `file-system`, `terminals`, `transports`, `content`, `error`, `extensibility`, `slash-commands`, `session-modes`, `session-list`, `session-config-options`, `schema`.
+
+### Transport
+- **stdio** is the only fully-spec'd transport today: client launches the agent as a subprocess, JSON-RPC frames are newline-delimited UTF-8 on stdin/stdout, agent may use stderr for free-form logs. Client must not write anything else to agent's stdin; agent must not write anything else to stdout.
+- **Streamable HTTP** is a draft.
+- Custom transports allowed as long as JSON-RPC framing is preserved.
+
+### Lifecycle (each step is JSON-RPC unless noted)
+1. `initialize` (request) — exchanges `protocolVersion`, `clientCapabilities` (`fs.readTextFile`, `fs.writeTextFile`, `terminal`), `agentCapabilities` (`loadSession`, `promptCapabilities.{image,audio,embeddedContext}`, `mcpCapabilities.{http,sse}`), `clientInfo` / `agentInfo`, `authMethods`. Capabilities omitted = unsupported. Backward-compatible additions go via capabilities, not version bumps.
+2. `authenticate` (request, optional) — runs the chosen auth method.
+3. `session/new` (request) — `cwd` + list of `mcpServers` (stdio/HTTP/SSE) → returns `sessionId`. Agent connects to the listed MCP servers as part of session boot.
+4. `session/load` (request, optional, if `loadSession`) — replays history as `session/update` notifications then resolves.
+5. `session/resume` (request, optional, if `sessionCapabilities.resume`) — reconnect without replay.
+6. `session/prompt` (request) — `prompt: ContentBlock[]` (text, image, audio, resource, resource_link). Agent streams `session/update` notifications during the turn.
+7. `session/update` (notification, agent → client) — `update.sessionUpdate` ∈ `plan` | `agent_message_chunk` | `user_message_chunk` (during replay) | `tool_call` | `tool_call_update`.
+8. `session/request_permission` (request, agent → client) — agent asks before destructive actions; client returns `outcome: Selected{option_id}` or `Cancelled`.
+9. `session/cancel` (notification, client → agent) — abort current turn; agent must respond to the prompt request with `stopReason: "cancelled"`.
+10. Prompt response — `stopReason` (`end_turn`, `cancelled`, etc.).
+
+### Agent → Client (gated by client capabilities)
+- `fs/read_text_file` `{sessionId, path, line?, limit?}` → text content. All paths are absolute. 1-based line numbers.
+- `fs/write_text_file` `{sessionId, path, content}` (full content overwrite — no diff format on the wire; diffs are rendered from `oldText`/`newText` in tool-call notifications).
+- `terminal/create` `{sessionId, command, args, env, cwd, outputByteLimit}` → `terminalId`. Returns immediately — command runs in background.
+- `terminal/output` → `{output, truncated, exitStatus?}`.
+- `terminal/wait_for_exit` → `{exitCode?, signal?}`.
+- `terminal/kill` — terminate process, terminal stays valid for output retrieval.
+- `terminal/release` — required cleanup once agent is done.
+- Terminals can be **embedded into tool calls** by adding `{type: "terminal", terminalId}` into the tool-call `content`; the client renders live output and continues to display it after release.
+
+### Tool-call schema (the heart of agent UX)
+Each `tool_call` notification has:
+- `toolCallId`, `title`, `kind` (`read | edit | delete | move | search | execute | think | fetch | other`),
+- `status` (`pending | in_progress | completed | failed`),
+- `content[]` — `{type: content, ...}` blocks **or** `{type: diff, path, oldText, newText}` blocks **or** `{type: terminal, terminalId}` blocks,
+- `locations[]` (`{path, line?}`) — files touched, used by Zed for "agent following",
+- `rawInput`, `rawOutput`.
+
+Updates use the same payload via `tool_call_update` (only changed fields needed). This is what powers Zed's hunk-level diff review and live terminal cards in tool cards.
+
+### Plan schema
+- `update.sessionUpdate = "plan"` with full `entries[]` each turn.
+- Entry: `{content, priority: high|medium|low, status: pending|in_progress|completed}`.
+- Agent **MUST** send the complete plan every update (replace, not patch).
+
+### Permission request schema
+- `session/request_permission` (request from agent to client). Request includes the proposed `tool_call` and `options[]` like `{option_id, name, kind: "allow_once"|"allow_always"|"reject_once"|"reject_always"}`. Response: `{outcome: {Selected: {option_id}}}` or `{outcome: "Cancelled"}`.
+- (Permission docs page returned 404 at the time of fetch; schema confirmed via `yolo_one_shot_client.rs` which auto-selects `request.options.first().option_id`.)
+
+## Minimal Rust ACP **agent**
+
+From [agentclientprotocol/rust-sdk: src/agent-client-protocol/examples/simple_agent.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/simple_agent.rs):
+
+```rust
+use agent_client_protocol::schema::{AgentCapabilities, InitializeRequest, InitializeResponse};
+use agent_client_protocol::{Agent, Client, ConnectionTo, Dispatch, Result};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    Agent
+        .builder()
+        .name("my-agent")
+        .on_receive_request(
+            async move |initialize: InitializeRequest, responder, _connection| {
+                responder.respond(
+                    InitializeResponse::new(initialize.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new()),
+                )
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_dispatch(
+            async move |message: Dispatch, cx: ConnectionTo<Client>| {
+                message.respond_with_error(
+                    agent_client_protocol::util::internal_error("TODO"), cx)
+            },
+            agent_client_protocol::on_receive_dispatch!(),
+        )
+        .connect_to(agent_client_protocol::ByteStreams::new(
+            tokio::io::stdout().compat_write(),
+            tokio::io::stdin().compat(),
+        ))
+        .await
+}
+```
+
+Highlights: builder API, `ByteStreams` over stdio, capabilities returned in `initialize`, all other messages handled by an `on_receive_dispatch` fallback. Real agents replace the fallback with handlers for `session/new`, `session/prompt`, etc.
+
+## Minimal Rust ACP **client**
+
+From [agentclientprotocol/rust-sdk: src/agent-client-protocol/examples/yolo_one_shot_client.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/yolo_one_shot_client.rs) (abridged — full file is ~5.8 KB):
+
+```rust
+// Spawn the agent subprocess
+let mut cmd = tokio::process::Command::new(&command);
+cmd.args(&args).stdin(Stdio::piped()).stdout(Stdio::piped());
+let mut child = cmd.spawn()?;
+
+let transport = agent_client_protocol::ByteStreams::new(
+    child.stdin.take().unwrap().compat_write(),
+    child.stdout.take().unwrap().compat(),
+);
+
+Client.builder()
+    .on_receive_notification(
+        async move |notification: SessionNotification, _cx| {
+            println!("{:?}", notification.update); // plan / tool_call / message_chunk
+            Ok(())
+        },
+        agent_client_protocol::on_receive_notification!(),
+    )
+    .on_receive_request(
+        async move |request: RequestPermissionRequest, responder, _conn| {
+            // YOLO: auto-approve first option
+            let id = request.options.first().map(|o| o.option_id.clone());
+            responder.respond(RequestPermissionResponse::new(
+                RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(id.unwrap())),
+            ))
+        },
+        agent_client_protocol::on_receive_request!(),
+    )
+    .connect_with(transport, |conn: ConnectionTo<Agent>| async move {
+        conn.send_request(InitializeRequest::new(ProtocolVersion::V1)).block_task().await?;
+        let s = conn.send_request(NewSessionRequest::new(std::env::current_dir()?)).block_task().await?;
+        let resp = conn.send_request(PromptRequest::new(
+            s.session_id.clone(),
+            vec![ContentBlock::Text(TextContent::new(cli.prompt))],
+        )).block_task().await?;
+        eprintln!("Stop reason: {:?}", resp.stop_reason);
+        Ok(())
+    })
+    .await?;
+```
+
+Highlights: spawn agent → wrap stdio in `ByteStreams` → register notification handler (text/tool_call/plan rendering) and permission handler → drive `initialize`/`session/new`/`session/prompt` and read `stopReason`.
+
+## UX patterns observed in Zed
+
+Sources: [agent panel docs](https://zed.dev/docs/ai/agent-panel), [external-agents docs](https://zed.dev/docs/ai/external-agents), [claude-code-via-acp blog post](https://zed.dev/blog/claude-code-via-acp), [bring-your-own-agent blog](https://zed.dev/blog/bring-your-own-agent-to-zed). No screenshot URLs were directly returned, but the page `https://zed.dev/acp` shows an image labeled "Multiple external agents in Zed made available by ACP".
+
+| Pattern | How Zed renders it from ACP messages |
+|---|---|
+| **Thread management** | Agent panel sidebar shows running threads. New thread per `session/new`. `+` button picks agent type (Gemini / Claude / Codex / external). |
+| **Streaming chat** | `agent_message_chunk` content is appended live. Zed supports markdown, code blocks, and citations from text content blocks. |
+| **Plan / task list** | `update.sessionUpdate = "plan"` renders as a checkable task list in the sidebar with priority colours and live `pending → in_progress → completed` transitions. |
+| **Tool call cards** | Each `tool_call` is a collapsible card with the kind icon, title, and content. `kind` decides icon (e.g. `edit`, `read`, `execute`). Status pill animates while `in_progress`. |
+| **Diff preview** | `content[].type = "diff"` → multi-buffer diff view with **per-hunk accept/reject** and full syntax highlighting + LSP. Setting `expand_edit_card` controls inline-vs-collapsed display. `Review Changes` (shift-ctrl-r) opens a single multi-buffer with the full set of pending edits. |
+| **Terminal embedding** | `content[].type = "terminal"` with a `terminalId` → live tail of `terminal/output` inside the tool card; output keeps rendering after `terminal/release`. |
+| **Permission prompts** | `session/request_permission` becomes an inline prompt under the tool card with the agent's options ("Allow once", "Allow always for this tool", "Reject"). User selection becomes the `outcome.Selected.option_id`. |
+| **`@-mentions`** | Editor side: client expands `@file`, `@diagnostics`, `@symbol` etc. into `ContentBlock::Resource` / `ContentBlock::ResourceLink` blocks before sending the prompt — agent gets typed context, not raw text. |
+| **Slash commands** | Agents declare slash commands; client autocompletes and translates them before sending the prompt. |
+| **Auth** | Adapter handles login (OAuth, API key) before turning into ACP; Zed renders an inline "Sign in" button when the agent surfaces it via `authMethods`. |
+| **Agent following** | When a tool call sets `locations[]`, Zed jumps the editor to that file/line as the tool runs — gives the user real-time "where the agent is looking now". |
+| **Multiple agents in one client** | Each session is independent; Zed lets users keep parallel threads with different agents. Permission/profile settings only apply to Zed's first-party agent — external agents get runtime prompts only. |
+
+Documented gaps for external agents in Zed: editing past messages, resuming threads from history, checkpointing, profile-level tool permissions, token usage display.
+
+## What you get for free by speaking ACP
+
+If a client implements ACP, every registry agent ships these capabilities to the client without per-agent code:
+
+1. **Streaming chat with rich content blocks** — text, image, audio, resource (embedded), resource_link.
+2. **Plan tracking UI** — pending/in-progress/completed task list with priorities.
+3. **Tool-call lifecycle** — pending → in_progress → completed/failed with structured `kind`-based icons.
+4. **Diff preview** — agent emits `{oldText, newText, path}`; client renders with whatever editor it already has.
+5. **Permission gating** — single in-protocol pattern for "ask before run".
+6. **Terminal embedding** — agent runs commands through the client's terminal infra; output auto-streams into the tool card.
+7. **MCP fan-out** — `session/new` accepts MCP servers; agent connects on session boot, so MCP tools the user already configured work for any ACP agent.
+8. **Slash commands & session resume** — uniform API; client gets per-agent commands and history support without ad-hoc plumbing.
+9. **Subprocess isolation** — agent crashes don't crash the client; updates flow purely over stdio JSON.
+10. **One-click distribution** — joining the registry means becoming installable in Zed, JetBrains IDEs, and every other registry-aware client without per-IDE work.
+
+## What you'd have to build (gaps a client must fill)
+
+- **Subprocess lifecycle**: spawning, environment, cwd, signals, restart, log capture from stderr.
+- **stdio framing**: newline-delimited JSON-RPC parser/writer (or use the SDK).
+- **Capability advertising**: deciding which `clientCapabilities` you'll honor (`fs/*`, `terminal`) and implementing the corresponding handlers safely.
+- **File-system handlers**: serving `fs/read_text_file` / `fs/write_text_file` calls — typically against the project workspace, with an undo/checkpoint layer (ACP itself defines no transactions).
+- **Terminal infra**: PTY, output buffering with byte limits, cancellation, embedding into UI cards.
+- **Diff / multi-buffer review UI**: ACP gives you `(path, oldText, newText)`; the multi-buffer hunk-level reviewer is a UI you build (Zed has an unusually good one).
+- **Permission UX**: rendering `session/request_permission` and routing the outcome.
+- **Agent picker / registry**: fetch `cdn.agentclientprotocol.com/registry/v1/latest/registry.json`, install via `npx` or signed binary, configure auth.
+- **Session persistence**: ACP supports `loadSession`/`resume` but the client decides how it stores `sessionId`s and whether it replays.
+- **Auth**: plain `authenticate` request; the actual login UX (OAuth flow, API key entry) is not in scope.
+- **MCP server list**: collecting MCP server configs from user prefs and forwarding them in `session/new`.
+- **Network/transport beyond stdio**: if you want remote agents, you implement Streamable HTTP yourself (still draft) or a custom transport.
+
+## Notes specific to zremote
+
+- **Remote agent execution**: ACP today is stdio-only; an agent process running on a remote host can't directly speak ACP to a local Zed without a tunnel. zremote's existing agent ↔ server WebSocket already provides exactly that bidirectional channel — wrapping ACP frames inside it would let the GUI act as an ACP client for any agent process running on any zremote host.
+- **Terminal mapping**: zremote already has a PTY/terminal subsystem with byte-limited buffers — that aligns 1:1 with `terminal/create`/`terminal/output`. The agent host could implement `terminal/*` as thin shims over zremote's existing PTY service.
+- **Filesystem mapping**: zremote runs the agent on the remote host, so `fs/read_text_file` would naturally hit the **remote** filesystem. That's exactly what users want when the agent is running where the project lives — no need for sshfs.
+- **Agent picker**: pulling the registry JSON gives zremote a free catalog of installable coding agents per host, with binary or `npx` distribution metadata already present.
+- **GUI parity**: GPUI desktop app would need to grow tool-call cards, plan list, multi-buffer diff review, terminal embedding, and permission prompts to match Zed's UX — these are non-trivial UI builds but reusable across all ACP agents.
+
+## Sources
+
+- [agentclientprotocol.com](https://agentclientprotocol.com)
+- [github.com/agentclientprotocol/agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol) (formerly [zed-industries/agent-client-protocol](https://github.com/zed-industries/agent-client-protocol))
+- Protocol docs (mdx): [initialization](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/initialization.mdx) · [session-setup](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/session-setup.mdx) · [prompt-turn](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/prompt-turn.mdx) · [tool-calls](https://agentclientprotocol.com/protocol/tool-calls) · [agent-plan](https://agentclientprotocol.com/protocol/agent-plan) · [file-system](https://agentclientprotocol.com/protocol/file-system) · [terminals](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/terminals.mdx) · [transports](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/transports.mdx)
+- SDKs: [Rust](https://github.com/agentclientprotocol/rust-sdk) · [TypeScript](https://github.com/agentclientprotocol/typescript-sdk) · [Python](https://github.com/agentclientprotocol/python-sdk) · [Kotlin](https://github.com/agentclientprotocol/kotlin-sdk) · [Java](https://github.com/agentclientprotocol/java-sdk)
+- Examples: [Rust simple_agent.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/simple_agent.rs) · [Rust yolo_one_shot_client.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/yolo_one_shot_client.rs) · [Python echo_agent.py](https://github.com/agentclientprotocol/python-sdk/blob/main/examples/echo_agent.py) · [TS agent.ts](https://github.com/agentclientprotocol/typescript-sdk/blob/main/src/examples/agent.ts)
+- Zed: [zed.dev/acp](https://zed.dev/acp) · [docs/ai/external-agents](https://zed.dev/docs/ai/external-agents) · [docs/ai/agent-panel](https://zed.dev/docs/ai/agent-panel) · [blog/acp-registry](https://zed.dev/blog/acp-registry) · [blog/bring-your-own-agent-to-zed](https://zed.dev/blog/bring-your-own-agent-to-zed) · [blog/claude-code-via-acp](https://zed.dev/blog/claude-code-via-acp) · [blog/acp-progress-report](https://zed.dev/blog/acp-progress-report) · [blog/jetbrains-on-acp](https://zed.dev/blog/jetbrains-on-acp)
+- JetBrains: [jetbrains.com/acp](https://www.jetbrains.com/acp/) · [help/ai-assistant/acp](https://www.jetbrains.com/help/ai-assistant/acp.html) · [blog/acp-agent-registry](https://blog.jetbrains.com/ai/2026/01/acp-agent-registry/) · [blog/koog-x-acp](https://blog.jetbrains.com/ai/2026/02/koog-x-acp-connect-an-agent-to-your-ide-and-more/)
+- Agents: [Claude adapter @zed-industries/claude-code-acp](https://www.npmjs.com/package/@zed-industries/claude-code-acp) · [Claude adapter repo](https://github.com/zed-industries/claude-agent-acp) · [community Xuanwo/acp-claude-code](https://github.com/Xuanwo/acp-claude-code) · [Gemini CLI ACP mode](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/acp-mode.md) · [OpenCode ACP](https://opencode.ai/docs/acp/) · [Goose](https://github.com/block/goose)
+- Editor clients: [CodeCompanion ACP](https://codecompanion.olimorris.dev/agent-client-protocol) · [agentic.nvim](https://github.com/carlos-algms/agentic.nvim) · [Kiro ACP CLI](https://kiro.dev/docs/cli/acp/)
+- Registry JSON: `https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json`
+- Crates.io API: [agent-client-protocol](https://crates.io/api/v1/crates/agent-client-protocol)
+- npm: [@agentclientprotocol/sdk](https://www.npmjs.com/package/@agentclientprotocol/sdk) · [@zed-industries/claude-code-acp](https://www.npmjs.com/package/@zed-industries/claude-code-acp)

--- a/docs/research/acp-rust-reuse.md
+++ b/docs/research/acp-rust-reuse.md
@@ -1,0 +1,541 @@
+# ACP Rust reuse — what to depend on, what to vendor, what to build
+
+**Date:** 2026-04-25
+**Builds on:** [`README.md`](./README.md), [`acp-spec.md`](./acp-spec.md), [`acp-ecosystem.md`](./acp-ecosystem.md), [`driver-architecture.md`](./driver-architecture.md), [`zremote-acp-integration-points.md`](./zremote-acp-integration-points.md), [`rfc-010-session-drivers-and-acp.md`](../rfc/rfc-010-session-drivers-and-acp.md)
+**Scope:** Code-level deep dive into the Rust ACP SDK family and Zed's open-source agent code, with a build-vs-depend-vs-vendor classification for every load-bearing work item in RFC-010.
+
+---
+
+## 1. TL;DR
+
+- **Depend, don't build, the JSON-RPC connection.** `agent-client-protocol = "=0.11.1"` ships the full Client/Agent/Proxy/Conductor builder, JSON-RPC dispatcher, request/response router, dynamic handler chain, session machinery (`SessionBuilder`, `ActiveSession`), and protocol types. Pin Zed's exact version (`=0.11.1`) and use the `unstable` feature group.
+- **Depend on `agent-client-protocol-tokio = "=0.11.1"`** for child-process spawn + line-framed stdio + stderr capture + kill-on-drop. It already includes `AcpAgent::zed_claude_code()` (npx invocation), `AcpAgent::zed_codex()`, `AcpAgent::google_gemini()`, plus `from_str` parsing of either bash command or JSON config. **This deletes ~250 lines from RFC-010 P2's plan** (subprocess plumbing, stderr task, child guard, ChildGuard wrapper).
+- **Skip `agent-client-protocol-test`.** It is `publish = false` (verified against crates.io: HTTP 404) and contains only mock types for SDK doctests, not a parity-test harness. RFC-010 P0's parity testing must be **built** by us against captured PTY traces — there is no shortcut.
+- **Skip `agent-client-protocol-conductor` for runtime use** but read `cookbook::running_proxies_with_conductor` and `concepts::proxies` for inspiration. Conductor wraps messages in a `_proxy/successor/*` envelope that is *not* compatible with talking directly to an agent — irrelevant for our agent-side driver use case.
+- **Defer `agent-client-protocol-rmcp`** unless we want to expose ZRemote's knowledge MCP server *to* the ACP agent through the SDK rather than through ACP's `mcp_servers` field on `NewSessionRequest`. RFC-010 §6.3 already wires this through MCP-by-config; the `-rmcp` crate is for *building* MCP servers in Rust, not for forwarding existing ones. Not in P2/P3 scope.
+- **Vendor (with attribution) Zed's `handle_session_update` translator shape and `AgentThreadEntry` data model** from `zed-industries/zed`'s `crates/acp_thread/` (Apache-2.0). The match arms in `acp_thread.rs:1428-1504` are a complete, tested mapping from `acp::SessionUpdate` to per-session GUI state. Strip GPUI-specific types (Markdown entity, Diff entity, Terminal entity), keep the structure.
+- **Build, no avoidable shortcut**: the diff-review widget (P4), the ACP→ZRemote canonical event translator (the *interface* between SDK and our `LoopStateUpdate`/`ExecutionNode`), the path-validating `fs/*` sandbox, the `terminalId` namespace + ring buffer for `terminal/*`, and the registry-fetch + agent-install machinery. Zed solves these but coupled to its workspace abstraction.
+- **The `claude-agent-acp` adapter has been renamed twice.** SDK code references `@zed-industries/claude-code-acp` (deprecated), npm now hosts `@zed-industries/claude-agent-acp`, and the canonical home is `@agentclientprotocol/claude-agent-acp@0.31.0`. RFC-010 P2 should pin `@agentclientprotocol/claude-agent-acp` and document the rename history. This single fact is a P2 risk item and was not in earlier research.
+
+---
+
+## 2. Crate-by-crate assessment of the rust-sdk family
+
+The workspace at `agentclientprotocol/rust-sdk` (Apache-2.0) ships nine crates. Source: `/tmp/rust-sdk/Cargo.toml:1-18`.
+
+### 2.1 `agent-client-protocol = "=0.11.1"` — **DEPEND**
+
+The core SDK. Re-exports `agent-client-protocol-schema` (which is what 0.12.x is — the schema crate, separately versioned).
+
+**What it gives us:**
+- All ACP message types (`InitializeRequest`, `NewSessionRequest`, `PromptRequest`, `SessionNotification`, `RequestPermissionRequest`, `CreateTerminalRequest`, all `fs/*` requests, `Plan`, `ToolCall`, `ContentBlock`, `StopReason`, etc.) — see `agent-client-protocol/src/lib.rs:130-138` for the public re-exports and `agent-client-protocol-schema-0.12.2/src/client.rs:84-115` for the `SessionUpdate` enum.
+- `Client.builder()` / `Agent.builder()` / `Proxy.builder()` / `Conductor.builder()` — fluent connection setup with `on_receive_request`, `on_receive_notification`, `on_receive_dispatch`. See `agent-client-protocol/src/lib.rs:113-118` and `cookbook::connecting_as_client`.
+- `ConnectTo<Role>` trait — abstracts over the transport. `AcpAgent` (subprocess) and `Stdio` (this process's own stdio) both implement it. We can implement it for our own transport if needed (e.g., to relay over our WS tunnel — though RFC-010 §3.5 explicitly says we don't).
+- `SessionBuilder` / `ActiveSession` — high-level API for `session/new` + `session/prompt` + reading `session/update` notifications. `ActiveSession::send_prompt()`, `read_update()`, `read_to_string()`. See `agent-client-protocol/src/session.rs:559-614`.
+- `SentRequest` with two consumption modes: `block_task()` (`.await` inside a spawned task) and `on_receiving_result(callback)` (callback fires when response arrives, blocking the dispatch loop briefly). Zed wraps both into a single `into_foreground_future` helper at `zed/crates/agent_servers/src/acp.rs:214-229` — recommended pattern.
+- All cargo features for "stable in spec, gated as unstable in SDK" methods: `unstable_session_resume`, `unstable_session_close`, `unstable_session_fork`, `unstable_session_model`, `unstable_session_additional_directories`, etc. Source: `rust-sdk/src/agent-client-protocol/Cargo.toml:18-39`.
+
+**Ergonomics observations:**
+- The builder uses `async closure` extensively. The macros `on_receive_request!()`, `on_receive_notification!()`, `on_receive_dispatch!()` are required because `return-type notation` is not stabilized — see `agent-client-protocol/src/lib.rs:151-209`. Mildly ugly, but stable Rust 2024.
+- `block_task()` deadlocks if used inside a handler. Comment at `cookbook::connecting_as_client::block_task` and at `zed/crates/agent_servers/src/acp.rs:200-213` documents this carefully. Use `on_receiving_result` from within handlers.
+- Zed pins `=0.11.1` with the full `unstable` feature group. RFC-010 §6.13 already plans the same. **Confirmed correct.**
+
+**Recommendation: DEPEND. Pin `=0.11.1` (exact), `features = ["unstable"]`.** Maps to RFC-010 P2 line "Pull in `agent-client-protocol = "=0.11.1"` with `unstable_session_resume` and `unstable_session_close`" — the actual feature is just `unstable` which forwards all flags.
+
+### 2.2 `agent-client-protocol-schema = "=0.12.2"` — **TRANSITIVE**
+
+The schema-only types. The core SDK depends on it; no need to add it directly. Note version skew: schema is 0.12.x while SDK is 0.11.x.
+
+**What's in it (Source: `/tmp/acp-schema/agent-client-protocol-schema-0.12.2/src/*`):**
+- `agent.rs` (schema for agent-side requests/notifications)
+- `client.rs` (`SessionUpdate` enum at line 84, `CurrentModeUpdate`, `ConfigOptionUpdate`, `SessionInfoUpdate`, `UsageUpdate`)
+- `tool_call.rs` (674 lines — all tool call shapes including diffs)
+- `plan.rs` (147 lines — `Plan`, `PlanEntry`)
+- `content.rs`, `elicitation.rs`, `error.rs`, `nes.rs` (next edit suggestion), `protocol_level.rs`, `rpc.rs`, `version.rs`
+
+The full `SessionUpdate` enum (file `client.rs:84-115`) lists every variant we will translate from in our driver. **Goose uses this crate without the full SDK** (Source: `/tmp/goose-block/crates/goose/Cargo.toml:149`) because they need only types. We don't follow that path because we want the connection machinery too.
+
+**Recommendation: transitive only. Don't add to our `Cargo.toml`.**
+
+### 2.3 `agent-client-protocol-tokio = "=0.11.1"` — **DEPEND**
+
+The crate that buys us the most engineering. Source: `/tmp/rust-sdk/src/agent-client-protocol-tokio/src/{lib.rs,acp_agent.rs}`.
+
+**What it gives us:**
+- `AcpAgent` — wraps an MCP-style stdio config (`McpServerStdio`). Implements `ConnectTo<Client>` and `ConnectTo<Conductor>`. Spawning, stderr-tee, stdin write-line, EOF handling, `select!` between protocol future and child-exit are all handled (`acp_agent.rs:280-371`).
+- `AcpAgent::from_str("python my_agent.py")` and `AcpAgent::from_str(json_config)` parse either form (`acp_agent.rs:471-498`).
+- `AcpAgent::from_args(["RUST_LOG=debug", "cargo", "run", "-p", "my-crate"])` parses leading `K=V` as env (`acp_agent.rs:392-443`).
+- Convenience constructors:
+  - `AcpAgent::zed_claude_code()` → `npx -y @zed-industries/claude-code-acp@latest` (deprecated package name; see §5)
+  - `AcpAgent::zed_codex()` → `npx -y @zed-industries/codex-acp@latest`
+  - `AcpAgent::google_gemini()` → `npx -y -- @google/gemini-cli@latest --experimental-acp`
+- `with_debug(callback)` — taps every line in/out + every stderr line. Maps directly to RFC-010's "agent stderr surfaced as banner" requirement (P2 §4.5).
+- `ChildGuard` — wraps the child so dropping the connection kills the process (`acp_agent.rs:225-237`). Solves RFC-010 risk #6 (server-mode child management).
+- `Stdio` (`lib.rs:14-104`) — for the agent-side case where *we* are the agent on stdio. Not relevant to v1 (case B from earlier research, deferred).
+
+**Ergonomics observations:**
+- The convenience constructors hardcode the deprecated `claude-code-acp` package. **We must build our own** with `@agentclientprotocol/claude-agent-acp`. Use `AcpAgent::from_str("npx -y @agentclientprotocol/claude-agent-acp@latest")` instead, with a fallback to `@zed-industries/claude-agent-acp` for environments stuck on the older name.
+- The crate doesn't surface `child.id()` or `wait()` directly — `monitor_child` is internal (`acp_agent.rs:243-268`). For our health-check / "agent crashed" UI banner (RFC-010 §4.5), we'd want the exit status reactively. This is a tiny gap; we either fork-and-PR upstream or wrap with our own `Command` + their connection logic.
+
+**Recommendation: DEPEND. Use `AcpAgent::from_str(...).with_debug(|line, dir| ...)`.** Add this to RFC-010 P2 as the spawn primitive and budget zero engineering for child-process plumbing.
+
+### 2.4 `agent-client-protocol-conductor = "=0.11.1"` — **SKIP, study patterns**
+
+A binary + library for "proxy chains in front of an agent." Source: `/tmp/rust-sdk/src/agent-client-protocol-conductor/src/lib.rs:1-50`.
+
+**What it does:**
+```
+Editor ← stdio → Conductor → Proxy 1 → Proxy 2 → Agent
+```
+The conductor wraps each message toward the agent in a `_proxy/successor/*` envelope (`SuccessorMessage`), so proxies can intercept/transform. The agent is unaware. **Direct connection to an agent through the conductor's proxy protocol does NOT work** — see `cookbook::running_proxies_with_conductor` line 838: *"If you connected directly to an agent, your proxy would send `SuccessorMessage` envelopes that the agent doesn't understand."*
+
+**Why it's wrong for us:** Our use case is the inverse. We want a *client* talking to a single agent. We are not building a proxy chain. The conductor is for cases like "add Sparkle embodiment + custom tools to any agent" (cookbook example).
+
+**Could it serve our `Server → Agent` tunnel?** No. Our tunneling goal (RFC-010 §3.5) is *"don't tunnel raw ACP frames at all — translate to canonical events."* The conductor solves a different problem: tunneling *raw ACP* with proxy-chain semantics. Adopting it would defeat the canonical-event design.
+
+**Recommendation: SKIP for runtime. Read `concepts::proxies` once for vocabulary.**
+
+### 2.5 `agent-client-protocol-rmcp = "=0.11.1"` — **DEFER**
+
+Glue between `agent-client-protocol::mcp_server::McpServer` and `rmcp` (the Model Context Protocol SDK). Source: `/tmp/rust-sdk/src/agent-client-protocol-rmcp/Cargo.toml`.
+
+**What it does:** `McpServerExt::from_rmcp(name, factory)` lets you wrap an existing rmcp server as an ACP MCP server (cookbook §`global_mcp_server` shows the example). Used when *you* are the proxy or agent and want to expose Rust MCP tools through the ACP protocol's `_meta.symposium` MCP-server registration.
+
+**Why it's not P2/P3:** ZRemote's existing knowledge MCP server (`crates/zremote-agent/src/mcp/`) is already an MCP server. ACP `NewSessionRequest` carries an `mcp_servers: Vec<McpServer>` field where each entry is a stdio command, HTTP URL, or SSE URL. We forward our existing MCP server *by config* (i.e., as a separate process or HTTP endpoint), not by re-implementing it through `from_rmcp`. RFC-010 §8 open question 3 already plans this.
+
+**When it might matter:** if we ever want to embed our knowledge MCP server *as a library* inside the same Rust process as the ACP driver (no separate stdio fork). That's an optimization for later, not P3.
+
+**Recommendation: DEFER. Document path: future ZRemote consolidation could turn agent's MCP into an `rmcp::ServerHandler` and use `McpServerExt::from_rmcp`.**
+
+### 2.6 `agent-client-protocol-derive = "=0.11.0"` — **TRANSITIVE**
+
+`#[derive(JsonRpcRequest)]` etc. proc macros. Used by the core SDK. Re-exported via `agent_client_protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse}` (`lib.rs:140`). Only needed if we define *custom* JSON-RPC message types (e.g., for our own protocol extensions on `_meta`). RFC-010 doesn't plan any.
+
+**Recommendation: transitive only.**
+
+### 2.7 `agent-client-protocol-cookbook = "=0.11.1"` — **READ, don't depend**
+
+A documentation-only crate (Source: `/tmp/rust-sdk/src/agent-client-protocol-cookbook/src/lib.rs`). Every module is a long doc comment with code examples:
+
+- `one_shot_prompt` — minimal client, useful for our smoke tests.
+- `connecting_as_client` — the canonical client setup, with permission handling (lines 173-188 show the `on_receive_request` for `RequestPermissionRequest`).
+- `building_an_agent` — agent-side, not relevant in v1 (case B from research).
+- `reusable_components` — pattern for `ConnectTo` impls. Useful if we ever want our driver to be a `ConnectTo` (we don't in v1).
+- `custom_message_handlers` — `MatchDispatch` for routing. Used for proxy/server work. Not in v1 critical path.
+- `global_mcp_server`, `per_session_mcp_server`, `filtering_tools` — only useful when *we* are the proxy/agent. Not v1.
+- `running_proxies_with_conductor` — see §2.4 above.
+
+**Recommendation: read `one_shot_prompt`, `connecting_as_client` once. Don't add as a dep — it's pure docs.** The core SDK already has `examples/yolo_one_shot_client.rs` and `examples/simple_agent.rs` for runnable code.
+
+### 2.8 `agent-client-protocol-test` — **UNAVAILABLE** (publish = false)
+
+Source: `/tmp/rust-sdk/src/agent-client-protocol-test/Cargo.toml:11` — `publish = false`. Verified via crates.io API: `https://crates.io/api/v1/crates/agent-client-protocol-test` returns *crate ... does not exist*.
+
+**What's actually in it (we cannot use directly, but content matters because it tells us what *isn't* there):**
+- `MockTransport` (`lib.rs:11-17`) — panics if used; only for doctests.
+- `MyRequest`, `MyResponse`, `ProcessRequest`, `AnalyzeRequest`, etc. — mock JSON-RPC types for the cookbook examples. `lib.rs:18-90`.
+- `mcp-echo-server` and `testy` binaries — internal SDK test fixtures.
+
+**This is not a parity-test harness.** Earlier research's wishful framing of "use `agent-client-protocol-test` for P0 parity tests" doesn't pan out. We have to build P0's golden-trace replay ourselves against captured PTY+analyzer output.
+
+**Recommendation: cannot DEPEND, would need to VENDOR if we wanted any of it — but we don't, the mocks aren't useful. RFC-010 P0 testing remains a BUILD item.**
+
+### 2.9 `agent-client-protocol-trace-viewer = "=0.11.0"` — **DEFER, dev only**
+
+A binary that visualizes JSON-RPC sequence traces from the conductor. Source: `/tmp/rust-sdk/src/agent-client-protocol-trace-viewer/`. Useful as a dev tool when debugging ACP flows: pipe stderr from `with_debug` callback into a trace file, open with the viewer.
+
+**Recommendation: install as `cargo install agent-client-protocol-trace-viewer` for development; do not link as a runtime dep.**
+
+---
+
+## 3. Zed agent code walkthrough (Apache-2.0)
+
+Repo: `zed-industries/zed`. License: Apache-2.0 (top-level `LICENSE`). Branch: `main` as of 2026-04-25. Crates of interest, sparse-checked at `/tmp/zed/`:
+
+| Crate | Path | Lines | Role |
+|---|---|---|---|
+| `agent_servers` | `crates/agent_servers/src/` | acp.rs 3624; agent_servers.rs 157; custom.rs 599; e2e_tests.rs 500 | The ACP-talking-to-an-agent layer. Spawns subprocess, holds `ConnectionTo<Agent>`, forwards every inbound to a foreground GPUI dispatch queue. |
+| `acp_thread` | `crates/acp_thread/src/` | acp_thread.rs 5514; connection.rs 1029; diff.rs 454; mention.rs 808; terminal.rs 255 | Per-session UI state: list of `AgentThreadEntry`, plan, modes, models, terminals, diffs. |
+| `agent` | `crates/agent/src/` | many files, ~10k lines | Higher-level agent abstraction over `acp_thread` for the chat panel. Heavily Zed-specific (workspace, project, language registry). Skip. |
+
+Reuse implications: Apache-2.0 is **compatible** with our project — we can vendor with the required attribution (NOTICE file + license preservation per Apache-2.0 §4). Zed's code is heavily coupled to GPUI's `Entity<T>`, `Context<T>`, `Markdown`, `Diff`, `Terminal` types. **Direct copy-paste won't compile in our tree;** the structural patterns and the translator match-arms are the high-value vendor target.
+
+### 3.1 Per-session state struct
+
+`zed/crates/acp_thread/src/acp_thread.rs:1038-…` defines `AcpThread`:
+
+```rust
+pub struct AcpThread {
+    title: Option<SharedString>,
+    provisional_title: Option<...>,
+    entries: Vec<AgentThreadEntry>,           // user msgs, assistant msgs, tool calls, completed plans
+    plan: ...,                                // pending Plan
+    available_commands: Vec<acp::AvailableCommand>,
+    token_usage: Option<TokenUsage>,
+    cost: Option<SessionCost>,
+    streaming_text_buffer: ...,               // for smooth markdown streaming
+    // ... + connection handle, project ref, action log, watch channels for capabilities
+}
+```
+
+`AgentThreadEntry` enum (acp_thread.rs:172-177):
+```rust
+pub enum AgentThreadEntry {
+    UserMessage(UserMessage),
+    AssistantMessage(AssistantMessage),
+    ToolCall(ToolCall),                       // detailed shape at acp_thread.rs:247-260
+    CompletedPlan(Vec<PlanEntry>),
+}
+```
+
+`ToolCall` (acp_thread.rs:247-260) maps 1:1 to `acp::ToolCall` plus rendering caches (`label: Entity<Markdown>`, resolved file locations, raw-input markdown). For ZRemote, the rendering caches are GPUI-specific; the *logical* fields (id, kind, content, status, locations, raw_input, raw_output) match ACP's schema directly.
+
+**Mapping to RFC-010 canonical events:**
+
+| Zed `AgentThreadEntry` | RFC-010 `DriverEvent` |
+|---|---|
+| `UserMessage` | (we don't have one — user input goes through `DriverControl::send_user_input`; if we want history, add `DriverEvent::UserMessageEcho`) |
+| `AssistantMessage.chunks` | `DriverEvent::AgentMessageChunk { text }` (one event per chunk) |
+| `ToolCall` (status = `Pending`/`InProgress`) | `DriverEvent::ToolCall(ExecutionNode)` with status |
+| `ToolCall` (status = `Completed`/`Failed`) | a second `DriverEvent::ToolCall` with the updated status |
+| `CompletedPlan` | `DriverEvent::Plan(Vec<PlanEntry>)` |
+
+**Reuse implication:** ZRemote's existing `ExecutionNode` (in `crates/zremote-protocol/src/agentic.rs`) already covers the tool-call shape. **No need to vendor `ToolCall`; just translate.** The vendoring target is the *match arms* of the translator below, not the data structures.
+
+### 3.2 The translator: `handle_session_update`
+
+The single most reusable piece. `zed/crates/acp_thread/src/acp_thread.rs:1428-1504`:
+
+```rust
+pub fn handle_session_update(
+    &mut self,
+    update: acp::SessionUpdate,
+    cx: &mut Context<Self>,
+) -> Result<(), acp::Error> {
+    match update {
+        acp::SessionUpdate::UserMessageChunk(acp::ContentChunk { content, .. }) => {
+            // Optimistically dedupe against the last entry's user message
+            // (some agents echo user chunks back).
+            ...self.push_user_content_block(...)...
+        }
+        acp::SessionUpdate::AgentMessageChunk(...) => self.push_assistant_content_block(content, false, cx),
+        acp::SessionUpdate::AgentThoughtChunk(...) => self.push_assistant_content_block(content, true, cx),
+        acp::SessionUpdate::ToolCall(tool_call)            => self.upsert_tool_call(tool_call, cx)?,
+        acp::SessionUpdate::ToolCallUpdate(tool_call_update) => self.update_tool_call(tool_call_update, cx)?,
+        acp::SessionUpdate::Plan(plan)                       => self.update_plan(plan, cx),
+        acp::SessionUpdate::SessionInfoUpdate(info_update)   => /* update title with provisional logic */,
+        acp::SessionUpdate::AvailableCommandsUpdate(...)     => /* emit AvailableCommandsUpdated */,
+        acp::SessionUpdate::CurrentModeUpdate(...)           => cx.emit(AcpThreadEvent::ModeUpdated(...)),
+        acp::SessionUpdate::ConfigOptionUpdate(...)          => cx.emit(AcpThreadEvent::ConfigOptionsUpdated(...)),
+        acp::SessionUpdate::UsageUpdate(update) if cx.has_flag::<AcpBetaFeatureFlag>() => /* update token_usage */,
+        _ => {}
+    }
+    Ok(())
+}
+```
+
+The non-obvious bits worth vendoring:
+
+1. **User-chunk dedup logic** (lines 1438-1445): some agents echo user chunks back over `session/update`. Zed checks `self.entries.last().and_then(|e| e.user_message()).is_some_and(|m| m.chunks.contains(&content))` before appending. Without this, the user's prompt appears twice.
+2. **Streaming text buffer** for smooth markdown (acp_thread.rs:1573-1584). Zed buffers `AgentMessageChunk` text into a `streaming_text_buffer` and flushes on a timer/non-text update, instead of re-rendering the markdown entity on every token.
+3. **Provisional title handling** (lines 1462-1473) — a session might be in a temporary "summarizing" title state; `SessionInfoUpdate` clears it.
+4. **`UsageUpdate` is feature-flagged** behind `AcpBetaFeatureFlag` because the schema gates it on `unstable_session_usage`. We turn the cargo feature on; keep the runtime flag in our own build to avoid surprising the user.
+
+**Pre/post-handle for terminal embeds:** `zed/crates/agent_servers/src/acp.rs:3296-3451` shows that **before** dispatching to `handle_session_update`, Zed inspects `tool_call.meta.terminal_info` and creates a display-only terminal (`TerminalProviderEvent::Created`) and **after**, on `ToolCallUpdate`, it streams `terminal_output` and `terminal_exit` through the same channel. ACP doesn't yet have first-class terminal-in-tool-call schema, so the `_meta` field is the convention — **this is undocumented in the spec; only Zed's source reveals it.** RFC-010 §4.2 mentions "embedded terminals" but doesn't capture this. **P4 must replicate the meta-field convention or it won't interop with `claude-agent-acp`.**
+
+### 3.3 Connection setup and agent process management
+
+`zed/crates/agent_servers/src/acp.rs:526-902` (`AcpConnection::stdio`).
+
+**The pattern:** Zed does **not** use `AcpAgent::from_str` from the tokio crate. They build their own:
+1. Resolve the command (`AgentServerCommand`) — including remote-host rewriting via `project.remote_client()` — line 671-694.
+2. Build a `std::process::Command` via `ShellBuilder::new(&Shell::System, cfg!(windows)).non_interactive()` (line 696). This is Zed's wrapper that handles login-shell quoting, Windows quirks.
+3. Set `stdin/stdout/stderr` to `Stdio::piped()`, spawn (line 708).
+4. Tap the line-by-line reader (line 734-743) and writer (line 745-755) with their `AcpDebugLog` for inspector UI. The tap is nearly identical to `AcpAgent::with_debug` but stores a ring buffer of `MAX_DEBUG_BACKLOG_MESSAGES = 2000` parsed messages.
+5. Wrap the tapped streams in `agent_client_protocol::Lines::new(outgoing, incoming)` (line 757) — exact same primitive `AcpAgent` uses internally.
+6. Call `Client.builder()....connect_with(transport, |conn| async { connection_tx.send(conn).ok(); pending::<...>().await })` to establish the connection and surface the `ConnectionTo<Agent>` handle through a oneshot.
+7. Spawn three tasks: `io_task` (drives the connection future), `dispatch_task` (foreground worker pulling from the `Send` mpsc queue), `wait_task` (`child.status()` → emits `LoadError::Exited` to all sessions when the child dies), `stderr_task` (reads stderr, logs at `warn`, records in debug log). Lines 766-816.
+8. Send `InitializeRequest::new(ProtocolVersion::V1).client_capabilities(...).client_info(...)` via the `into_foreground_future` helper, await response, check `protocol_version >= MINIMUM_SUPPORTED_VERSION` (line 817-842).
+9. Build the `AcpConnection` struct holding **all four tasks** as `_io_task`, `_dispatch_task`, `_wait_task`, `_stderr_task` (lines 400-404). Drop = cancel.
+
+**Lessons for ZRemote:**
+- The `_io_task: Task<()>` etc. fields enforce RFC-010's "no `.detach()` for long-running work" rule. RFC-010's CLAUDE.md async-task convention matches Zed's pattern verbatim.
+- The `wait_task` that emits `LoadError::Exited` to all session threads is exactly RFC-010 §4.5 case 1 ("Agent process exits unexpectedly"). **Vendor the structure.** ZRemote's `DriverHandle` should hold its own `wait_task` and emit `DriverEvent::SessionEnded { stop_reason: ShellExit { code, signal } }` on child exit.
+- The foreground/background bridge (`enqueue_request` / `enqueue_notification` / `ForegroundWorkItem` trait at `acp.rs:276-383`) is GPUI-specific (the foreground thread is `!Send`). **Tokio is `Send`-friendly; we don't need this.** Replace with direct `tokio::sync::mpsc::Sender<DriverEvent>` calls inside SDK handlers.
+- `into_foreground_future` (acp.rs:214-229) — wraps a `SentRequest` so it can be `.await`ed from a `!Send` GPUI task. We can use `block_task()` directly inside our spawned tokio tasks. **No vendoring needed.**
+
+### 3.4 Capability advertising
+
+`zed/crates/agent_servers/src/acp.rs:817-836` shows what Zed advertises:
+
+```rust
+acp::ClientCapabilities::new()
+    .fs(acp::FileSystemCapabilities::new()
+        .read_text_file(true)
+        .write_text_file(true))
+    .terminal(true)
+    .auth(acp::AuthCapabilities::new().terminal(true))
+    .meta(acp::Meta::from_iter([
+        ("terminal_output".into(), true.into()),
+        ("terminal-auth".into(), true.into()),
+    ]))
+```
+
+**Notable:** `terminal_output` and `terminal-auth` are *meta-keys* (extension flags) Zed invented. `claude-agent-acp` checks for them. **Without these meta keys, terminal output streaming inside tool calls won't work.** This is again undocumented in the spec — read it from the source. **RFC-010 P5 must include these meta keys in our `InitializeRequest`.**
+
+### 3.5 Permission handling
+
+`zed/crates/agent_servers/src/acp.rs:594-597` registers `handle_request_permission` as the handler for `RequestPermissionRequest`. The handler enqueues onto the foreground dispatch queue, where it eventually maps to a GPUI modal. Translation pattern matches RFC-010 §3.7's plan exactly: ACP request → channel `PermissionRequest`. **No code to vendor — pattern is a one-line forward.**
+
+### 3.6 What is not reusable
+
+- `Entity<Markdown>`, `Entity<Diff>`, `Entity<Terminal>` — GPUI-specific; we use a different rendering layer.
+- `Project`, `ActionLog`, `LanguageRegistry` references — Zed's workspace model; we have project + worktree from RFC-009 instead.
+- `AcpDebugLog` (acp.rs:147-198) — interesting as a debug pane, but not core. Could be a future devtool.
+- `proxy_remaining_messages` (in `agent-client-protocol::session::ActiveSession`) — proxy use case, not ours.
+- The `pending_sessions: Rc<RefCell<HashMap<...>>>` ref-count bookkeeping for shared session loads (acp.rs:407-409, 941-1080) — we don't share sessions across windows in v1.
+
+### 3.7 License compliance for vendoring
+
+Apache-2.0 §4 requires:
+1. Carry copy of the license with redistributed source.
+2. State changes prominently in the modified files.
+3. Retain attribution notices, copyright statements, NOTICE files.
+4. If we redistribute, our NOTICE must mention the upstream NOTICE.
+
+**Practical:** add `LICENSES/Apache-2.0-zed.txt` (or extend an existing third-party-licenses file), prefix vendored files with `// Adapted from zed-industries/zed at <commit>, Apache-2.0. See LICENSES/Apache-2.0-zed.txt`. Add a workspace `NOTICE` file once we vendor *anything*.
+
+---
+
+## 4. Other Rust ACP apps
+
+### 4.1 Goose (`block/goose`) — **server, not client**
+
+| Field | Value |
+|---|---|
+| Repo | https://github.com/block/goose |
+| License | Apache-2.0 |
+| Crates | `crates/goose` (with `src/acp/` subtree), `crates/goose-acp-macros` |
+| Role | Goose ships an ACP **agent** server with HTTP and WebSocket transports — opposite direction from us. |
+| Uses SDK? | Only `agent-client-protocol-schema` (see `goose-block/crates/goose/Cargo.toml:149`). They wrote their own JSON-RPC dispatch and HTTP/WS framing. |
+| Reusable? | Their HTTP/WS transport (`crates/goose/src/acp/transport/{http.rs,websocket.rs}`) is interesting *if we ever decide to expose ZRemote-as-ACP-server* (case B from research, deferred indefinitely per RFC-010 §2 non-goals). For v1, **not reusable.** |
+| Notable | Goose's roadmap (per their discussions) is to consolidate goosed + goose-cli behind `/acp`. Validates that ACP-over-HTTP is becoming a real thing. |
+
+**Verdict:** instructive for case B, irrelevant for case A (our v1).
+
+### 4.2 `Xuanwo/acp-claude-code` — **deprecated TypeScript**
+
+Archived 2025-09-08. TypeScript. MIT-licensed. Replaced by `@zed-industries/claude-code-acp` (now also deprecated; see §5). Skip.
+
+### 4.3 Other 27 ACP-listed agents
+
+The earlier ecosystem report listed 27 agents in the registry. Cross-referencing crates.io:
+
+- `goose-acp` — **not published on crates.io** (verified: HTTP 404).
+- No `*-acp` crates on crates.io belong to any of the registry agents. They are all TypeScript adapters.
+
+**Verdict:** there is no "another Rust ACP client" to imitate beyond Zed. Goose is a Rust server; everyone else is TS/Python.
+
+---
+
+## 5. Claude Code adapter spawn cookbook
+
+Source: `/tmp/claude-agent-acp/{package.json,src/index.ts,src/acp-agent.ts}`.
+
+### 5.1 Package identity confusion
+
+The package has been renamed twice:
+
+| Name | Status |
+|---|---|
+| `@zed-industries/claude-code-acp` | **Deprecated** — last 0.16.x line. SDK's `AcpAgent::zed_claude_code()` still hardcodes this. |
+| `@zed-industries/claude-agent-acp` | **Active mirror** — second rename, npm-only. |
+| `@agentclientprotocol/claude-agent-acp` | **Canonical, active** — version 0.31.0 as of 2026-04. Repo `agentclientprotocol/claude-agent-acp`. |
+
+**For RFC-010 P2:** spawn `@agentclientprotocol/claude-agent-acp@latest`. Add a fallback to `@zed-industries/claude-agent-acp@latest` only if the canonical name fails to resolve in npm. Do **not** rely on the SDK's `AcpAgent::zed_claude_code()` — its hardcoded package is deprecated.
+
+### 5.2 Exact spawn command
+
+```bash
+npx -y @agentclientprotocol/claude-agent-acp@latest
+```
+
+Or from a Rust driver, equivalent to:
+```rust
+let agent = AcpAgent::from_str("npx -y @agentclientprotocol/claude-agent-acp@latest")?
+    .with_debug(|line, dir| { /* tee to log file */ });
+```
+
+**Required runtime:** Node.js ≥ 18 (per `package.json` deps on `@anthropic-ai/claude-agent-sdk@0.2.119`). The Anthropic SDK ships a native binary as a platform-specific optional npm dependency (`acp-agent.ts:280-283`). If `npm install --omit=optional` was used, set `CLAUDE_CODE_EXECUTABLE` to the path of the native CLI binary.
+
+### 5.3 What the adapter spawns internally
+
+`acp-agent.ts:267-295` shows the resolution chain for the underlying Claude Code CLI:
+
+1. `process.env.CLAUDE_CODE_EXECUTABLE` if set — used as-is.
+2. Otherwise, resolve `@anthropic-ai/claude-agent-sdk-{platform}-{arch}{-musl}/claude` via Node `createRequire`. Linux first tries `-musl`, falls back to glibc.
+3. Throws if not found.
+
+So the ACP adapter is *not* "Claude Code installed somewhere on PATH." It's a Node.js wrapper that ships its own copy of the Claude Code native binary as an npm optional-dep. This is good news for ZRemote: **one `npx` invocation pulls in everything.**
+
+### 5.4 Environment variables the adapter consumes
+
+Exhaustive list from `grep "process.env" src/acp-agent.ts`:
+
+| Env var | Purpose | Set by us? |
+|---|---|---|
+| `CLAUDE_CODE_EXECUTABLE` | Override the bundled native CLI path | No (let it auto-resolve) |
+| `CLAUDE_CONFIG_DIR` | Where Claude reads `.claude/` config (defaults to `$HOME/.claude`) | Pass-through if user set it |
+| `IS_SANDBOX` | Allow `bypassPermissions` mode even when running as root | No (we are not root) |
+| `NO_BROWSER`, `SSH_CONNECTION`, `SSH_CLIENT`, `SSH_TTY`, `CLAUDE_CODE_REMOTE` | Disable browser-based OAuth flow when remote | **Yes** when ZRemote is in server mode (we are remote by definition for the agent host). Set `CLAUDE_CODE_REMOTE=1`. |
+| `MAX_THINKING_TOKENS` | Numeric cap on extended thinking | Pass-through if set in profile |
+| `CLAUDE_MODEL_CONFIG` | JSON Bedrock-style model overrides | Pass-through if set in profile |
+| `ANTHROPIC_MODEL` | Force a specific model | Pass-through; per-profile setting |
+| `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS`, `ANTHROPIC_AUTH_TOKEN` | Gateway routing — set internally by adapter when its own gateway-auth config is present. **Don't override.** | No |
+
+The adapter sets `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1` for the Claude Code SDK child internally (`acp-agent.ts:1752`). We don't set this from the outside.
+
+### 5.5 MCP servers the adapter pre-configures
+
+`acp-agent.ts:1757`: `mcpServers: { ...(userProvidedOptions?.mcpServers || {}), ...mcpServers }` — so MCP servers come from two sources:
+1. `_meta.claudeCode.options.mcpServers` on the `NewSessionRequest` (set by the client).
+2. The user's local `.claude/` config file (loaded by the Claude Agent SDK itself).
+
+**For ZRemote (RFC-010 §8 open question 3):** we forward our knowledge MCP server via the `mcp_servers` field on `NewSessionRequest`. The adapter will merge it into the session.
+
+### 5.6 ACP unstable features the adapter requires
+
+The adapter is built against `@agentclientprotocol/sdk@0.20.0` (TypeScript SDK; numbering doesn't match Rust SDK). Looking at the protocol-level interactions in `acp-agent.ts`:
+
+- `session/load` and `session/resume` — supported. We must enable `unstable_session_resume` on our Rust SDK.
+- `session/cancel` — stable.
+- `session/set_mode`, `session/set_model` — used. We need `unstable_session_model`.
+- `current_mode_update` notification — stable in 0.12.x schema.
+- `_meta.terminal_output` and `_meta.terminal-auth` capability keys — required (see §3.4).
+
+**RFC-010 P2 update:** the SDK feature set is broader than just `unstable_session_resume + unstable_session_close`. Recommend `features = ["unstable"]` (the umbrella forwarding flag) — this is what Zed does.
+
+### 5.7 Failure modes
+
+| Mode | What happens | Surface to user |
+|---|---|---|
+| Auth failure (no API key + no OAuth login) | The Claude Code CLI itself returns an error on the first `session/prompt`. Adapter forwards as a `session/update` with stop reason `Error`. | Banner: "Claude Code is not authenticated. Run `claude /login` in your terminal." We have to surface stderr to detect this. |
+| Network failure | Adapter forwards the underlying SDK error. `PromptResponse.stop_reason = Error` plus an `AgentMessageChunk` containing the error text. | Same banner; offer "Retry" button. |
+| Model error / rate limit | Same path as network failure. | Same banner; suggest a different model from `session/set_model` if available. |
+| Subprocess crash | `child.exit` event fires → our `wait_task` → `LoadError::Exited` → driver emits `SessionEnded { stop_reason: ShellExit { code, signal } }`. Captured stderr is in the banner. | Banner with "Restart" action. |
+| Protocol mismatch | `InitializeResponse.protocol_version < V1` → SDK returns error from `connect_with`. | Driver reports start failure → launcher falls back to `cc-hooks` per RFC-010 §4.5 case 2. |
+
+---
+
+## 6. Reuse decision table
+
+For each work item RFC-010 calls out:
+
+| # | Work item | Verdict | Rationale |
+|---|---|---|---|
+| 1 | JSON-RPC 2.0 stdio framing (newline-delimited) | **DEPEND** | `agent-client-protocol::Lines::new(out_sink, in_stream)` + `ByteStreams` — `lib.rs:113-118`. Zero-cost; already battle-tested. |
+| 2 | Bidirectional connection + request/response router | **DEPEND** | `Client.builder().on_receive_request().on_receive_notification().connect_with(transport, ...)` — `cookbook::connecting_as_client`. Zero new code. |
+| 3 | All ACP message schema types | **DEPEND** (transitive via core SDK) | `agent_client_protocol::schema::*` re-exports `agent-client-protocol-schema = 0.12.x`. Match-arm enum already exhaustive (`#[non_exhaustive]`). |
+| 4 | Subprocess spawn + lifecycle + stderr capture | **DEPEND** | `agent-client-protocol-tokio::AcpAgent::from_str(...).with_debug(...)`. `ChildGuard` kills on drop. `monitor_child` races protocol vs exit. ~250 LoC saved. |
+| 5 | Translator: `session/update` → ZRemote `LoopStateUpdate`/`ExecutionNode`/`Plan`/`AgentMessageChunk` | **VENDOR** | The match-arm structure of Zed's `acp_thread.rs:1428-1504` is the model. Strip GPUI types; emit our canonical events. Ship as `crates/zremote-agent/src/session_driver/acp/translator.rs` with attribution header. |
+| 6 | Multi-buffer diff review widget | **BUILD** | Zed's `acp_thread::Diff` (`crates/acp_thread/src/diff.rs:454 LoC`) is GPUI Editor-coupled. Our diff renderer is GPUI-too but uses different abstractions. The *data model* (path + oldText + newText + hunks + per-hunk Accept/Reject) is the standard one — vendor that struct shape. The widget is a build. |
+| 7 | Tool-call card rendering data structures | **VENDOR shape, BUILD render** | Vendor `ToolCall { id, kind, content, status, locations, raw_input/output }` shape from acp_thread.rs:247-260. Render as GPUI element ourselves. |
+| 8 | Permission UX state machine | **DEPEND** for protocol; **BUILD** for our policy bridge | The `RequestPermissionRequest` → user-facing options flow uses SDK types (`acp::PermissionOption`, `acp::RequestPermissionOutcome`). Our bridge translates to `ChannelAgentAction::PermissionRequest` (existing). Code is ~30 LoC. |
+| 9 | Terminal byte-limit ring buffer + `terminalId` namespace | **BUILD** | ACP's `outputByteLimit` requires per-terminal byte counter wrapping. Our PTY layer (`crates/zremote-agent/src/pty/`) doesn't have this. Zed has it (`crates/acp_thread/src/terminal.rs:255 LoC` + `terminal::Terminal` from elsewhere) but it's their full terminal implementation — too big to vendor. **Build a `TerminalRingBuffer` wrapping our existing PTY in P5.** |
+| 10 | Path-validating `fs/*` sandbox | **BUILD** | Goose has `goose/src/acp/fs.rs:440 LoC` and Zed has its own. Both bind to their workspace abstraction. ZRemote's worktree root (RFC-009) is the sandbox — the validation fn is ~20 LoC of `path.canonicalize().starts_with(worktree_root)`. **Build, don't vendor.** Security-reviewer signs off. |
+| 11 | Session resume / load semantics | **DEPEND on SDK** for protocol; **BUILD** the policy | `unstable_session_resume` + `unstable_session_fork` features expose the methods. Our policy of *which* method to call when (RFC-010 §8 open Q4) is small build. |
+| 12 | ACP Registry JSON parsing + agent install | **BUILD** | The registry format (`https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json`) is documented by spec. JSON parsing is a `serde::Deserialize` derive. The npx-install side-effect machinery and signed-binary download is **not** in any SDK crate — Zed has it inside their `agent_registry_store` (not in our sparse checkout, but it's not generic-enough to vendor anyway). RFC-010 P3 ~1 day of build. |
+| 13 | Test harness for parity testing | **BUILD** | `agent-client-protocol-test` is `publish=false` and contains only doctest mocks, not a parity harness. **Build P0's golden-trace replay against captured PTY+analyzer output ourselves.** This is the same pattern we already use in `agentic/adapters/` tests — extend, don't introduce new tooling. |
+
+---
+
+## 7. RFC-010 amendments
+
+Concrete deltas to the RFC's phasing and scope. Patches to be applied during P0 review.
+
+### 7.1 §5 Phasing — effort revisions
+
+| Phase | RFC-010 estimate | Revised | Reason |
+|---|---|---|---|
+| **P0 — Driver skeleton** | M | **M** (unchanged) | Test harness still build-our-own; refactor is the bulk of work. |
+| **P1 — ClaudeHooksDriver** | S | **S** (unchanged) | Internal refactor only. |
+| **P2 — ClaudeAcpDriver** | L | **M** | Subprocess plumbing, stderr-tee, kill-on-drop, child-exit monitor, stdio framing all ship in `agent-client-protocol-tokio`. JSON-RPC dispatch ships in core. **Net: ~400 LoC saved** — only translator + handlers remain. |
+| **P3 — GenericAcpDriver + Registry** | M | **M** (unchanged) | SDK helps with transport but registry parsing + npx install + agent install policy is build. |
+| **P4 — Rich UI features** | L | **L** (unchanged) | Multi-buffer diff widget remains the largest item. Zed structures inform; we still build. |
+| **P5 — Host-side `terminal/*` and `fs/*`** | M | **M** (unchanged) | All-build. The `fs` sandbox is ~20 LoC; the `terminal/*` namespace + ring buffer is the bulk. |
+
+### 7.2 §6 Decisions — additions
+
+Add as decision **#14 (new):**
+
+> **Spawn the canonical `@agentclientprotocol/claude-agent-acp` package, not the SDK's hardcoded `claude-code-acp`.**
+> *Why:* Package was renamed twice. SDK's `AcpAgent::zed_claude_code()` points at the deprecated name. Use `AcpAgent::from_str("npx -y @agentclientprotocol/claude-agent-acp@latest")` directly. Document fallback to `@zed-industries/claude-agent-acp` in the troubleshooting docs.
+
+Add as decision **#15 (new):**
+
+> **Use `agent-client-protocol-tokio` `AcpAgent` for child-process management; do not roll our own subprocess code.**
+> *Why:* The crate handles spawn, line-framed stdio, stderr capture, kill-on-drop, child-exit race-with-protocol — battle-tested in Zed. We add `with_debug` for tee-to-logfile.
+
+Add as decision **#16 (new):**
+
+> **`features = ["unstable"]` on `agent-client-protocol`, not the per-feature opt-in.**
+> *Why:* Adapter requires `unstable_session_resume`, `unstable_session_close`, `unstable_session_fork`, `unstable_session_model`, `unstable_session_additional_directories` simultaneously. The umbrella `unstable` is what Zed uses (`zed/Cargo.toml`).
+
+### 7.3 §7 Risks — additions
+
+Add as risk **#9:**
+
+> **Adapter package rename.** The Claude Code ACP adapter has been renamed twice (`claude-code-acp` → `@zed-industries/claude-agent-acp` → `@agentclientprotocol/claude-agent-acp`). Hardcoding any name is fragile. *Mitigation:* keep the package name in profile config (`AgentProfileData.settings_json.acp_command`), with a sensible default but user-overridable.
+
+Add as risk **#10:**
+
+> **Undocumented `_meta` keys in `InitializeRequest`.** Zed advertises `meta.terminal_output = true` and `meta.terminal-auth = true`. The Claude Code adapter reads them; without them, terminal embedding inside tool calls won't work. *Mitigation:* match Zed's capability advertisement byte-for-byte (`acp.rs:817-836`); document the meta keys in the driver's source comments.
+
+Add as risk **#11:**
+
+> **`agent-client-protocol-test` is unpublished.** Earlier research assumed a parity-test harness was available. It isn't. *Mitigation:* P0's parity testing is BUILD work — capture PTY+analyzer traces during the current implementation, replay through the new `PtyDriver`, assert event-stream equality. Same pattern as `agentic/adapters/` tests, larger scope.
+
+### 7.4 §8 Open questions — partial answers
+
+- **Q3 (MCP servers in `session/new`):** Forward via `NewSessionRequest.mcp_servers` field. Adapter merges automatically (`acp-agent.ts:1757`). Recommendation stands.
+- **Q4 (Resume vs load):** SDK gates both behind `unstable_*`. The TypeScript adapter implements both. *New recommendation:* call `session/resume` for in-memory daemon-mode reconnect (no replay), `session/load` for cold-start after agent restart (full replay). Both methods need their respective unstable features enabled — covered by `features=["unstable"]`.
+- **Q5 (Auth UX):** ACP's `AuthCapabilities::new().terminal(true)` lets the adapter spawn an auth terminal back through us. Zed advertises this; we should too. P3 ships with the auth-terminal flow, no in-app OAuth in v1.
+
+### 7.5 §10 References — additions
+
+Add:
+- ACP Rust SDK: `agentclientprotocol/rust-sdk` — Apache-2.0
+- Claude Code ACP adapter: `agentclientprotocol/claude-agent-acp` — Apache-2.0
+- Goose ACP server (reference for case B, deferred): `block/goose` — Apache-2.0
+- Zed agent crates: `zed-industries/zed/crates/{agent_servers,acp_thread}` — Apache-2.0
+
+---
+
+## 8. Sources
+
+Every claim above traces to one of:
+
+1. `/tmp/rust-sdk/src/agent-client-protocol/{Cargo.toml,src/{lib.rs,session.rs}}` — core SDK, version `=0.11.1`.
+2. `/tmp/rust-sdk/src/agent-client-protocol-tokio/src/{lib.rs,acp_agent.rs}` — tokio crate, version `=0.11.1`.
+3. `/tmp/rust-sdk/src/agent-client-protocol-test/{Cargo.toml,src/lib.rs}` — `publish = false`, mock-types only.
+4. `/tmp/rust-sdk/src/agent-client-protocol-conductor/{Cargo.toml,src/lib.rs}` — `_proxy/successor/*` envelope; not for client→agent direct.
+5. `/tmp/rust-sdk/src/agent-client-protocol-cookbook/src/lib.rs` — doc-only crate; cookbook patterns.
+6. `/tmp/rust-sdk/src/agent-client-protocol-rmcp/Cargo.toml` — rmcp glue.
+7. `/tmp/acp-schema/agent-client-protocol-schema-0.12.2/src/{client.rs,tool_call.rs,plan.rs}` — schema crate (0.12.2 used by SDK 0.11.x).
+8. crates.io API: confirmed `-tokio`, `-rmcp`, `-cookbook`, `-conductor`, `agent-client-protocol-schema` are at 0.11.1/0.12.2; `-test` does not exist on crates.io.
+9. `/tmp/zed/crates/agent_servers/src/{agent_servers.rs,acp.rs,custom.rs}` — Zed's `AcpConnection`, foreground dispatch bridge, custom-agent settings, registry hooks.
+10. `/tmp/zed/crates/acp_thread/src/{acp_thread.rs,connection.rs,diff.rs,terminal.rs}` — Zed's per-session state model, `handle_session_update` translator (lines 1428-1504), terminal-meta convention (acp.rs:3296-3451).
+11. `/tmp/zed/Cargo.toml` — `agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }` confirms the pinning + feature set.
+12. `/tmp/claude-agent-acp/{package.json,src/{index.ts,acp-agent.ts,utils.ts}}` — adapter at version 0.31.0; canonical package `@agentclientprotocol/claude-agent-acp`; env vars enumerated; native CLI resolution at lines 267-295.
+13. `/tmp/goose-block/crates/goose/src/acp/{transport/{mod.rs,http.rs,websocket.rs},server.rs,fs.rs}` — Goose's HTTP/WS ACP server transport (case B reference).
+14. Web research for adapter rename history (`@zed-industries/claude-code-acp` → `@zed-industries/claude-agent-acp` → `@agentclientprotocol/claude-agent-acp`) and Goose ACP roadmap.
+
+Sources for adapter rename and ecosystem context:
+- [@zed-industries/claude-code-acp on npm](https://www.npmjs.com/package/@zed-industries/claude-code-acp) — deprecated
+- [@zed-industries/claude-agent-acp on npm](https://www.npmjs.com/package/@zed-industries/claude-agent-acp) — second-rename mirror
+- [`@agentclientprotocol/claude-agent-acp` repo](https://github.com/agentclientprotocol/claude-agent-acp) — canonical
+- [Zed docs: External Agents](https://zed.dev/docs/ai/external-agents) — refers to `claude-code-acp` (stale)
+- [Goose ACP discussion](https://github.com/block/goose/discussions/4645) — adopt-ACP roadmap
+- [Goose ACP-over-HTTP issue](https://github.com/block/goose/issues/6642) — rationale for HTTP transport
+- [Xuanwo/acp-claude-code](https://github.com/Xuanwo/acp-claude-code) — TypeScript, archived 2025-09
+- [agent-client-protocol crate docs](https://docs.rs/agent-client-protocol/0.11.1)

--- a/docs/research/acp-spec.md
+++ b/docs/research/acp-spec.md
@@ -1,0 +1,739 @@
+# Agent Client Protocol (ACP) — Specification Research
+
+> Audience: ZRemote engineering team evaluating ACP adoption.
+> Author: research agent `acp-spec` (team `acp-research`).
+> Date: 2026-04-25.
+> Sources: official spec at [agentclientprotocol.com](https://agentclientprotocol.com), reference repos `agentclientprotocol/agent-client-protocol`, `agentclientprotocol/rust-sdk`, [crates.io](https://crates.io/crates/agent-client-protocol).
+
+---
+
+## TL;DR (10 lines max)
+
+1. ACP is a **JSON-RPC 2.0** protocol between a **Client** (IDE/editor) and an **Agent** (LLM coding agent), modelled on LSP/MCP.
+2. The Client owns the UI, files, terminals, and permissions; the Agent owns the model loop and tool decisions.
+3. Default transport is **stdio with newline-delimited JSON** (no `Content-Length` headers — unlike LSP); HTTP/WebSocket is a draft RFD.
+4. Lifecycle: `initialize` → optional `authenticate` → `session/new` (or `session/load`/`session/resume`) → many `session/prompt` turns → `session/cancel`/`session/close`.
+5. Each prompt turn streams `session/update` notifications (message chunks, plan, tool_call, tool_call_update, available_commands_update, current_mode_update) and ends with a `stopReason`.
+6. Tool calls are **fully observable** — the Agent reports `tool_call`/`tool_call_update` to the Client; the Client gates side-effects via `session/request_permission`.
+7. The Client may be asked to perform host-side work for the Agent: `fs/read_text_file`, `fs/write_text_file`, `terminal/create|output|wait_for_exit|kill|release` — all gated by capabilities advertised in `initialize`.
+8. Versioning is a **single integer MAJOR**; capabilities omitted in `initialize` are treated as unsupported.
+9. Extensibility via **`_meta`** fields and **underscore-prefixed methods** (`_zed.dev/...`); reserved keys for W3C trace context (`traceparent`, `tracestate`, `baggage`).
+10. The Rust SDK ships as **`agent-client-protocol` v0.11.1** (Apache-2.0, 2026-04-21) on top of **`agent-client-protocol-schema` v0.12.2**; it uses a Role-typestate (`Client`/`Agent`/`Proxy`/`Conductor`) rather than a single trait.
+
+---
+
+## 1. Transport & Framing
+
+### 1.1 stdio (mandatory, recommended baseline)
+
+- The Client spawns the Agent as a subprocess.
+- **Wire format:** newline-delimited JSON-RPC 2.0 messages. Each message is a single JSON object terminated by `\n`. Messages **MUST NOT** contain embedded newlines.
+- Encoding: UTF-8.
+- Stdin: Client → Agent. Stdout: Agent → Client. Both directions are bidirectional JSON-RPC streams (so notifications and requests can flow either way).
+- Stderr is **reserved for logging only**; agents MAY emit free-form UTF-8 there. Clients MUST NOT parse stderr as protocol traffic.
+- Source: <https://agentclientprotocol.com/protocol/transports.md>.
+
+> **Difference from LSP:** LSP uses `Content-Length: N\r\n\r\n` framed JSON-RPC; ACP uses bare newline-delimited JSON. Simpler, but messages cannot contain raw newlines.
+>
+> **Difference from MCP:** MCP also uses newline-delimited JSON over stdio, plus optional Streamable HTTP / SSE. ACP currently has no production HTTP transport.
+
+### 1.2 HTTP / WebSocket (draft)
+
+- A **Streamable HTTP / WebSocket transport** is a draft RFD ([rfds/streamable-http-websocket-transport.md](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport.md)) and a recently-formed Transports Working Group ([announcements/transports-working-group.md](https://agentclientprotocol.com/announcements/transports-working-group.md)).
+- Custom transports are explicitly allowed as long as they preserve JSON-RPC framing and bidirectional message flow.
+- **Implication for ZRemote:** if we want to expose a remote agent over our existing WebSocket, we are doing it ahead of the official transport spec — same status as the broader ACP community, not a violation.
+
+### 1.3 Concurrency & ordering
+
+- A single ACP connection multiplexes **multiple concurrent sessions** (each identified by `sessionId`).
+- JSON-RPC `id` correlates request/response on a single connection.
+- Notifications from a session are delivered in order on a given connection, but the spec does not impose ordering guarantees across sessions.
+
+---
+
+## 2. Lifecycle
+
+```
++-------- Client --------+                                  +-------- Agent --------+
+|                        |  initialize (req)                |                       |
+|                        | -------------------------------> |                       |
+|                        |  initialize result               |                       |
+|                        | <------------------------------- |                       |
+|                        |                                  |                       |
+|                        |  authenticate (req, optional)    |                       |
+|                        | -------------------------------> |                       |
+|                        |  authenticate result             |                       |
+|                        | <------------------------------- |                       |
+|                        |                                  |                       |
+|                        |  session/new (or load/resume)    |                       |
+|                        | -------------------------------> |                       |
+|                        |  { sessionId }                   |                       |
+|                        | <------------------------------- |                       |
+|                        |                                  |                       |
+|                        |  session/prompt (req)            |                       |
+|                        | -------------------------------> |  -- model loop --     |
+|                        |                                  |   (tool calls,        |
+|                        |  session/update (notif) *N       |    permission asks,   |
+|                        | <------------------------------- |    fs / terminal ops) |
+|                        |                                  |                       |
+|                        |  fs/read|write, terminal/* (req) |                       |
+|                        | <------------------------------- |                       |
+|                        |  results                         |                       |
+|                        | -------------------------------> |                       |
+|                        |                                  |                       |
+|                        |  session/request_permission (req)|                       |
+|                        | <------------------------------- |                       |
+|                        |  { selected | cancelled }        |                       |
+|                        | -------------------------------> |                       |
+|                        |                                  |                       |
+|                        |  session/prompt result           |                       |
+|                        |  { stopReason }                  |                       |
+|                        | <------------------------------- |                       |
+|                        |                                  |                       |
+|                        |  session/cancel (notif, optional)|                       |
+|                        | -------------------------------> |                       |
+|                        |  session/close (req, optional)   |                       |
+|                        | -------------------------------> |                       |
++------------------------+                                  +-----------------------+
+```
+
+### 2.1 `initialize` — version + capability negotiation
+
+| Field | Direction | Type | Notes |
+|---|---|---|---|
+| `protocolVersion` | both | integer | Single integer MAJOR. Client sends its latest; Agent echoes if supported, otherwise its latest. If versions don't agree, Client SHOULD close. |
+| `clientCapabilities.fs.readTextFile` | C→A | bool | Agent may call `fs/read_text_file` only if true. |
+| `clientCapabilities.fs.writeTextFile` | C→A | bool | Same gate for writes. |
+| `clientCapabilities.terminal` | C→A | bool | Gates `terminal/*` methods. |
+| `clientInfo` | C→A | `{name,title?,version}` | Optional metadata. |
+| `agentCapabilities.loadSession` | A→C | bool | Gates `session/load`. |
+| `agentCapabilities.promptCapabilities.image` | A→C | bool | Gates `image` content blocks in prompt. |
+| `agentCapabilities.promptCapabilities.audio` | A→C | bool | Gates `audio`. |
+| `agentCapabilities.promptCapabilities.embeddedContext` | A→C | bool | Gates `resource` (embedded). |
+| `agentCapabilities.mcpCapabilities.http` | A→C | bool | Agent can connect to MCP over HTTP. |
+| `agentCapabilities.mcpCapabilities.sse` | A→C | bool | Agent can connect to MCP over SSE. |
+| `agentCapabilities.sessionCapabilities.list` | A→C | bool | Gates `session/list`. |
+| `agentCapabilities.sessionCapabilities.resume` | A→C | bool | Gates `session/resume`. |
+| `agentCapabilities.sessionCapabilities.close` | A→C | bool | Gates `session/close`. |
+| `agentInfo` | A→C | `{name,title?,version}` | Optional. |
+| `authMethods` | A→C | `AuthMethod[]` | Available auth flows; empty array means no auth required. |
+
+Source (request/response examples): <https://agentclientprotocol.com/protocol/initialization.md>.
+
+> The spec is strict: **"Clients and Agents MUST treat all capabilities omitted in the initialize request as UNSUPPORTED."** Forgetting a capability silently disables a feature; it is not implicitly enabled.
+
+### 2.2 `authenticate` (optional)
+
+- Used only if `authMethods` is non-empty. Concrete shape is part of the unstable `unstable_auth_methods` feature flag in the schema crate.
+- A `logout_method` RFD is in flight (<https://agentclientprotocol.com/rfds/logout-method.md>).
+
+### 2.3 `session/new` — required entry point
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "session/new",
+  "params": {
+    "cwd": "/abs/path",
+    "mcpServers": [
+      { "name": "filesystem", "command": "mcp-fs", "args": ["--root","/repo"] }
+    ]
+  }
+}
+```
+
+Response: `{ "sessionId": "sess_..." }`.
+
+- `cwd` MUST be absolute.
+- `mcpServers` are MCP servers the Agent should connect to for this session. Agents MUST support **stdio** MCP transport; HTTP and SSE depend on `mcpCapabilities`.
+- New stable additions (announced 2026): **`session/list`**, **`session/resume`**, **`session/close`** ([announcements](https://agentclientprotocol.com/announcements/session-list-stabilized.md)). Some are still gated by capability flags during the transition.
+
+### 2.4 `session/load` vs `session/resume` vs `session/list` vs `session/close`
+
+| Method | Capability gate | Behaviour |
+|---|---|---|
+| `session/load` | `agentCapabilities.loadSession` | Agent **replays** prior turns by sending `session/update` notifications with prior user/agent messages, then returns `null`. |
+| `session/resume` | `sessionCapabilities.resume` | Restores context **without replay**. Returns empty result (optionally with config state). |
+| `session/list` | `sessionCapabilities.list` | Cursor-paginated discovery: optional `cwd`, `cursor`; returns `{sessions: SessionInfo[], nextCursor?}`. |
+| `session/close` | `sessionCapabilities.close` | Cancels in-flight work and frees resources. |
+
+Source: <https://agentclientprotocol.com/protocol/session-setup.md>, <https://agentclientprotocol.com/protocol/session-list.md>.
+
+### 2.5 Cancellation & shutdown
+
+- `session/cancel` is a **notification** (no response) — Client → Agent — to abort the current prompt.
+- The Agent must:
+  - halt model + tool calls promptly,
+  - send any final updates,
+  - reply to the in-flight `session/prompt` with `stopReason: "cancelled"`.
+- The Client must:
+  - mark non-finished `tool_call`s as cancelled on its side,
+  - respond to any pending `session/request_permission` with `outcome: "cancelled"`.
+- There is no global `shutdown` RPC like LSP; closing stdin / dropping the connection is the natural exit signal. A `request_cancellation` RFD ([rfds/request-cancellation.md](https://agentclientprotocol.com/rfds/request-cancellation.md)) is being explored for cancelling individual non-prompt requests.
+
+---
+
+## 3. Message catalog
+
+> Naming convention: methods on the **Agent** (called by Client) are `session/...`, `fs/...` is on the **Client**, `terminal/...` is on the **Client**, `initialize`/`authenticate` are on the Agent. `session/update` and `session/request_permission` are agent-initiated.
+
+### Client → Agent
+
+| Method | Kind | Purpose |
+|---|---|---|
+| `initialize` | request | Version + capability negotiation. |
+| `authenticate` | request | Optional auth flow. |
+| `session/new` | request | Create a new session. Returns `sessionId`. |
+| `session/load` | request | Resume + replay history (capability gated). |
+| `session/resume` | request | Resume without replay (capability gated). |
+| `session/list` | request | List known sessions (capability gated). |
+| `session/close` | request | End session, free resources (capability gated). |
+| `session/prompt` | request | Send a turn; long-running, returns `{stopReason}`. |
+| `session/cancel` | notification | Abort the current prompt turn. |
+| `session/set_mode` | request | Switch session mode (legacy of `session/set_config_option`). |
+| `session/set_config_option` | request | Set a generic config option (model, mode, thought level, …). |
+
+### Agent → Client
+
+| Method | Kind | Purpose |
+|---|---|---|
+| `session/update` | notification | Streamed updates (see §3.1). |
+| `session/request_permission` | request | Ask user to allow/reject a tool call. |
+| `fs/read_text_file` | request | Read a text file (also returns unsaved editor buffers). |
+| `fs/write_text_file` | request | Write a text file. |
+| `terminal/create` | request | Start a command in a Client-managed terminal. Returns `terminalId`. |
+| `terminal/output` | request | Snapshot of current output (non-blocking). |
+| `terminal/wait_for_exit` | request | Block until the command exits. |
+| `terminal/kill` | request | Kill the process; terminal stays valid. |
+| `terminal/release` | request | Kill (if needed) and release the terminal id. |
+
+### 3.1 `session/update` payload variants
+
+`session/update` is a notification with `params: { sessionId, update: { sessionUpdate: <variant>, ... } }`. The discriminant is the `sessionUpdate` field (snake_case). Confirmed variants:
+
+| `sessionUpdate` value | Carries | Used for |
+|---|---|---|
+| `user_message_chunk` | `{content: ContentBlock}` | Replays of user messages on `session/load`. |
+| `agent_message_chunk` | `{content: ContentBlock}` | Streaming model output to UI. |
+| `agent_thought_chunk` | `{content: ContentBlock}` | Reasoning/thought stream (thinking content). |
+| `tool_call` | tool call object (see §4) | Announce a new tool call. |
+| `tool_call_update` | partial tool call (id required) | Status / content / location updates. |
+| `plan` | `{entries: PlanEntry[]}` | Multi-step execution plan, see §6. |
+| `available_commands_update` | `{availableCommands: AvailableCommand[]}` | Slash command catalog updates. |
+| `current_mode_update` | `{modeId}` | Agent-initiated mode switch. |
+| `config_option_update` | `{configId, ...}` | Agent-initiated config switch (see §7). |
+
+Sources: <https://agentclientprotocol.com/protocol/prompt-turn.md>, <https://agentclientprotocol.com/protocol/slash-commands.md>, <https://agentclientprotocol.com/protocol/session-modes.md>, <https://agentclientprotocol.com/protocol/session-config-options.md>.
+
+### 3.2 `session/prompt` request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "session/prompt",
+  "params": {
+    "sessionId": "sess_abc",
+    "prompt": [
+      { "type": "text", "text": "Analyze main.py" },
+      { "type": "resource",
+        "resource": {
+          "uri": "file:///repo/main.py",
+          "mimeType": "text/x-python",
+          "text": "def f(): pass"
+        }
+      }
+    ]
+  }
+}
+```
+
+Response:
+
+```json
+{ "jsonrpc": "2.0", "id": 2, "result": { "stopReason": "end_turn" } }
+```
+
+`stopReason ∈ { end_turn, max_tokens, max_turn_requests, refusal, cancelled }`.
+
+---
+
+## 4. Tool calls + permissions
+
+### 4.1 The tool call object
+
+```json
+{
+  "sessionUpdate": "tool_call",
+  "toolCallId": "call_001",
+  "title": "Run pytest in repo root",
+  "kind": "execute",
+  "status": "pending",
+  "rawInput":  { "cmd": "pytest", "args": ["-q"] },
+  "rawOutput": null,
+  "locations": [ { "path": "/repo/tests" } ],
+  "content":   []
+}
+```
+
+- `kind ∈ { read, edit, delete, move, search, execute, think, fetch, switch_mode, other }`.
+- `status ∈ { pending, in_progress, completed, failed }` (defaults `pending`).
+- `locations`: `{ path, line? }[]` — used by Clients to "follow the agent's eyes" in the editor.
+- `content` items can be:
+  - **regular content**: `{type: "content", content: ContentBlock}`
+  - **diff**: `{type: "diff", path, oldText, newText}`
+  - **terminal**: `{type: "terminal", terminalId}` — embeds live terminal output.
+
+### 4.2 `tool_call_update`
+
+Identical shape but only `toolCallId` is required; every other field is a partial patch. This is how the Agent reports progress (e.g. `pending → in_progress → completed`) and adds output as it arrives.
+
+### 4.3 `session/request_permission`
+
+Issued by the Agent when a side-effecting tool call needs user approval. Direction: Agent → Client (request).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "session/request_permission",
+  "params": {
+    "sessionId": "sess_abc",
+    "toolCall": { /* full tool call object */ },
+    "options": [
+      { "optionId": "allow_once",    "name": "Allow",            "kind": "allow_once" },
+      { "optionId": "allow_always",  "name": "Allow always",     "kind": "allow_always" },
+      { "optionId": "reject_once",   "name": "Reject",           "kind": "reject_once" },
+      { "optionId": "reject_always", "name": "Reject always",    "kind": "reject_always" }
+    ]
+  }
+}
+```
+
+Client response:
+
+```json
+{ "jsonrpc": "2.0", "id": 42,
+  "result": {
+    "outcome": { "type": "selected", "optionId": "allow_once" }
+  }
+}
+```
+
+Or, on cancellation: `"outcome": { "type": "cancelled" }`.
+
+`PermissionOption.kind ∈ { allow_once, allow_always, reject_once, reject_always }` — these are *hints* to the UI; the Agent honours `allow*` vs `reject*` semantics via the `optionId` returned.
+
+Source: <https://agentclientprotocol.com/protocol/tool-calls.md>.
+
+---
+
+## 5. File-system operations (Agent → Client)
+
+Both methods are gated by `clientCapabilities.fs.readTextFile` / `clientCapabilities.fs.writeTextFile`. If the flag is `false` or absent, the Agent **MUST NOT** call them.
+
+### 5.1 `fs/read_text_file`
+
+```json
+{ "jsonrpc": "2.0", "id": 3,
+  "method": "fs/read_text_file",
+  "params": {
+    "sessionId": "sess_abc",
+    "path": "/abs/repo/src/main.py",
+    "line": 10,
+    "limit": 50
+  }
+}
+```
+
+Response: `{ "content": "<file body>" }`.
+
+- `path` must be absolute.
+- `line` is 1-based (optional), `limit` (optional) caps the number of lines returned.
+- The Client SHOULD return **unsaved editor buffer** content if the file is open and dirty — this is the core reason `fs/read_text_file` exists rather than the Agent reading from disk directly.
+
+### 5.2 `fs/write_text_file`
+
+```json
+{ "jsonrpc": "2.0", "id": 4,
+  "method": "fs/write_text_file",
+  "params": {
+    "sessionId": "sess_abc",
+    "path": "/abs/repo/config.json",
+    "content": "{\n  \"debug\": true\n}\n"
+  }
+}
+```
+
+Response: `null`. The Client creates the file if it doesn't exist.
+
+> **Note:** ACP defines only **text** file ops in the stable surface. Binary files travel through `resource_link` content blocks or MCP servers. There is currently no `fs/list`, `fs/stat`, or `fs/move` in the stable spec.
+
+---
+
+## 6. Terminal operations (Agent → Client)
+
+Gated by `clientCapabilities.terminal`. Designed so the Agent can run shell commands without owning the host environment.
+
+### 6.1 Lifecycle
+
+```
+                      terminal/create (returns terminalId)
+                              │
+        ┌─────────────────────┼──────────────────────┐
+        ▼                     ▼                      ▼
+  terminal/output     terminal/wait_for_exit    terminal/kill
+  (poll snapshot)     (block until exit)        (signal process)
+        │                     │                      │
+        └─────────────────────┴──────────────────────┘
+                              │
+                       terminal/release
+                       (free terminalId; output may stay rendered in tool call)
+```
+
+### 6.2 `terminal/create`
+
+```json
+{ "method": "terminal/create",
+  "params": {
+    "sessionId": "sess_abc",
+    "command": "cargo",
+    "args": ["test", "--workspace"],
+    "env":  [{"name":"RUST_LOG","value":"info"}],
+    "cwd":  "/abs/repo",
+    "outputByteLimit": 1048576
+  }
+}
+```
+
+Returns `{ terminalId }` immediately, even if the command is still running.
+
+### 6.3 `terminal/output`
+
+Returns the current accumulated output, a `truncated` flag, and (if exited) `exitStatus = { exitCode, signal }`. Non-blocking.
+
+### 6.4 `terminal/wait_for_exit`
+
+Blocks until exit, returns `{ exitCode?, signal? }`.
+
+### 6.5 `terminal/kill`
+
+Sends a kill signal but **keeps the terminal id valid** — Agent can still call `terminal/output` and `terminal/wait_for_exit`. `terminal/release` is still required.
+
+### 6.6 `terminal/release`
+
+Frees the terminalId. After release, future `terminal/*` calls with that id are invalid. Output already embedded in a `tool_call` should remain visible in the UI.
+
+> **Implication for ZRemote:** the existing PTY abstraction in `zremote-agent` is a near-perfect fit for this surface. We already have create/output/kill primitives; what's missing is the byte-limit ring buffer and `terminalId` semantics distinct from our `session_id`.
+
+---
+
+## 7. Sessions: modes & config options
+
+### 7.1 Session modes (legacy, being deprecated)
+
+- Agent advertises `availableModes: Mode[]` and `currentModeId` during session setup or via `current_mode_update` notifications.
+- Mode = `{ id, name, description? }`. Reference triple: **Ask** (request permission for changes), **Architect** (design without implementation), **Code** (full tool access).
+- Client switches via `session/set_mode { sessionId, modeId }`.
+
+### 7.2 Session config options (current direction)
+
+Generalises modes into a typed list of selectable options.
+
+```jsonc
+// Agent advertises:
+"configOptions": [
+  {
+    "id": "model",
+    "name": "Model",
+    "category": "model",
+    "type": "select",
+    "currentValue": "sonnet",
+    "options": [
+      { "value": "opus", "name": "Claude Opus" },
+      { "value": "sonnet", "name": "Claude Sonnet" }
+    ]
+  },
+  {
+    "id": "mode",
+    "name": "Mode",
+    "category": "mode",
+    "type": "select",
+    "currentValue": "code",
+    "options": [
+      { "value": "ask", "name": "Ask" },
+      { "value": "code", "name": "Code" }
+    ]
+  }
+]
+```
+
+- Reserved `category` values: `mode`, `model`, `thought_level`. Custom values must start with `_`.
+- Client mutates with `session/set_config_option { sessionId, configId, value }`; Agent responds with the **complete** updated config (so cascading dependencies surface).
+- Agents SHOULD send both `modes` and `configOptions` during the transition window for backwards compatibility.
+
+Source: <https://agentclientprotocol.com/protocol/session-config-options.md>, [announcements/session-config-options-stabilized.md](https://agentclientprotocol.com/announcements/session-config-options-stabilized.md).
+
+### 7.3 Slash commands
+
+- Advertised via the `available_commands_update` `session/update` notification (Agent → Client).
+- Schema per command: `{ name, description, input?: { hint?: string } }`.
+- The user invokes by typing `"/web search me"` as a normal `session/prompt` message — the prefix is purely a UI convention; the wire format is unchanged. The protocol does **not** define a separate "execute slash command" RPC.
+- Source: <https://agentclientprotocol.com/protocol/slash-commands.md>.
+
+### 7.4 Plans
+
+`session/update` with `sessionUpdate: "plan"` carries an `entries: PlanEntry[]` where each entry is `{ content, priority: high|medium|low, status: pending|in_progress|completed }`. Plans can be replaced fully on each notification — the latest one wins. Source: <https://agentclientprotocol.com/protocol/agent-plan.md>.
+
+---
+
+## 8. Content blocks
+
+Reusable across prompts, message chunks, and tool call content. `type` discriminator:
+
+| `type` | Required fields | Notes / capability |
+|---|---|---|
+| `text` | `text` | Always supported. |
+| `image` | `mimeType`, `data` (base64); `uri?` | `promptCapabilities.image` for prompts. |
+| `audio` | `mimeType`, `data` (base64) | `promptCapabilities.audio`. |
+| `resource` | `resource: {uri, mimeType?, text\|blob}` | `promptCapabilities.embeddedContext`. The "@-mention" of a file with body inlined. |
+| `resource_link` | `uri`, `name`; `mimeType?`, `title?`, `description?`, `size?` | Reference without inline data. |
+
+All variants accept optional `annotations` for display metadata. Source: <https://agentclientprotocol.com/protocol/content.md>.
+
+---
+
+## 9. Versioning, capabilities, extensibility
+
+### 9.1 Versioning
+
+- `protocolVersion` is a **single integer** representing the MAJOR version.
+- Client sends its highest supported version. Agent replies with the same (if it supports it) or its own latest.
+- Both parties MUST act according to the agreed version. If they cannot agree, **client SHOULD close the connection**. There is no "minor compatibility" — semantics are tied to MAJOR.
+- The current protocol version observed in examples is `1`.
+
+### 9.2 Capabilities
+
+- All features beyond `initialize` + `session/new` + `session/prompt` + `session/request_permission` are capability-gated.
+- Capabilities omitted from the `initialize` payload are treated as **unsupported**.
+- Capabilities are flat-namespaced under `clientCapabilities` and `agentCapabilities` and grouped (`fs.*`, `promptCapabilities.*`, `mcpCapabilities.*`, `sessionCapabilities.*`).
+
+### 9.3 Extensibility (`_meta` and underscore methods)
+
+- Every protocol type MAY carry an `_meta: { [string]: unknown }` field. Implementations MUST NOT add custom fields at the **root** of a spec type — only inside `_meta`.
+- Reserved root-level `_meta` keys: `traceparent`, `tracestate`, `baggage` (W3C Trace Context).
+- **Custom methods MUST start with `_`** (e.g. `_zed.dev/workspace/buffers`):
+  - Custom **requests** that aren't recognised → respond with JSON-RPC error `-32601` (Method not found).
+  - Custom **notifications** that aren't recognised → silently ignore.
+- Recommended pattern for vendor capabilities: advertise inside `_meta` of the capability object during `initialize`:
+  ```json
+  "_meta": { "zed.dev": { "workspace": true, "fileNotifications": true } }
+  ```
+
+Source: <https://agentclientprotocol.com/protocol/extensibility.md>.
+
+---
+
+## 10. ACP vs MCP vs LSP
+
+| Dimension | **ACP** | **MCP** | **LSP** |
+|---|---|---|---|
+| Primary axis | Editor ↔ AI agent | Agent ↔ tool/data server | Editor ↔ language server |
+| Wire | JSON-RPC 2.0 | JSON-RPC 2.0 | JSON-RPC 2.0 |
+| Transport | stdio (newline-delimited); HTTP/WS draft | stdio (newline-delimited), Streamable HTTP, SSE | stdio (`Content-Length` framed), TCP, sockets |
+| Who initiates | Client spawns Agent | Client spawns server (or connects to remote) | Editor spawns server |
+| Who issues tool calls | Agent decides; Client gates with permission | Agent calls server's `tools/call` | n/a (LSP exposes refactors/quick-fixes, not arbitrary tool calls) |
+| File access | `fs/read_text_file`, `fs/write_text_file` (text only) | Via `resources/*` and tool calls | `textDocument/*` (full editor sync) |
+| Terminal | `terminal/*` first-class | Only via custom tools | None |
+| Permissions | First-class `session/request_permission` | Out-of-band (host UX) | n/a |
+| Sessions | Multi-session, list/load/resume/close | Connection ≈ session; resumable streams | Per-document state |
+| Streaming updates | `session/update` notification with discriminated variants | `notifications/*` + Streamable HTTP SSE chunks | `textDocument/publishDiagnostics`, etc. |
+| Versioning | Single integer MAJOR | Date-versioned strings ("2025-06-18") | Semver-style version strings |
+| Extensibility | `_meta` + `_methodName` | `_meta` + experimental capabilities | `experimental` capabilities |
+| Relationship | **Composes with MCP**: ACP agents typically host MCP clients to consume tool servers. | Standalone, but MCP servers are commonly mounted *into* ACP agents via `session/new.mcpServers`. | Independent. |
+
+> **Mental model:** LSP is **editor ↔ language**. MCP is **agent ↔ tool**. ACP is **editor ↔ agent**. They are complementary: a Zed-style stack is `editor —ACP→ agent —MCP→ tool servers`, with the language server still riding LSP.
+
+There is also an active RFD for **MCP-over-ACP** (<https://agentclientprotocol.com/rfds/mcp-over-acp.md>) which would let an ACP-only Client expose its MCP tools through the same ACP channel — relevant if ZRemote ever wants to be a "tool host" for downstream agents.
+
+---
+
+## 11. Rust SDK API shape
+
+### 11.1 Crate layout
+
+| Crate | Version (2026-04) | Purpose |
+|---|---|---|
+| `agent-client-protocol-schema` | **0.12.2** | Pure schema crate: every request/response/notification type, derived from `schema/schema.json`. Edition 2024, Apache-2.0, schemars/serde/strum based. |
+| `agent-client-protocol` | **0.11.1** | High-level SDK: roles, connections, JSON-RPC plumbing. Depends on `-schema` and `agent-client-protocol-derive`. |
+| `agent-client-protocol-tokio` | recent | Tokio process-spawn helpers. |
+| `agent-client-protocol-conductor` | 0.11.1 | Binary for proxy chaining. |
+| `agent-client-protocol-rmcp` | recent | rmcp (MCP) integration glue. |
+| `agent-client-protocol-test` | recent | Test harness. |
+| `agent-client-protocol-cookbook` | recent | Doc/examples crate. |
+
+The Rust SDK lives at <https://github.com/agentclientprotocol/rust-sdk> (a Cargo workspace); the **schema** crate alone lives at <https://github.com/zed-industries/agent-client-protocol> (a duplicate-named upstream that auto-generates types from `schema/schema.json`).
+
+### 11.2 Roles, not a single Agent/Client trait
+
+Unlike older blog-post sketches that show `trait Agent` and `trait Client`, the real 0.11 SDK uses a **role-typestate** pattern:
+
+```rust
+pub trait Role: Debug + Clone + Send + Sync + 'static + Eq + Ord + Hash {
+    type Counterpart: Role<Counterpart = Self>;
+    fn role_id(&self) -> RoleId;
+    fn counterpart(&self) -> Self::Counterpart;
+    // ... default_handle_dispatch_from etc.
+}
+
+pub struct Client;     // Counterpart = Agent
+pub struct Agent;      // Counterpart = Client
+pub struct Proxy;      // Counterpart = Conductor
+pub struct Conductor;  // Counterpart = Proxy
+```
+
+You don't *implement Agent or Client*; you **build a connection in a given role** and attach handlers to it via `Builder` and `HandleDispatchFrom<Counterpart>` impls.
+
+Minimal client (from `lib.rs` doc):
+
+```rust
+use agent_client_protocol::Client;
+use agent_client_protocol::schema::{InitializeRequest, ProtocolVersion};
+
+Client.builder()
+    .name("my-client")
+    .connect_with(transport, async |cx| {
+        cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task().await?;
+
+        cx.build_session_cwd()?
+            .block_task()
+            .run_until(async |mut session| {
+                session.send_prompt("What is 2 + 2?")?;
+                let response = session.read_to_string().await?;
+                println!("{}", response);
+                Ok(())
+            })
+            .await
+    })
+    .await
+```
+
+Key public surface (from `lib.rs` re-exports):
+
+- `Builder<Role, Handler, Run>` — composes handlers and a runner.
+- `Channel`, `ByteStreams`, `Lines` — transport abstractions; `ByteStreams` is what you'll wrap a tokio process around.
+- `ConnectionTo<Role>` — the working handle inside `connect_with`. Methods: `send_request_to(peer, req)`, `send_notification_to(peer, notif)`, `add_dynamic_handler(...)`, `build_session_cwd()`, etc.
+- `Dispatch` — incoming-message envelope (`Request`, `Notification`, `Response`).
+- `HandleDispatchFrom<Peer>` — async trait you implement to attach handlers per peer role.
+- `JsonRpcMessage`, `JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcNotification`, `Responder`, `SentRequest`, `ResponseRouter` — JSON-RPC plumbing.
+
+`schema::*` types (key ones, all `serde::Serialize`/`Deserialize` + `schemars`):
+
+- `ProtocolVersion`, `InitializeRequest`, `InitializeResponse`,
+  `AgentCapabilities`, `ClientCapabilities`, `PromptCapabilities`, `McpCapabilities`, `SessionCapabilities`.
+- `NewSessionRequest`, `NewSessionResponse`, `LoadSessionRequest`, `ResumeSessionRequest`, `ListSessionsRequest`, `ListSessionsResponse`, `CloseSessionRequest`.
+- `PromptRequest`, `PromptResponse`, `StopReason`, `CancelNotification`.
+- `SessionUpdate` (enum with all `sessionUpdate` variants), `SessionNotification`.
+- `ToolCall`, `ToolCallUpdate`, `ToolKind`, `ToolCallStatus`, `ToolCallContent`, `Diff`.
+- `RequestPermissionRequest`, `RequestPermissionResponse`, `PermissionOption`, `PermissionOptionKind`.
+- `ContentBlock`, `EmbeddedResource`, `ResourceLink`.
+- `ReadTextFileRequest/Response`, `WriteTextFileRequest`,
+  `CreateTerminalRequest/Response`, `TerminalOutputResponse`, `WaitForTerminalExitResponse`, `KillTerminalRequest`, `ReleaseTerminalRequest`.
+- `Plan`, `PlanEntry`, `PlanEntryStatus`, `PlanEntryPriority`.
+- `AvailableCommand`, `AvailableCommandInput`.
+- `ConfigOption`, `ConfigOptionValue`, `SetConfigOptionRequest`, `ConfigOptionUpdate`.
+
+### 11.3 Feature flags
+
+Gate **unstable** schema variants behind cargo features (default `[]`):
+
+```
+unstable = [
+  unstable_auth_methods, unstable_boolean_config, unstable_logout,
+  unstable_message_id, unstable_session_additional_directories,
+  unstable_session_close, unstable_session_fork, unstable_session_model,
+  unstable_session_resume, unstable_session_usage,
+]
+```
+
+This is critical: many "stabilized" announcements (session/list, session/close, session/resume) are still gated **at the type level** until the next minor bump. ZRemote should pin specifically (`agent-client-protocol = "=0.11.1"`) and decide explicitly which `unstable_*` features to opt into.
+
+### 11.4 Async runtime
+
+- Tokio, mandatory (`tokio` is a workspace dependency, not optional).
+- The SDK uses `async fn in trait` (Rust 2024 edition) — pulls `edition.workspace = true` from the workspace.
+- **MSRV** is not stated explicitly in `Cargo.toml`; Rust 2024 edition + `async fn` in traits implies **Rust 1.85+**.
+
+### 11.5 TypeScript SDK
+
+- Package: `@agentclientprotocol/sdk` on npm.
+- Key classes: `AgentSideConnection`, `ClientSideConnection`.
+- Production reference: Gemini CLI uses it as an Agent.
+- API docs: <https://agentclientprotocol.github.io/typescript-sdk>.
+
+### 11.6 Languages
+
+Official SDKs: **Rust, TypeScript, Python, Kotlin, Java**. 40+ agents implement ACP, including **Claude Code** (via Zed adapter), **GitHub Copilot** (preview), **Gemini CLI**, **Cursor**, **Cline**, **OpenHands**, **Goose**, **JetBrains Junie**, **Codex CLI**, etc. Source: <https://agentclientprotocol.com/get-started/agents.md>.
+
+---
+
+## 12. Open questions / ambiguities
+
+1. **HTTP/WebSocket transport.** No production spec yet. We will be improvising. The Transports Working Group exists ([announcement](https://agentclientprotocol.com/announcements/transports-working-group.md)) but no document we can pin to.
+2. **Authentication.** `authMethods` is in the stable response shape, but the concrete `authenticate` payloads are gated behind `unstable_auth_methods`. Don't design around them yet.
+3. **Binary file ops.** No `fs/read_binary_file` in the stable spec — only text. Binaries flow via `resource_link` URIs or MCP tool calls.
+4. **`SDK trait Agent`/`trait Client` references** in third-party blog posts (and in <https://agentclientprotocol.com/libraries/rust>) are **outdated**. The current SDK uses the role-typestate pattern. The doc page is misleading and we should confirm against `docs.rs/agent-client-protocol/0.11.1` before writing examples.
+5. **Crate naming collision.** Two crates exist: `agent-client-protocol-schema` (types only) and `agent-client-protocol` (full SDK). Both are advertised as "the" Rust crate. ZRemote should depend on the high-level one unless we want types only.
+6. **Two GitHub repos with same name.** `zed-industries/agent-client-protocol` and `agentclientprotocol/agent-client-protocol` both exist. The second is the post-handover canonical home (Sergey Ignatov took over as lead maintainer per [announcements/sergey-ignatov-lead-maintainer.md](https://agentclientprotocol.com/announcements/sergey-ignatov-lead-maintainer.md)). The Rust SDK is in a third repo: `agentclientprotocol/rust-sdk`.
+7. **Streaming token semantics.** Spec doesn't mandate chunk granularity for `agent_message_chunk`; agents may stream per-token, per-line, or per-full-message. Clients must tolerate any.
+8. **Cancellation of non-prompt requests.** Today, `session/cancel` cancels the entire turn. Cancelling a single in-flight `terminal/wait_for_exit` is the subject of an open RFD (<https://agentclientprotocol.com/rfds/request-cancellation.md>).
+9. **`session/load` replay format.** Spec says the Agent emits prior `user_message_chunk` and `agent_message_chunk` updates, but does not specify whether prior tool calls are also replayed. Implementations differ.
+10. **Session-mode vs config-option migration window.** Spec asks agents to emit both during transition, but does not say when `session/set_mode` will be removed.
+
+---
+
+## 13. Sources
+
+- Official spec
+  - Site index: <https://agentclientprotocol.com/llms.txt>
+  - Overview: <https://agentclientprotocol.com/protocol/overview>
+  - Architecture: <https://agentclientprotocol.com/get-started/architecture.md>
+  - Initialization: <https://agentclientprotocol.com/protocol/initialization.md>
+  - Session setup: <https://agentclientprotocol.com/protocol/session-setup.md>
+  - Session list: <https://agentclientprotocol.com/protocol/session-list.md>
+  - Session modes: <https://agentclientprotocol.com/protocol/session-modes.md>
+  - Session config options: <https://agentclientprotocol.com/protocol/session-config-options.md>
+  - Prompt turn: <https://agentclientprotocol.com/protocol/prompt-turn.md>
+  - Tool calls: <https://agentclientprotocol.com/protocol/tool-calls.md>
+  - File system: <https://agentclientprotocol.com/protocol/file-system.md>
+  - Terminals: <https://agentclientprotocol.com/protocol/terminals.md>
+  - Content blocks: <https://agentclientprotocol.com/protocol/content.md>
+  - Plans: <https://agentclientprotocol.com/protocol/agent-plan.md>
+  - Slash commands: <https://agentclientprotocol.com/protocol/slash-commands.md>
+  - Transports: <https://agentclientprotocol.com/protocol/transports.md>
+  - Extensibility: <https://agentclientprotocol.com/protocol/extensibility.md>
+  - Schema: <https://agentclientprotocol.com/protocol/schema.md>
+  - Agents directory: <https://agentclientprotocol.com/get-started/agents.md>
+- Reference implementations
+  - Schema repo (Zed): <https://github.com/zed-industries/agent-client-protocol>
+  - Schema crate Cargo.toml: `name = "agent-client-protocol-schema", version = "0.12.2", edition = "2024"`
+  - SDK repo: <https://github.com/agentclientprotocol/rust-sdk>
+  - SDK Cargo.toml: `name = "agent-client-protocol", version = "0.11.1"`, deps include `tokio`, `rmcp`, `serde`, `schemars`, `jsonrpcmsg`.
+  - SDK `src/role/acp.rs` — shows `Client`, `Agent`, `Proxy`, `Conductor` role structs.
+  - SDK `lib.rs` — top-level docs and re-exports.
+- Crates.io / lib.rs
+  - <https://crates.io/crates/agent-client-protocol>
+  - <https://lib.rs/crates/agent-client-protocol>
+- Announcements
+  - Lead maintainer handover: <https://agentclientprotocol.com/announcements/sergey-ignatov-lead-maintainer.md>
+  - Transports WG: <https://agentclientprotocol.com/announcements/transports-working-group.md>
+  - Session list / resume / close stabilizations: <https://agentclientprotocol.com/announcements/session-list-stabilized.md>, <https://agentclientprotocol.com/announcements/session-resume-stabilized.md>, <https://agentclientprotocol.com/announcements/session-close-stabilized.md>
+  - Session config options: <https://agentclientprotocol.com/announcements/session-config-options-stabilized.md>
+- Open RFDs cited
+  - Streamable HTTP/WS: <https://agentclientprotocol.com/rfds/streamable-http-websocket-transport.md>
+  - Request cancellation: <https://agentclientprotocol.com/rfds/request-cancellation.md>
+  - MCP-over-ACP: <https://agentclientprotocol.com/rfds/mcp-over-acp.md>
+  - Logout: <https://agentclientprotocol.com/rfds/logout-method.md>
+  - Auth methods: <https://agentclientprotocol.com/rfds/auth-methods.md>

--- a/docs/research/driver-architecture.md
+++ b/docs/research/driver-architecture.md
@@ -1,0 +1,234 @@
+# SessionDriver architecture — ACP as a driver, not a special case
+
+**Date:** 2026-04-25
+**Builds on:** [`README.md`](./README.md), [`zremote-acp-integration-points.md`](./zremote-acp-integration-points.md)
+**Status:** proposal (no implementation)
+
+---
+
+## TL;DR
+
+Treat ACP not as a parallel pipe to bolt on, but as **one of several pluggable drivers** for a session. A `SessionDriver` abstraction sits where today's `connection/mod.rs` god-object dispatches per-session state. Each driver owns its loop-event production and emits a canonical event stream that the existing UI / DB / Telegram consumers already understand. ACP, CC-via-hooks, CC-via-ACP, plain-PTY, and any future agent integration become **siblings** instead of conditional branches. This framing also doubles as the `connection/mod.rs` refactor we already need.
+
+---
+
+## 1. The framing
+
+Today, "what runs in this session" is implicit and scattered:
+
+- A PTY is always created.
+- A process detector polls every 1s on top of every PTY.
+- An OutputAnalyzer is attached to most PTYs.
+- A CC hooks sidecar may or may not be running per-connection.
+- A handful of HashMaps in `connection/mod.rs:222-919` track which sessions opted into which feature.
+
+What the user is proposing: make this **explicit and exclusive**. Every session is owned by exactly one driver, picked at start time. The driver knows *how* to talk to the underlying agent and *what events* to emit. The rest of the system (UI, DB, Telegram, activity panel, permission policy) consumes a single canonical event stream regardless of who produces it.
+
+```
+                  +---------------------------+
+                  |  SessionDriver::start()   |
+                  +---------------------------+
+                   |          |       |
+   +---------------+   +------+--+    +-----------------+
+   |  PtyDriver    |   | CcHooks |    | AcpDriver       |
+   | (raw shell)   |   | Driver  |    |  + variant ids: |
+   |  ─ process    |   | (PTY +  |    |    claude-acp,  |
+   |    scan       |   | hooks   |    |    codex-acp,   |
+   |  ─ analyzer   |   | sidecar |    |    gemini-acp,  |
+   |    (regex)    |   | side-   |    |    generic-acp  |
+   |               |   | channel)|    |                 |
+   +-------+-------+   +----+----+    +--------+--------+
+           |                |                   |
+           +-------+--------+-------+-----------+
+                   |
+                   v
+          canonical event stream
+   (Output bytes, LoopStateUpdate, ExecutionNode,
+    PermissionRequest, Plan, AgentMessageChunk,
+    SessionEnded {stop_reason})
+                   |
+                   v
+   +--------+----+--------+--------+---------+
+   |   UI   | DB | Tele-  | Hooks  | Channel |
+   |        |    | gram   | policy | bridge  |
+   +--------+----+--------+--------+---------+
+```
+
+The picture is a thin trait above many implementations, not a fat trait + many capability gates.
+
+---
+
+## 2. The trait (sketch)
+
+Lives in `crates/zremote-agent/src/session_driver/mod.rs` (new). The shape, not the final API:
+
+```rust
+/// What the GUI/server already consumes today, normalized.
+pub enum DriverEvent {
+    /// Raw PTY-like bytes for the terminal panel. PTY drivers stream this
+    /// continuously; ACP drivers emit it only when the agent embeds a terminal
+    /// in a tool call.
+    Output { bytes: Bytes },
+
+    /// Canonical loop state — the Working/WaitingForInput/RequiresAction
+    /// pipeline that already exists at `crates/zremote-protocol/src/agentic.rs:14-23`.
+    LoopState(LoopStateUpdate),
+
+    /// One row in the existing ExecutionNode history.
+    ToolCall(ExecutionNode),
+
+    /// Routes through the existing channel permission flow at
+    /// `crates/zremote-protocol/src/channel.rs:127-131`.
+    PermissionRequest(PermissionRequest),
+
+    /// ACP-only today. PTY drivers stay None.
+    Plan(Vec<PlanEntry>),
+
+    /// ACP-only: streaming model output token-by-token. PTY drivers stay None.
+    AgentMessageChunk { text: String },
+
+    /// Terminal end with reason: end_turn / cancelled / failed / shell_exit.
+    SessionEnded { stop_reason: StopReason },
+}
+
+/// Capabilities the driver advertises so the UI can degrade gracefully.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DriverCapabilities {
+    pub structured_loop_state: bool,   // false = best-effort regex; true = authoritative
+    pub typed_tool_calls:      bool,   // tool_call has structured kind/locations
+    pub typed_diffs:           bool,   // (path, oldText, newText)
+    pub permission_requests:   bool,   // can ask before destructive actions
+    pub streaming_text:        bool,   // agent_message_chunk
+    pub plan_tracking:         bool,
+    pub clean_cancel:          bool,   // session/cancel vs Ctrl-C
+    pub session_resume:        bool,
+    pub slash_commands:        bool,
+    pub embedded_terminals:    bool,
+}
+
+#[async_trait]
+pub trait SessionDriver: Send + Sync + 'static {
+    fn id(&self) -> DriverId;                       // "pty" | "cc-hooks" | "claude-acp" | ...
+    fn capabilities(&self) -> DriverCapabilities;
+
+    /// Spawn whatever underlying process(es) this driver needs (PTY, ACP child,
+    /// hooks sidecar, ...) and return a control handle + event receiver.
+    async fn start(&self, params: StartParams) -> Result<DriverHandle>;
+}
+
+pub struct DriverHandle {
+    pub events: tokio::sync::mpsc::Receiver<DriverEvent>,
+    pub control: Box<dyn DriverControl>,
+}
+
+#[async_trait]
+pub trait DriverControl: Send + Sync {
+    async fn send_user_input(&self, input: UserInput) -> Result<()>; // PTY bytes OR ACP prompt
+    async fn answer_permission(&self, request_id: Uuid, decision: PermissionDecision) -> Result<()>;
+    async fn cancel_turn(&self) -> Result<()>;                       // clean cancel; PTY does Ctrl-C
+    async fn shutdown(self: Box<Self>) -> Result<()>;
+}
+```
+
+`DriverId` is a string slug stored on the session row and on `AgentProfileData.settings_json` as the new field `driver_id`. No SQL migration: profile settings are already a free-form JSON blob (RFC-003 §1).
+
+---
+
+## 3. The four concrete drivers (mapping of existing code)
+
+| Driver | Wraps | New / mostly reuse | Capabilities advertised |
+|---|---|---|---|
+| **PtyDriver** | `pty/`, `agentic/detector.rs`, `agentic/analyzer.rs`, `agentic/manager.rs` (process scan) | mostly reuse; emits `LoopStateUpdate` from `AnalyzerEvent::PhaseChanged` and `Output` from PTY bytes | `structured_loop_state=false` (best-effort), `typed_tool_calls=false`, `permission_requests=false`, everything else `false` |
+| **ClaudeHooksDriver** | PtyDriver + `hooks/handler.rs` sidecar | reuses today's CC integration in full; sidecar becomes an internal detail of *this driver only* | `structured_loop_state=true`, `typed_tool_calls=partial` (no diffs), `permission_requests=true`, `streaming_text=false`, `plan_tracking=false`, `clean_cancel=false` |
+| **ClaudeAcpDriver** | spawns `@zed-industries/claude-agent-acp` over stdio; reuses ACP SDK | new (depends on `agent-client-protocol = "=0.11.1"`); translator emits `LoopStateUpdate` + `ExecutionNode` from `session/update` so existing UI consumers don't change | all true |
+| **GenericAcpDriver** | spawns any ACP registry binary over stdio with profile-supplied command | same code as ClaudeAcpDriver, parameterized | all true (subject to agent's own `agentCapabilities`) |
+
+What stays unchanged because of the framing:
+
+- `crates/zremote-protocol/src/agentic.rs` — `AgenticAgentMessage`, `LoopStateUpdate`, `ExecutionNode` are already the canonical event types. Drivers emit them.
+- `crates/zremote-protocol/src/channel.rs` — `PermissionRequest`/`PermissionResponse` keep their current shape; ACP `session/request_permission` translates *into* them.
+- The existing GUI sidebar / activity panel / Telegram / permission UI all keep consuming the same events.
+- Per-project `permission-policy` keeps its single decision point.
+
+What gets cleaner:
+
+- `connection/mod.rs:222-919` becomes `Connection { sessions: HashMap<SessionId, ActiveDriver> }` — 8+ HashMaps collapse into one.
+- `hooks/handler.rs` is no longer a mid-`connection/` lifecycle hook; it's owned by the `ClaudeHooksDriver` impl. The "should I install hooks?" check (`connection/mod.rs:368-388`) goes away — the driver decides at construction.
+- `agentic/manager.rs` (process scan) only runs for PTY-driver sessions. ACP and CC-hooks sessions don't need it because they get explicit start/end events.
+
+---
+
+## 4. Selection: which driver runs my session?
+
+Source of truth at start time, in priority order:
+
+1. Explicit user choice in the launcher dropdown ("Run with: Claude Code (ACP) / Claude Code (hooks) / Codex (ACP) / plain shell").
+2. `AgentProfileData.driver_id` from the profile (RFC-003 settings_json).
+3. Default for the agent kind (e.g., `claude` → `cc-hooks` for backwards compat in v1, switching to `claude-acp` once ACP-CC is proven).
+4. Plain `PtyDriver` for "just give me a shell".
+
+This makes the migration trivial: every existing session implicitly uses `PtyDriver` or `ClaudeHooksDriver` based on what's already happening. New sessions can opt into ACP. No flag day.
+
+---
+
+## 5. Why this is better than the synthesis recommendation
+
+The synthesis ([README.md §3](./README.md)) treated ACP as "case (A): a new launcher inside the existing AgentLauncher trait." That works, but leaves the existing CC hooks pipeline as a parallel-life code path with hard-to-reason-about race conditions. The driver framing fixes that:
+
+| Risk from research synthesis | How drivers fix it |
+|---|---|
+| **Double-driver races** between hooks sidecar and ACP for the same session ([§6.2](./zremote-acp-integration-points.md#6-risks)) | By construction impossible — exactly one driver per session. Selection at start is exclusive. |
+| **`connection/mod.rs` is 1000+ lines / 8+ HashMaps** ([§6.3](./zremote-acp-integration-points.md#6-risks)) | The driver abstraction *is* the refactor. Per-session state is owned by the driver, not by global HashMaps. |
+| **Permission policy double-source** ([§6.5](./zremote-acp-integration-points.md#6-risks)) | All drivers translate their permission needs into the canonical `PermissionRequest`. Single decision point at the channel layer. |
+| **PTY ownership when GUI talks ACP directly** ([§6.6](./zremote-acp-integration-points.md#6-risks)) | The driver owns transport and translation. ACP frames produce `ExecutionNode`s through the driver-internal translator; UI feeds keep working without "ACP-aware" branches anywhere downstream. |
+| **Per-launcher transport gate at `connection/mod.rs:368-388`** ([§7](./zremote-acp-integration-points.md#7-recommended-phasing)) | Disappears. Hooks install lives inside `ClaudeHooksDriver::start`, not in shared connection logic. |
+
+It also reframes the unique zremote value prop from §2.4 of the synthesis: an `AcpDriver` running on the agent host with the GUI consuming the canonical event stream over our existing WS *is* "ACP over the network" — no need for a special `AgentMessage::AcpFrame` tunneling variant. Drivers run agent-side, events flow agent→server→GUI through the existing event channel.
+
+---
+
+## 6. Tradeoffs to call out
+
+1. **Trait-design tax.** Designing `DriverEvent` and `DriverCapabilities` so they cover both PTY and ACP without becoming a mush is real work. Get the capability flags right or every UI consumer ends up branching on `driver_id`.
+2. **Capability degradation UX.** When `streaming_text=false`, what does the chat panel do? When `typed_diffs=false`, what does the diff reviewer do? Per-feature fallback policies need to be documented up front, not retrofitted.
+3. **Event ordering vs. backpressure.** Drivers should emit on a single `mpsc::Sender` per session so total ordering is preserved. The buffer size and how we handle slow consumers (drop? coalesce LoopState updates? wait?) is a per-event decision.
+4. **Driver registry is a new public surface.** A trait + dynamic registration mechanism (probably keyed by `DriverId` strings) means we have to think about ABI/version pinning across crates. Recommendation: drivers live in `zremote-agent` crate only, no external plugin loading in v1.
+5. **Two seam refactor.** This collapses `LauncherRegistry` (RFC-003) and `connection/mod.rs` per-session bookkeeping into one driver abstraction. That's good long-term but means RFC-003's `AgentLauncher::build_command` becomes one of two ways drivers spawn things — we either keep `AgentLauncher` as a helper *used by* drivers (cleanest) or fold it into the trait (bigger churn).
+
+---
+
+## 7. Phasing under the driver framing
+
+Cleaner than the synthesis's Phases 1–5 because the refactor and the ACP work share a foundation.
+
+| Phase | Scope | Notes |
+|---|---|---|
+| **P0 — Driver skeleton** | Define `SessionDriver` trait, `DriverEvent`, `DriverCapabilities`, `DriverHandle`. Wire one driver — `PtyDriver` — that wraps existing PTY + analyzer. `connection/mod.rs` is refactored to dispatch through the driver. No behaviour change, no ACP yet. | Pure refactor. Test parity with golden traces of PTY output and analyzer events. Lands the per-session struct cleanup the codebase already needs. |
+| **P1 — ClaudeHooksDriver** | Move `hooks/handler.rs` ownership into a driver impl. The "install hooks sidecar?" decision becomes "did we instantiate `ClaudeHooksDriver`?" | No new user-facing behaviour. Deletes some HashMaps in `connection/mod.rs`. |
+| **P2 — ClaudeAcpDriver (spike + ship)** | Pull in `agent-client-protocol = "=0.11.1"` (with `unstable_session_resume`, `unstable_session_close`). Spawn `@zed-industries/claude-agent-acp`. Translate ACP frames into the canonical event stream. New launcher entry "Claude Code (ACP)" in the GUI alongside the existing one. | First user-facing ACP capability. Validates the trait and the translator. CC remains usable via hooks, so we can flip per-profile. |
+| **P3 — GenericAcpDriver** | Reuse the ACP transport from P2, parameterize the binary + args via `AgentProfileData`. Pull the [registry JSON](https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json) for one-click agent install in the profile editor. | Codex / Gemini / Goose / Junie / Cline / Cursor / OpenCode / etc. light up at once. |
+| **P4 — Rich UI features** | Tool-call cards, multi-buffer diff review, plan list, permission modal, embedded terminal cards — driven by the canonical events. Capability flags decide what to show per session. | This is most of the UX cost; reusable across all ACP drivers. |
+| **P5 — `terminal/*` and `fs/*` providers** | The agent host implements ACP's host-side methods backed by zremote PTY + worktree (RFC-009) sandbox. Lets ACP agents run shell commands and edit files on the *remote* host. | Where the "Zed for remote hosts" angle becomes user-visible. |
+| **Defer** | ACP-as-server (case B in synthesis), internal protocol replacement (case C). | Both are XL with no current pain. |
+
+---
+
+## 8. Open questions specific to this framing
+
+1. **Where does `LauncherRegistry` (RFC-003) end up?** Recommendation: keep it as a helper that builds `LaunchCommand` for drivers that need to spawn things. Drivers consume it. This avoids re-litigating RFC-003.
+2. **Default driver for `claude` kind in v1.** Stay on `cc-hooks` for safety, with `claude-acp` opt-in? Or flip after a soak? Recommendation: stay on hooks for at least one minor release, ship `claude-acp` as opt-in with a feature flag in the profile editor, then flip the default once parity is confirmed.
+3. **Driver lifetime vs. session lifetime.** A PTY session can outlive the agent's loop (user keeps the shell open after `claude` exits). Does the driver get torn down at `SessionEnded` or stays until the user closes the panel? Recommendation: driver stays as long as the underlying transport (PTY/stdio child) is alive; emits `SessionEnded` as a soft signal but does not self-destruct.
+4. **Translator placement for ACP→ExecutionNode.** Inside the `AcpDriver` (private)? Or shared in a helper crate so external consumers can reuse it? Recommendation: private in v1, lift if we see a second consumer.
+5. **Driver capabilities and the GUI.** Does the GUI fetch capabilities once at session start and cache, or react to live updates? ACP has `session/update` for plan / commands / mode but capabilities themselves are immutable for the session. Recommendation: immutable per session, set at construction.
+
+---
+
+## 9. What this changes in the synthesis recommendation
+
+- **Recommendation flips from "ACP launcher fits into AgentLauncher" → "introduce SessionDriver; ACP/CC-hooks/PTY are sibling drivers."**
+- **Phase ordering changes** — driver skeleton (P0) is the prerequisite, then ClaudeHooks driver (P1, refactor only), then ACP work.
+- **Server-mode tunneling concern dissolves** — drivers run agent-side, events flow over the existing event WS, no new `AgentMessage::AcpFrame` variant needed.
+- **Effort estimate shifts.** The total work is similar (P0+P1 add 2-3 weeks of refactor) but the second and third drivers are much cheaper than they would be as bolt-ons.
+- **Risk list shrinks** — three of the six top risks in the synthesis become non-issues by construction.
+
+This proposal supersedes [README §3 and §6.2/6.3](./README.md) of the synthesis as the recommended target architecture, while keeping all evidence-level material (spec, ecosystem, integration points) unchanged.

--- a/docs/research/zremote-acp-integration-points.md
+++ b/docs/research/zremote-acp-integration-points.md
@@ -1,0 +1,275 @@
+# zremote ↔ ACP integration points
+
+**Branch:** `feature/acp` (no ACP code yet)
+**Author:** zremote-architect (research only — no implementation)
+**Date:** 2026-04-25
+**Sister reports:** acp-spec, acp-ecosystem (parallel research)
+
+---
+
+## TL;DR
+
+- zremote already runs an **agentic-loop pipeline** (process detection + PTY output analyzer + CC hooks). ACP would replace ad-hoc terminal-output scraping with **structured events from any ACP-speaking agent**, dramatically improving fidelity.
+- Best landing zone: **(A) ACP client inside the GPUI app** — drives external agents (Claude Code, Codex, Gemini-CLI, Zed-style agents) over stdio per session. Highest user value, lowest blast radius on existing wire protocol.
+- Second: **(B) ACP agent on `zremote-agent`** — exposes zremote's PTY/terminal infrastructure to external editors (Zed). Useful for multi-host but smaller user base.
+- Third: **(C) Internal ACP between GUI and agent** — nice in theory but would duplicate the existing tagged-enum WS protocol with no current pain. Defer.
+- Existing `AgentLauncher` trait + `LauncherRegistry` (RFC-003) is the natural place to plug ACP-speaking subprocesses. The trait already abstracts "kind → command builder + post-spawn hook".
+- ACP **complements** MCP cleanly: MCP supplies tools to the agent; ACP supplies the agent loop to the host. They live on different wires.
+- Worktrees (RFC-009) and project hooks (RFC-008) flow naturally into ACP's `cwd`, `fs/*`, and `terminal/*` extensions.
+- Highest risk: **double protocols**. The CC-hooks sidecar (`crates/zremote-agent/src/hooks/`) emits structured loop events today; running both that and ACP for the same session would race. Adoption needs a per-launcher switch.
+- Suggested phasing: ship ACP-client launcher for one external agent end-to-end (small slice, validates whole stack) → add `terminal/*` and `fs/*` providers → only then consider exposing ACP from `zremote-agent`.
+- Open question: can the GPUI app spawn local stdio subprocesses on a **remote** host? The current `--server` mode goes through a WS-multiplexed bridge — ACP-over-WS would need framing. See "Risks" below.
+
+---
+
+## 1. Current architecture map
+
+```
++-----------------------------+              +---------------------------+
+|  zremote-gui  (GPUI app)    |  REST/WS     |  zremote-agent (per host) |
+|                             | <----------> |                           |
+| - sidebar / terminal panel  |              | - PTY sessions            |
+| - cc_widgets, command pal.  |              | - bridge:: WS for GUI     |
+| - zremote-client SDK        |              | - agentic:: detector +    |
++-----------------------------+              |   analyzer + manager      |
+        ^                                    | - hooks:: (CC sidecar)    |
+        |                  (server mode      | - claude:: launcher       |
+        |                   only — proxy)    | - mcp::    knowledge srv  |
+        |                                    | - channel:: (CC bridge)   |
+        |                                    | - worktree:: service      |
+        |                                    | - knowledge::, projects:: |
+        |                                    | - local::  (axum router)  |
+        |                                    +---------------------------+
+        |                                              ^
++-------+----------------------+   WS /ws/agent       |
+|  zremote-server  (multi-host)|<--------------------+
+|  (lib used by                |   WS /ws/events
+|   `zremote agent server`)    |   REST /api/...
++------------------------------+
+```
+
+### Crate responsibilities (load-bearing files)
+
+| Crate | Role | Key entry points |
+|---|---|---|
+| `zremote-protocol` | Wire-format types, tagged-enum WS messages | `crates/zremote-protocol/src/lib.rs:1-30`, `terminal.rs:46-306` (AgentMessage / ServerMessage) |
+| `zremote-core` | Shared DB / state / queries / validation | `crates/zremote-core/src/lib.rs`, `state.rs`, `processing/agentic.rs` (loop processing) |
+| `zremote-client` | HTTP/WS SDK consumed by GUI | `crates/zremote-client/src/lib.rs:14-93` (re-exports protocol + SDK types) |
+| `zremote-agent` | Runs on each host (local + server modes) | `crates/zremote-agent/src/lib.rs`, `local/mod.rs:40-328`, `connection/mod.rs:222-919` |
+| `zremote-server` | Multi-host server (Axum) | `crates/zremote-server/src/lib.rs:51-313`, `state.rs` |
+| `zremote-gui` | GPUI desktop app | `crates/zremote-gui/src/views/main_view.rs:39-79`, `cc_widgets.rs` |
+
+---
+
+## 2. Existing wire protocol catalogue
+
+Everything goes through tagged-enum JSON via `#[serde(tag = "type", content = "payload")]` over WebSocket (or REST for sync calls).
+
+### 2.1 Top-level messages (agent ↔ server)
+
+`crates/zremote-protocol/src/terminal.rs`:
+
+| Direction | Variant | Line | Purpose |
+|---|---|---|---|
+| A→S | `AgentMessage::Register` | `terminal.rs:48-57` | Initial handshake |
+| A→S | `AgentMessage::Heartbeat` | `terminal.rs:58-60` | Liveness |
+| A→S | `AgentMessage::TerminalOutput` | `terminal.rs:61-64` | PTY bytes |
+| A→S | `AgentMessage::SessionCreated/Closed` | `terminal.rs:66-74` | Lifecycle |
+| A→S | `AgentMessage::ClaudeAction(...)` | `terminal.rs:178` | CC-specific updates |
+| A→S | `AgentMessage::ChannelAction(...)` | `terminal.rs:179` | Channel bridge replies |
+| A→S | `AgentMessage::AgentLifecycle(...)` | `terminal.rs:181-182` | Generic launcher (RFC-003) |
+| A→S | `AgentMessage::WorktreeCreateResponse` | `terminal.rs:144-152` | RFC-009 sync reply |
+| A→S | `AgentMessage::DirectoryListing/...Settings...` | `terminal.rs:155-176` | Request/response pairs |
+| S→A | `ServerMessage::SessionCreate/Close/Input/Resize` | `terminal.rs:194-220` | PTY control |
+| S→A | `ServerMessage::AgentAction(StartAgent...)` | `terminal.rs:228-231` | Spawn-via-launcher (RFC-003) |
+| S→A | `ServerMessage::ClaudeAction(StartSession...)` | `terminal.rs:226` | Legacy CC start |
+| S→A | `ServerMessage::WorktreeCreateRequest` | `terminal.rs:265-278` | RFC-009 request |
+| S→A | `ServerMessage::ContextPush` | `terminal.rs:298-305` | Inject memories/conventions |
+
+### 2.2 Sub-protocols
+
+- **Claude messages** — `crates/zremote-protocol/src/claude.rs:32-110`: `StartSession`, `DiscoverSessions`, `SessionStarted`, `SessionIdCaptured`, `MetricsUpdate`.
+- **Channel messages** — `crates/zremote-protocol/src/channel.rs:8-136`: `Instruction`, `ContextUpdate`, `Signal`, `ChannelResponse::{Reply,StatusReport,ContextRequest}`, **`PermissionRequest`/`PermissionResponse`** — closest existing analogue to ACP `session/request_permission`.
+- **Agentic messages** — `crates/zremote-protocol/src/agentic.rs:26-74`: `LoopDetected`, `LoopStateUpdate` (with `prompt_message`, `permission_mode`, `action_tool_name`, `action_description`), `LoopEnded`, `LoopMetricsUpdate`, `ExecutionNode`. **Direct conceptual overlap with ACP `session/update`** (text/tool-call/edit streams).
+- **Agents (RFC-003)** — `crates/zremote-protocol/src/agents.rs:18-119`: `AgentServerMessage::StartAgent { profile: AgentProfileData }`, `AgentLifecycleMessage::{Started, StartFailed}`, `SUPPORTED_KINDS = [{ kind: "claude", ... }]`. **This is the seam ACP plugs into.**
+- **Server events to GUI** — `crates/zremote-protocol/src/events.rs:91-267`: 24 variants including `LoopDetected/StatusChanged/Ended`, `ChannelPermissionRequested`, `ExecutionNodeCreated`, `ClaudeSessionMetrics`. The `Unknown` variant (`#[serde(other)]` at line 265) is the protocol's forward-compat lever.
+
+### 2.3 Local-mode REST surface
+
+`crates/zremote-agent/src/local/router.rs:17-307` — ~50 endpoints. Most relevant for ACP:
+
+| Endpoint | Line | Role |
+|---|---|---|
+| `POST /api/agent-tasks` | `router.rs:212-215` | Profile-driven launch (generic, RFC-003) |
+| `POST /api/claude-tasks` | `router.rs:218-221` | Legacy CC start |
+| `GET /api/agent-profiles/kinds` | `router.rs:29-31` | What kinds are supported |
+| `POST /api/sessions/{id}/channel/permission/{request_id}` | `router.rs:276-279` | **Existing permission-grant path** |
+| `POST /api/sessions/{id}/context/push` | `router.rs:69-72` | Inject memories (analog of ACP `session/set_session_mode`?) |
+| `GET /ws/terminal/{session_id}` | `router.rs:290-293` | Per-session PTY WS |
+| `GET /ws/events` | `router.rs:294-295` | Server-event firehose |
+
+---
+
+## 3. Agentic-loop detection today
+
+This is the **single most relevant existing feature** when evaluating ACP. zremote already does loop detection — the question is whether ACP can replace, augment, or coexist with each layer.
+
+### 3.1 Three layers, in order of fidelity
+
+**Layer 1 — Process detection (low fidelity, kind-agnostic):**
+`crates/zremote-agent/src/agentic/detector.rs:11-59` — walks the BFS process tree under each session's shell PID, matches against `KNOWN_TOOLS = [("claude","claude-code"), ("codex","codex"), ("gemini","gemini-cli"), ("aider","aider")]`. Manager runs every second (`crates/zremote-agent/src/agentic/manager.rs:35-101`, interval `connection/mod.rs:83`). Output: `LoopDetected` / `LoopEnded`. Cannot tell working vs waiting vs done.
+
+**Layer 2 — Output analyzer (medium fidelity, regex-based):**
+`crates/zremote-agent/src/agentic/analyzer.rs:371-588` — `OutputAnalyzer` per session. Strips ANSI, parses **OSC 133 prompt markers** (line 666-691) and **OSC 7 cwd**, runs per-provider adapters in `agentic/adapters/{claude,codex,gemini,aider}.rs`. Emits `AnalyzerEvent::{AgentDetected, PhaseChanged, TokenUpdate, ToolCall, CwdChanged, NodeCompleted}` (`analyzer.rs:56-77`). Phase enum (`analyzer.rs:47-54`): `Unknown / ShellReady / Idle / Busy / NeedsInput`. Cost estimation lives in `agentic/patterns.rs::estimate_cost`.
+
+**Layer 3 — Claude Code hooks (high fidelity, CC-specific):**
+`crates/zremote-agent/src/hooks/handler.rs:124-261` is an HTTP sidecar (started per-connection, `connection/mod.rs:368-388`) that CC calls with structured payloads on `PreToolUse`, `PostToolUse`, `Stop`, `Notification`, `Elicitation`, `UserPromptSubmit`, `SessionStart`, `SubagentStart/Stop`, `FileChanged`, `CwdChanged`, `StopFailure`. **This is what ACP looks like, but for CC only.**
+
+The `AgenticStatus` doc-comment at `crates/zremote-protocol/src/agentic.rs:6-12` is explicit:
+> "Only hook-driven `WaitingForInput` / `RequiresAction` statuses are authoritative for user-facing notifications (Telegram, toasts)."
+
+PTY-silence-derived `Idle` is a non-notifying fallback (`connection/mod.rs:144-189`). When hooks are active for a session the analyzer's phase events are suppressed (`hook_mode` check at `connection/mod.rs:144`).
+
+### 3.2 What this stack can/can't do
+
+Can: detect any of the four hard-coded tools, count tokens, summarise tool output, build execution-node history (`ExecutionNode` protocol message → DB → UI via `ExecutionNodeCreated` event).
+
+Can't:
+- Distinguish "tool is asking permission" from "agent is busy" without CC-specific hooks. Codex / Gemini / Aider all fall back to Layer 2 only.
+- Show structured tool-call diffs (we get free-form text in `output_summary`, capped at 500 chars per `analyzer.rs:102`).
+- Cancel a running agent's turn cleanly. Today this requires sending Ctrl-C bytes to the PTY.
+- Stream token-by-token assistant text. Output is line-buffered through ANSI stripping.
+
+ACP gives all four for any agent that speaks it.
+
+---
+
+## 4. Integration-point analysis
+
+### (A) ACP client inside `zremote-gui`
+
+**Use case.** User picks "Claude Code (ACP)" or "Codex (ACP)" from the launcher. The GUI spawns an external ACP-speaking subprocess (locally for standalone mode; over the agent for server mode), drives it directly with structured `session/prompt` calls, and renders streaming `session/update` events as native GPUI views (text, tool-call cards, file-diff hunks, permission modals). Existing terminal panel becomes the "fallback" for non-ACP agents.
+
+**What changes.**
+
+- New crate or module under `zremote-client` (or `zremote-acp/`) with the ACP wire types + a JSON-RPC stdio transport.
+- `zremote-gui`: new view variant alongside `TerminalPanel` for ACP-driven sessions. Permission requests render as a modal (the `WaitingForInput` toast pipeline at `crates/zremote-gui/src/views/main_view.rs:34-79` is the place to dispatch from).
+- `zremote-agent`: a new `AgentLauncher` impl (`crates/zremote-agent/src/agents/`) that, instead of returning a `LaunchCommand` for the PTY, spawns the agent as a child process and proxies stdio frames to/from the GUI. The trait would need an extension method (`spawn_acp` returning a transport handle) since today `AgentLauncher::build_command` returns shell text only (`crates/zremote-agent/src/agents/mod.rs:115-117`).
+- Profile schema: `agent_profiles.settings_json` stays the same; new field `transport: "pty" | "acp"`. This is exactly the kind of evolution `settings_json` was designed for (RFC-003 §1).
+
+**Compatibility.** Adding a new launcher kind (`"claude-acp"`) and a new optional `AgentMessage` variant for streaming ACP frames is straightforwardly forward-compatible per CLAUDE.md table:
+- New variant + `#[serde(other)]` Unknown fallback ⇒ old servers ignore.
+- New `transport` field with `#[serde(default)]` ⇒ old profiles default to PTY.
+
+**Effort.** **L**. Wire types + stdio transport (S/M), GPUI views for streamed updates and permission modals (M), launcher integration with the existing registry + profile editor (M), per-host transport for server mode (M).
+
+**Dependencies.** `zremote-protocol` (new variant for ACP frames in server mode), `zremote-agent::agents` (launcher trait extension), `zremote-gui::views` (new view + permission modal), `zremote-gui::notifications` (already there for waiting-for-input). Worktree integration (RFC-009) provides the natural `cwd` per session.
+
+### (B) ACP agent inside `zremote-agent`
+
+**Use case.** Zed (or another ACP-aware editor running on the user's laptop) connects to zremote's agent and asks it to act as the agent. The agent maps `session/prompt` to its existing PTY+CC stack (or a future first-class loop) and streams updates. This makes zremote a **remote-execution backend for any ACP client**, including non-zremote ones.
+
+**What changes.**
+
+- `zremote-agent` exposes a new transport endpoint (stdio if the editor spawns the agent as subprocess; or WS framed with JSON-RPC for the network case).
+- A new module under `crates/zremote-agent/` that translates the agent's existing internal events (`AnalyzerEvent`, `AgenticAgentMessage`) into ACP `session/update` frames. The hooks pipeline (`hooks/handler.rs`) is the right place to fork — it already produces structured "tool started / waiting / completed" events per CC turn.
+- `terminal/*` operations map onto zremote's PTY layer (`crates/zremote-agent/src/pty/mod.rs`) cleanly — zremote already has PTY create/output/resize/wait-for-exit.
+- `fs/read_text_file` and `fs/write_text_file` need a new sandboxed file-IO module. Worktrees (`crates/zremote-agent/src/worktree/service.rs`) define the natural sandbox root.
+
+**Compatibility.** Pure addition. Old GUIs continue to use the existing REST/WS surface; new editors use ACP. **Major caveat**: hooks-driven CC integration would need to either (a) be the canonical loop driver and emit ACP frames, or (b) be disabled for ACP-driven sessions to avoid double-emission.
+
+**Effort.** **XL**. Bigger because zremote-agent has to faithfully implement an agent loop (not just observe one) — including conversation history, tool wiring, permission policy. Roughly: stdio/WS framing (M), session lifecycle (M), `session/prompt` → existing CC launcher with structured streaming (L), `terminal/*`+`fs/*` providers (M), permission mapping to `channel::PermissionRequest` (M), end-to-end test with a real Zed client (M).
+
+**Dependencies.** Touches PTY, worktree, hooks, channel, claude, MCP — almost the whole agent. High blast radius.
+
+### (C) Internal ACP between `zremote-gui` and `zremote-agent`
+
+**Use case.** Replace (some of) the existing tagged-enum REST/WS protocol with ACP messages between GUI and agent.
+
+**What changes.** Almost everything. `zremote-protocol` becomes a thin re-export of ACP types; `zremote-client` becomes an ACP client; `zremote-agent::local::router` becomes an ACP server. **The current protocol is deeply non-ACP-shaped**: 50+ REST endpoints, projects/knowledge/linear/worktrees/hooks/channels are all out of ACP's scope. ACP would only cover a slice.
+
+**Compatibility.** **High risk.** Every protocol-compat rule in CLAUDE.md applies. We have a working tagged-enum protocol with established forward-compat patterns; replacing it with ACP would require a coordinated rollout across server, agent, and GUI versions.
+
+**Effort.** **XL**, with most of the work being protocol churn rather than user-facing capability.
+
+**Verdict.** Defer. There is no current pain that ACP-as-internal-bus solves. (A) and (B) deliver real user value without rewriting working code.
+
+---
+
+## 5. Overlap / conflict analysis
+
+### 5.1 ACP vs current agentic-loop code
+
+| zremote concept | ACP equivalent | Conflict / harmony |
+|---|---|---|
+| `AgenticLoopManager.check_sessions` (process scan) | `session/new` then track session lifetime explicitly | ACP gives explicit start; process-scan becomes redundant for ACP-driven sessions but still needed for non-ACP fallback. |
+| `OutputAnalyzer::process_output` (stripping ANSI to derive phase) | `session/update` (typed) | ACP fully supersedes this for ACP-speaking agents. Keep analyzer for non-ACP terminals. |
+| `hooks/handler.rs` (CC-specific) | ACP `session/update` + `session/request_permission` | Direct overlap. **Pick one per launcher** — CC could emit either, depending on profile. |
+| `AgenticStatus { Working, WaitingForInput, RequiresAction, Idle, Error, Completed, Unknown }` (`agentic.rs:14-23`) | Implicit in ACP's tool-call states (pending, in_progress, completed, failed) plus `request_permission` | Map at the boundary — produce `LoopStateUpdate` from ACP frames so existing UI keeps working. |
+| `ChannelAgentAction::PermissionRequest` (`channel.rs:127-131`) | ACP `session/request_permission` | Almost identical shape (request_id, tool_name, tool_input). Could share data model. |
+| `ExecutionNode` (`agentic.rs:59-73`) | ACP `session/update` tool-call entries | Different granularity but bridgeable. |
+| `LoopMetricsUpdate` (`agentic.rs:52-58`) | ACP `session/update` token-count fields | Bridgeable. |
+
+### 5.2 ACP vs MCP
+
+**No conflict, complementary.** Today `zremote-agent mcp-serve` (`crates/zremote-agent/src/mcp/mod.rs:30-73`) exposes `knowledge_search`, `knowledge_memories`, `knowledge_context` to whatever agent is running (CC consumes them via MCP). MCP supplies tools to the model; ACP supplies the agent loop to the host. An ACP-driven session would still load the existing MCP server for knowledge tools — no change needed. Confirmed by the code: MCP and ACP would touch different files.
+
+### 5.3 ACP vs REST/WS
+
+The 50-endpoint REST API in `local/router.rs` covers projects, worktrees, knowledge, linear, hooks, command-palette discovery, etc. **Almost none of it overlaps ACP.** ACP would sit beside, not replace, this API. `/ws/events` (server events) might be partially redundant with ACP `session/update` for ACP sessions, but the rest stays.
+
+---
+
+## 6. Risks
+
+1. **Double-driver races.** If a CC session is ACP-driven *and* the existing CC-hooks sidecar is installed, both will emit loop-state events. Solution: the launcher knows the transport; the hooks sidecar should be skipped when transport is ACP. Touch point: `connection/mod.rs:368-388` and the per-session `hook_mode` flag at `connection/mod.rs:144`.
+2. **Server-mode transport for ACP stdio.** Server mode multiplexes everything through `WS /ws/agent`. ACP stdio frames need a new `AgentMessage` variant (e.g. `AcpFrame { session_id, payload: serde_json::Value }`) so the agent-side process IO is tunneled to the GUI. This is straightforward but is a new wire variant.
+3. **State explosion in `connection/mod.rs`.** This file is already 1000+ lines holding 8+ HashMaps (`session_analyzers`, `channel_dialog_detectors`, `channel_bridge`, `delivery_coordinator`, `session_writers`, ...). Adding ACP transports per-session needs care — likely a per-session struct refactor before ACP work, otherwise this file becomes unmaintainable.
+4. **Version skew.** ACP is young; the spec moves. We need a version negotiation step in the GUI (sister report `acp-spec` should cover this). zremote's existing `#[serde(other)]` pattern handles unknown variants but doesn't help with method-name renames.
+5. **Permission policy double-source.** zremote has `permission-policy` per-project (`crates/zremote-server/src/routes/channel.rs`, `local/router.rs:271-283`) and `ChannelDialogDetector` for auto-approve. ACP has its own permission_mode + `request_permission` flow. We need a single decision point per session that takes both into account.
+6. **PTY ownership.** If the GUI talks ACP directly to a child process (case A), the agent's PTY+analyzer pipeline is bypassed. That's fine for ACP-aware agents but breaks the existing `ExecutionNode` history feed for that session. Need to decide whether ACP frames also produce execution nodes (probably yes, via a translator).
+
+---
+
+## 7. Recommended phasing
+
+If we adopt ACP:
+
+1. **Spike (1–2 weeks).** Pick one external ACP-speaking agent (per `acp-ecosystem`'s recommendation), get it running locally as a subprocess driven by the GPUI app. Stub the streaming UI as plain text. No protocol changes yet. Goal: validate JSON-RPC stdio transport + version negotiation.
+2. **Phase 1 — ACP launcher (case A, local mode only).** New `AgentLauncher` impl with `transport: "acp"`. Profile editor gets a transport toggle. New GPUI view renders `session/update` streams with proper text/tool-call/permission cards. No server-mode yet. Touches: `agents/`, `local/routes/agent_tasks`, `gui/views/`.
+3. **Phase 2 — server mode.** Add `AgentMessage::AcpFrame` variant to tunnel ACP through `/ws/agent`. Agent spawns the ACP child; frames are forwarded both ways.
+4. **Phase 3 — `terminal/*` and `fs/*` providers.** Wire ACP's standardized terminal and file ops into zremote's PTY layer and a sandboxed file IO module. Worktree path becomes the FS root.
+5. **Phase 4 — translator to existing UI.** ACP `session/update` → `AgenticAgentMessage::LoopStateUpdate` + `ExecutionNode`. This keeps the sidebar / activity panel / Telegram notifications working unchanged.
+6. **Phase 5 (optional) — case B.** Expose ACP from `zremote-agent` to external editors. Only if (A) succeeds and there is demand from Zed users etc.
+7. **Defer indefinitely.** Case C (internal protocol replacement).
+
+---
+
+## 8. Open questions for team-lead / user
+
+1. **Which external agent first?** Claude Code over ACP, Codex, or Gemini-CLI? (Sister `acp-ecosystem` report should answer.) The choice affects how much we can dogfood — CC-over-ACP would let us replace the hooks sidecar end-to-end.
+2. **Server-mode priority.** Is standalone (`gui --local`) ACP enough for v1, or must server mode work day one? Server mode is significantly more work.
+3. **Coexistence policy with hooks sidecar.** When CC is launched with `transport: "acp"`, do we still install the hooks sidecar (defense in depth) or skip it (cleaner separation)? My recommendation: skip when transport is ACP, document the tradeoff.
+4. **Scope of `terminal/*`.** ACP's terminal provider can run shell commands the agent requests. Do those land in a new zremote PTY session (visible in sidebar) or a hidden one? Sidebar visibility makes more user sense but conflicts with "this is the agent's tool, not a user session".
+5. **Permission policy unification.** Should the existing `permission-policy` per project apply to ACP `request_permission` too? (Recommended: yes, treat ACP requests as identical to the channel `PermissionRequest` flow at the policy layer.)
+6. **Backwards compat for CC tasks.** RFC-003 already deprecated `/api/claude-tasks` softly. Does ACP launch finally retire it, or do we keep three paths (legacy CC, generic launcher RFC-003, ACP)?
+
+---
+
+## 9. Appendix: file map for ACP work
+
+If/when implementation starts, these are the files most likely to change:
+
+- `crates/zremote-protocol/src/agents.rs` — extend `AgentProfileData` with transport, add ACP-specific kind metadata.
+- `crates/zremote-protocol/src/lib.rs` — possibly new `acp` module mirroring `claude` / `channel`.
+- `crates/zremote-protocol/src/terminal.rs:46-306` — new `AgentMessage::AcpFrame` / `ServerMessage::AcpFrame` variants for server-mode tunneling.
+- `crates/zremote-agent/src/agents/mod.rs` — extend `AgentLauncher` trait with optional ACP-spawn method (or new sibling trait).
+- `crates/zremote-agent/src/agents/` — new file `acp.rs` (or per-vendor: `claude_acp.rs`, `codex_acp.rs`).
+- `crates/zremote-agent/src/local/routes/agent_tasks.rs` — branch on transport.
+- `crates/zremote-agent/src/connection/mod.rs:368-388` — gate hooks sidecar install on transport.
+- `crates/zremote-agent/src/connection/dispatch.rs` — new arm for `AcpFrame` server messages.
+- `crates/zremote-gui/src/views/` — new view module for ACP streamed sessions; permission modal; integration with command palette + sidebar.
+- `crates/zremote-gui/src/views/main_view.rs:34-79` — wire ACP `request_permission` into existing toast/notification flow.
+- `crates/zremote-client/src/` — new module for ACP transport (or pull in an external `agent-client-protocol` crate if one exists — sister report covers this).
+
+No new SQL migrations are required for v1: the `agent_profiles.settings_json` blob already accepts arbitrary kind-specific config (RFC-003 §1).

--- a/docs/rfc/rfc-010-session-drivers-and-acp.md
+++ b/docs/rfc/rfc-010-session-drivers-and-acp.md
@@ -1,0 +1,733 @@
+# RFC 010: Session Drivers and ACP Integration
+
+**Status:** Draft
+**Author:** team-lead (synthesizing research from team `acp-research`)
+**Date:** 2026-04-25
+**Branch:** `feature/acp`
+**Research basis:** [`docs/research/README.md`](../research/README.md), [`docs/research/acp-spec.md`](../research/acp-spec.md), [`docs/research/acp-ecosystem.md`](../research/acp-ecosystem.md), [`docs/research/zremote-acp-integration-points.md`](../research/zremote-acp-integration-points.md), [`docs/research/driver-architecture.md`](../research/driver-architecture.md), [`docs/research/acp-rust-reuse.md`](../research/acp-rust-reuse.md)
+
+---
+
+## 0. Terminology
+
+ACP and zremote both use the words "client," "agent," and "session." They mean different things. This RFC resolves the collision as follows:
+
+| Term | In this RFC means | Not to be confused with |
+|---|---|---|
+| **ACP Client** | The role on one side of the ACP wire that hosts the UI/files/terminals. In zremote that role is played by the **`SessionDriver` running inside `zremote-agent`**, never the GUI. | "client" in zremote sense (the GUI/CLI) |
+| **ACP Agent** | The role on the other side of the ACP wire that runs the model loop. Always a **subprocess** (Claude Code adapter, Codex CLI, Gemini, …). | `zremote-agent` (the Rust crate / daemon process) |
+| **ACP child** | The concrete subprocess implementing the ACP Agent role. Always lives on the same host as `zremote-agent`. | — |
+| **`zremote-agent`** | Our Rust process running on each managed host. Plays the ACP Client role internally; speaks zremote's REST+WS to remote GUIs. | ACP Agent |
+| **GUI / CLI** | The user-facing client (GPUI desktop app or `zremote` CLI). Speaks zremote's REST+WS only, **never ACP**. | ACP Client |
+| **Driver** | An implementation of the `SessionDriver` trait owning a single session's lifecycle and producing canonical events. | ACP-specific concept; drivers may have nothing to do with ACP |
+| **ACP session** | A single `session/new` lifecycle inside the ACP wire (agent-host-local). | zremote session (PTY + metadata, may or may not have an ACP child) |
+| **zremote session** | Today's per-PTY session row in the DB; with this RFC, it owns one driver. May contain at most one ACP session. | ACP session |
+| **Canonical event** | A `LoopStateUpdate` / `ExecutionNode` / `PermissionRequest` / `Plan` / `AgentMessageChunk` / `SessionEnded` event emitted by a driver and consumed by GUI / CLI / Telegram / DB. | Raw ACP `session/update` notification (which only the driver sees) |
+| **Tunneling** | Forwarding raw ACP frames over zremote's WS. **This RFC explicitly does not do this.** | Canonical-event flow |
+
+When in doubt, "ACP" prefix means inside-the-driver, "canonical" prefix means crosses-the-network.
+
+---
+
+## 1. Context & Problem
+
+ZRemote needs first-class support for coding agents (Claude Code, Codex, Gemini, Cursor, etc.) and the agent ecosystem is consolidating around the **Agent Client Protocol (ACP)** — an open JSON-RPC protocol with stable Rust SDK, 27+ agents in a public registry, and 6+ editor clients shipping today (Zed, all JetBrains IDEs, Neovim, Emacs, marimo).
+
+### What we have today
+
+Per-session "what's running" is implicit and fragmented across `crates/zremote-agent/`:
+
+- A PTY is always created.
+- A process-tree scanner polls every 1 s looking for four hard-coded binaries (`claude`, `codex`, `gemini`, `aider`).
+- An `OutputAnalyzer` per session strips ANSI, parses OSC 133 prompt markers, and runs vendor-specific regex adapters under `agentic/adapters/`.
+- A Claude Code HTTP hooks sidecar may or may not be installed per connection, producing structured loop events but only for CC.
+- `connection/mod.rs` (1000+ lines, 8+ HashMaps) ties it all together with conditional branches.
+
+The result is a system that works for the four hard-coded vendors at varying fidelity — high for CC (via hooks), low for everyone else (regex on terminal output) — and that gets harder to extend with each new agent.
+
+### What ACP would give us
+
+Replacing the regex stack with structured events from any ACP-speaking agent, gaining:
+- streaming model output (token-level), typed tool calls with diff and terminal embeds, plan tracking, permission gating, clean cancellation, session resume — for **any** agent that speaks ACP, not per-vendor;
+- one-click distribution of 27+ agents via the ACP Registry;
+- an unusual zremote-only opportunity: ACP today is stdio-only, so editors like Zed cannot drive a remote agent. zremote already operates a bidirectional WS tunnel to remote hosts. With our agent-side drivers, "ACP over the network" works through the existing event channel — effectively *Zed for remote hosts*.
+
+### The architectural choice
+
+Two ways to bring ACP in:
+
+- **Bolt-on:** add an ACP launcher next to the current code paths (research synthesis §3, case A). Works, but leaves CC-via-hooks and ACP as parallel pipelines competing for the same session and grows `connection/mod.rs` further.
+- **Refactor + integrate:** introduce a `SessionDriver` abstraction. Every session is owned by exactly one driver picked at start. ACP, CC-via-hooks, plain PTY, and future integrations are siblings, not branches.
+
+**This RFC chooses the second option.** It is the connection-state refactor we already need *and* the foundation ACP plugs into.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- One per-session abstraction (`SessionDriver`) owning all "what runs and what it emits" decisions.
+- A canonical event stream that downstream consumers (UI, DB, Telegram, channel bridge, permission policy) consume regardless of driver.
+- Three driver implementations in v1: PTY (refactor of today's behaviour), CC-via-hooks (refactor), CC-via-ACP (new).
+- A pluggable seam where adding a new ACP agent is a profile entry, not code in five places.
+- Server-mode parity from the start: drivers run agent-side; canonical events flow over the existing WS event channel without new tunneling variants.
+- Replace zero existing UX. Today's terminal panel keeps working unchanged for sessions that don't pick an ACP driver.
+
+### Non-goals
+
+- Exposing ACP from `zremote-agent` to external editors (case B from research). Possibly later, not v1.
+- Replacing the internal GUI↔agent REST/WS protocol with ACP (case C). Defer indefinitely.
+- Custom user-defined drivers loaded as plugins. All v1 drivers live in-tree under `zremote-agent`.
+- Network transport for ACP itself. We do not ship our own HTTP/WS-ACP transport; we tunnel canonical events, not raw ACP frames.
+- Migration of stored session histories. New driver fields are additive on profiles, no SQL migration.
+
+---
+
+## 3. Architecture
+
+### 3.1 Where the seam goes
+
+A new module `crates/zremote-agent/src/session_driver/` defines a single trait `SessionDriver` with an event stream and a small control surface. `connection/mod.rs` becomes a dispatcher: per session it owns one `ActiveDriver` instead of eight specialized HashMaps.
+
+The trait's job is: given a start request, spawn whatever underlying processes the driver needs (PTY, ACP child, hooks sidecar, …), and produce a canonical event stream until the session ends. Control flows the other way for user input, permission decisions, and clean cancel.
+
+### 3.2 The canonical event stream
+
+The events drivers emit are intentionally close to what already exists today in `crates/zremote-protocol/src/agentic.rs` and `channel.rs`:
+
+- raw output bytes for a terminal panel, with a `source` discriminator (`MainPty` for PTY-driver-owned shells and CC-hooks TUIs; `SidePty` for ACP drivers' side PTY per §4.6; `EmbeddedTerminal { tool_call_id, terminal_id }` for ACP terminal embeds);
+- `LoopStateUpdate` — the existing `Working / WaitingForInput / RequiresAction / Idle / Error / Completed` state machine;
+- `ExecutionNode` — one row in the existing tool-call history;
+- `PermissionRequest` — same shape as today's `ChannelAgentAction::PermissionRequest`;
+- new ACP-only signals: `Plan`, `AgentMessageChunk` (token streaming), `SessionEnded { stop_reason }`. PTY drivers leave these off.
+
+Translation work — turning ACP `session/update` notifications into `LoopStateUpdate` and `ExecutionNode` — lives **inside the ACP driver**, not at the GUI boundary. This is the load-bearing decision: every consumer downstream (sidebar, Telegram, activity panel, DB persistence) keeps its current code unchanged.
+
+### 3.3 Capability advertising
+
+Each driver exposes a small set of capability flags (structured loop state, typed diffs, permission requests, streaming text, plan tracking, clean cancel, session resume, slash commands, embedded terminals). The GUI reads them at session start and decides which UI components to render.
+
+Capabilities are **immutable for the lifetime of a session**. ACP itself does have dynamic notifications for slash commands and session modes, but those affect content within an already-advertised capability — they don't toggle the capability itself.
+
+### 3.4 Driver selection
+
+The order of precedence at start time:
+
+1. **Explicit user choice** in the launcher — "Run with: Claude Code (ACP) / Claude Code (hooks) / Codex (ACP) / plain shell".
+2. **Profile-level default** stored as `driver_id` inside `AgentProfileData.settings_json` (free-form JSON blob, no migration needed per RFC-003 §1).
+3. **Built-in default per agent kind** — `claude` defaults to `cc-hooks` in v1, flips to `claude-acp` after a soak release.
+4. **Plain `PtyDriver`** when the user just wants a shell.
+
+This makes the migration a non-event: every existing session is implicitly using either `PtyDriver` (plain shell) or `ClaudeHooksDriver` (CC tasks), depending on what's already happening. No flag day, no schema change.
+
+### 3.5 Server mode and remote access
+
+#### 3.5.1 Cardinal rule
+
+**ACP stdio JSON-RPC never travels over the network.** It lives entirely inside the agent host's process boundary, between the `SessionDriver` and the ACP child process. The GUI and CLI never speak ACP. They speak zremote's existing canonical event stream, which already crosses the network reliably with daemon-mode buffering, reconnection, and multiplex support.
+
+This is the single most important architectural decision in this RFC. It makes server mode work without any new network-layer concepts: ACP-driven sessions are accessed by remote clients through exactly the same channels as PTY-driven sessions are today.
+
+#### 3.5.2 Topology
+
+```
++--------------+       +-----------------+       +------------------------------+
+| GUI (laptop) | HTTPS | zremote-server  |  WS   | zremote-agent (remote host)  |
+| or CLI       |   +   |  - auth, route  | /ws/  |  - SessionDriver (ACP)       |
+|              |   WS  |  - session reg. | agent |    spawns + owns ACP child   |
+| - launcher   |<----->|  - WS multiplex |<----->|  - PTY layer (terminal/*)    |
+| - tool cards |       |    GUI<->agent  |       |  - worktree sandbox (fs/*)   |
+| - diff view  | /ws/  |  - event fan-   |       |  - MCP server (host-local)   |
+| - perm modal | events|    out          |       |       |                      |
+| - plan side  |       +-----------------+       |       v                      |
++--------------+                                 |  +-----------------------+   |
+                                                 |  | ACP child (subprocess)|   |
+                                                 |  | (stdio JSON-RPC)      |   |
+                                                 |  +-----------------------+   |
+                                                 +------------------------------+
+```
+
+The ACP wire stays inside the right-hand box. Only canonical events cross the network.
+
+#### 3.5.3 What flows over the GUI/CLI ↔ agent-host wire
+
+Three categories of traffic, all on the existing protocol surface:
+
+**Commands client → agent** (extending current `ServerMessage` variants):
+
+- `StartAcpSession { profile, driver_id }` — picks a driver and spawns the child
+- `Prompt { session_id, content_blocks }` — `@-mention` resolution and Resource block construction happens GUI-side before send
+- `AnswerPermission { request_id, decision }` — same shape as today's channel-permission flow
+- `Cancel { session_id }` — agent host translates to ACP `session/cancel` notification on the stdio channel
+- `SwitchSessionMode` / `SetConfigOption` — for session modes / config options
+- `LoadSession` / `ResumeSession` — after reconnect
+
+**Canonical events agent → client** (extending current `AgentMessage` variants):
+
+- `LoopStateUpdate` (existing) — Working / WaitingForInput / RequiresAction / Idle
+- `ExecutionNode` (existing) — one tool-call row in history
+- `PermissionRequest` (existing) — translated 1:1 from ACP `session/request_permission`
+- `Plan` (**new**) — ACP-only, other drivers leave off; full entries list per spec
+- `AgentMessageChunk` (**new**) — ACP-only, token-level streaming text
+- `SessionEnded { stop_reason }` — translated from ACP `stopReason`
+
+The two new variants follow the existing forward-compat pattern (new variants + `#[serde(other)] Unknown`) so older clients/servers ignore them.
+
+**Bulk content fetch-on-demand** (extending REST surface):
+
+Tool-call content can be large (10 MB diff, 50 MB terminal output). To keep events small:
+
+- Inline up to ~256 KB directly in the canonical event.
+- Larger content → reference `{ tool_call_id, content_index, size }`; client fetches via new endpoint `GET /api/sessions/{id}/tool-calls/{tcid}/content/{idx}` only when the user expands the card.
+- Streaming output (embedded terminals) — driver maintains the ACP `outputByteLimit` ring buffer; client receives delta chunks.
+
+This is the only REST-surface addition the RFC requires.
+
+#### 3.5.4 ACP host-side methods (`fs/*`, `terminal/*`) execute on the agent host
+
+The agent host is the ACP "client" from the protocol's POV, so when the ACP child calls back with `fs/read_text_file` or `terminal/create`, the request resolves locally with no network hop:
+
+1. Driver receives the request over stdio from the ACP child.
+2. Driver path-validates against the worktree sandbox root (RFC-009) and the project's `permission-policy`.
+3. Driver invokes zremote's internal services:
+   - `fs/*` → sandboxed file IO module; paths outside the worktree root are rejected.
+   - `terminal/*` → existing PTY layer; new PTYs surface in the sidebar tagged as agent-spawned (§4.4).
+4. Driver returns the result to the ACP child over stdio.
+5. In parallel, the driver emits canonical events to the GUI/CLI so the user sees what the agent is doing — typically an `ExecutionNode` update with the diff content or `terminalId`.
+
+**No round-trip to the remote client for fs/terminal.** This is the main argument for the driver-on-host model: if ACP frames travelled to the GUI and back, every `fs/read_text_file` would be two WAN round-trips per call.
+
+#### 3.5.5 Daemon-mode and reconnection
+
+ACP fits cleanly into today's daemon-mode session semantics:
+
+- **GUI/CLI disconnect** → driver does not tear down. The ACP child keeps running on the agent host. Canonical events buffer in the existing event channel.
+- **GUI/CLI reconnect** → client lists sessions via `GET /api/sessions`, opens `/ws/events`, receives the buffered tail.
+- **Resume after agent restart** — if the ACP child survived, client emits `ResumeSession` and the driver calls ACP `session/resume` on the child (or `session/load` for replay from history when supported).
+- **ACP child died during disconnect** — driver emits `SessionEnded { stop_reason: "shell_exit" }`; client surfaces a "Restart agent" banner.
+
+#### 3.5.6 Credentials live on the agent host
+
+ACP child authentication (API keys, OAuth tokens, …) lives in the agent host's secret/profile storage — the same mechanism CC tasks already use. The GUI is a control panel and never holds credentials. Side benefit: laptop loss does not leak agent secrets.
+
+#### 3.5.7 MCP server propagation
+
+ACP `session/new` accepts a list of MCP server configs the agent should connect to. In server mode, the agent host (which is the ACP "client") forwards configs from its local MCP configuration — both the bundled knowledge MCP server and any user-configured ones. The GUI does not need to know about MCP servers; they are a host-side concern.
+
+#### 3.5.8 One driver code path across all three modes
+
+The driver is identical regardless of where the GUI is:
+
+| Mode | Communication |
+|---|---|
+| Standalone (`gui --local`) | Driver runs in the in-process agent spawn; events flow over an in-process channel |
+| Local mode (`agent local`) | Driver on localhost agent; events flow over localhost WS |
+| Server mode | Driver on remote agent host; events flow over the multiplexed WS through `zremote-server` |
+
+This is the structural payoff of the driver framing: ACP is not a "server-mode feature" or a "standalone feature." It is a per-session driver, indifferent to where the session physically runs.
+
+### 3.6 ACP terminals and files (host-side)
+
+ACP defines client-side methods the agent calls back: `terminal/{create,output,kill,wait_for_exit,release}` and `fs/{read_text_file,write_text_file}`. In our model, the **driver** answers them — so they execute on the agent host.
+
+- `terminal/*` maps onto the existing PTY infrastructure with two additions: an `outputByteLimit` ring buffer and a `terminalId` namespace separate from our `session_id`. Sub-terminals spawned by the agent become first-class but visually-tagged sessions in the sidebar (see UX §4.4).
+- `fs/*` operates inside the worktree root from RFC-009. The worktree path is the natural sandbox boundary — paths outside it are rejected. Only text ops are stable in ACP today; binary access goes through MCP if needed (per spec §5).
+
+### 3.7 Permissions
+
+ACP's `session/request_permission` translates one-to-one into the existing `ChannelAgentAction::PermissionRequest`. The same per-project `permission-policy` that gates CC hook prompts gates ACP requests. **Single decision point per session.** The driver is the source-of-truth-translator; the channel layer is the policy layer.
+
+### 3.8 Where `LauncherRegistry` and `AgentLauncher` (RFC-003) end up
+
+Kept, repositioned. RFC-003's launcher trait was designed for "kind → command builder + post-spawn hook." That's exactly what `PtyDriver` and `ClaudeHooksDriver` need internally to spawn their underlying process. Drivers **use** the launcher; they don't replace it.
+
+`AgentLauncher::build_command` does not need to grow an ACP variant. The ACP driver spawns its child directly with the agent's binary + args from the profile. Two seams remain: launchers for shell-based agents, drivers for the per-session lifecycle. They compose.
+
+---
+
+## 4. UX Decisions
+
+### 4.1 Launcher picker
+
+The new-task / new-session UI gains a single "Run with" dropdown:
+
+- "Plain shell" (default, no agent)
+- "Claude Code (hooks)" — current behaviour, stays the v1 default for CC profiles
+- "Claude Code (ACP)" — opt-in in v1, default after soak
+- "Codex (ACP)", "Gemini (ACP)", "Goose (ACP)", … — populated from the ACP Registry the first time the user installs an agent
+
+**Why a dropdown rather than a separate button per agent:** keeps the launcher screen flat and lets the registry grow without UI changes. Profile-level defaults still apply; the dropdown is the override.
+
+**Driver-mode hint text** appears below the dropdown when a non-default driver is selected. For "Claude Code (ACP)" specifically, the hint reads: *"Rich UI (typed cards, diffs, plans). TUI shortcuts (`ESC, ESC`, `/cost`) replaced by typed equivalents. Built-in shell pane for raw shell access."* For "Claude Code (hooks)": *"Full TUI compatibility. No streaming chat panel, no typed diffs."* These hints make the tradeoff explicit at the moment of choice (resolves a §9 fixable item — moves it from "documentation gap" to "UX surface").
+
+### 4.2 What the GUI looks like for an ACP session
+
+The terminal panel is still there, but for ACP sessions it shrinks to the bottom and a structured panel above it renders the canonical event stream:
+
+- **Streaming chat** — `AgentMessageChunk` events appended live with markdown rendering. Capability flag `streaming_text` decides whether this panel shows up at all.
+- **Tool-call cards** — one card per `ExecutionNode`. Status pill animates while in-progress. The `kind` (read/edit/execute/search/think/...) drives the icon. Locations link into the file tree.
+- **Diff hunks inside tool cards** — when the tool call carries `(path, oldText, newText)`, a multi-buffer diff view opens with per-hunk accept/reject. **This is the biggest UX build** of the RFC and the main reason ACP sessions look qualitatively different from PTY sessions.
+- **Plan list in the sidebar** — `Plan` events render a checkable task list with priorities. Updates replace the whole list (per spec).
+- **Permission modal** — `PermissionRequest` becomes an inline prompt under the tool card with the agent's options ("Allow once / Allow always / Reject"). Same flow that today renders for CC channel prompts; the `permission-policy` per project still applies.
+- **Embedded terminals** — when a tool call carries a `terminalId`, a small terminal widget renders inside the card with live tail. The widget keeps showing output even after the agent releases the terminal.
+
+For non-ACP sessions, none of this appears — the panel falls back to a regular terminal. The driver's capability flags decide.
+
+### 4.3 Capability degradation
+
+Drivers below the bar still get a usable UI. The decision tree:
+
+| Capability | If `false`, the GUI… |
+|---|---|
+| `structured_loop_state` | falls back to existing OSC133/regex-derived phase. Sidebar status becomes best-effort, not authoritative. |
+| `typed_tool_calls` | hides tool-call cards entirely; tools surface only as terminal output. |
+| `typed_diffs` | tool-card edits show as plain text patches, not multi-buffer diffs. |
+| `streaming_text` | hides the chat panel; output flows only through the terminal panel. |
+| `plan_tracking` | sidebar plan widget hidden. |
+| `permission_requests` | no inline approval prompts; legacy channel-permission flow if available, otherwise none. |
+| `clean_cancel` | cancel button sends Ctrl-C to the PTY. |
+| `embedded_terminals` | tool-card terminal widgets fall back to "see terminal panel". |
+
+**Why per-feature fallbacks rather than "ACP UI" vs "PTY UI":** lets `ClaudeHooksDriver` (which has structured loop state and permissions but no streaming text or diffs) light up most of the new UI without pretending to be ACP. The flags map naturally to the driver matrix.
+
+### 4.4 Agent-driven terminals visibility
+
+When an ACP agent calls `terminal/create`, the resulting PTY shows up in the sidebar tagged as agent-spawned, with the parent session's color and an arrow icon. Visible by default, hideable via a sidebar filter.
+
+**Why visible:** transparency. The user should be able to see what the agent ran. Hidden agent terminals make the user blind to long-running side effects (a `cargo build` that's been running 20 minutes).
+
+**Why tagged, not promoted:** these are tool calls, not first-class user sessions. Closing the parent session closes them; the user can't accidentally type into them.
+
+### 4.5 Falling back when the agent crashes or the protocol breaks
+
+ACP is young. Three kinds of failure to plan for:
+
+1. **Agent process exits unexpectedly.** Driver emits `SessionEnded { stop_reason: "shell_exit" }` and surfaces a banner in the chat panel: "Agent crashed (exit code N). Logs in stderr." User can restart with one click.
+2. **Protocol version mismatch at `initialize`.** Driver emits a one-line error event and the launcher tries to fall back to the next-best driver for that agent kind (e.g., CC-ACP fails → CC-hooks). Visible "fell back to ..." banner.
+3. **Capability the GUI used isn't actually delivered** (agent advertised `plan_tracking=true` but never sends a plan). Not an error — UI just stays empty. No cleanup needed.
+
+### 4.6 ACP drivers own a side PTY in the same session
+
+When a user moves from `cc-hooks` (PTY-based, full TUI) to `claude-acp` (ACP child runs without a TUI), TUI shortcuts like `ESC, ESC`, `Ctrl-C`, prompt-history arrows, and `!`-prefix bash mode have no native channel into the ACP wire — the ACP child does not expose a PTY, and stuffing bytes into its stdin would break JSON-RPC parsing.
+
+The cleanest fix is **architectural, not a sidecar**: the ACP driver provisions both an ACP child *and* a side PTY in the same session, owned by the same driver, sharing one `session_id`, one cwd (the worktree root), one permission scope, and one sidebar row. The side PTY is a regular shell (`$SHELL` in the worktree); CC does not run inside it. The two resources are independent on the wire — the PTY is for the user, the ACP child is for the model — but unified in the UI.
+
+#### Why this beats a separate-session companion shell
+
+- One sidebar row, not two — less visual noise, easier lifecycle.
+- Same worktree by definition; no risk of drift between agent's view of files and shell's view.
+- Permissions and credentials are shared automatically.
+- Discoverability: the shell pane is right there in the ACP session view; the user does not have to know that "Open companion shell" exists.
+- Decision 4 (one driver per session) holds without amendment — a driver may own multiple resources, just not multiple drivers per session.
+
+#### UI layout
+
+The ACP session view stacks:
+
+```
+┌────────── ACP Session ──────────┐
+│ Chat panel (streaming text +    │  top, dominant
+│ tool cards + diffs + permission │
+│ prompts + plan if compact)      │
+├──────────────────────────────────┤
+│ [Plan list — right rail,         │  optional
+│  collapsible]                    │
+├──────────────────────────────────┤
+│ Shell pane (live PTY in cwd,     │  collapsible,
+│ ~1/3 height by default)          │  ~1/3 of session
+└──────────────────────────────────┘
+```
+
+The shell pane is interactive with full keystroke fidelity for the shell. `ESC, ESC` works for the shell; for CC there is no `ESC, ESC` to interpret because CC does not run there. That is fine — CC-style cancel is reachable from the chat panel via the typed mapping below.
+
+#### Three input channels in one session
+
+The user has three ways to send something:
+
+1. **Chat input** → typed `Prompt` over ACP (the model receives content blocks).
+2. **Shell pane** → raw bytes to the side PTY (the shell interprets them; full TUI fidelity for `git`, `cargo`, `vim`, etc.).
+3. **Quick-action buttons in the chat panel** — surface things ACP does not natively map. For example:
+   - **"Cancel turn"** → `session/cancel` (the typed equivalent of CC's `ESC, ESC`).
+   - **`/cost`, `/compact`, `/clear`** — match against `available_commands_update` from the agent; if not advertised, render as disabled with a tooltip explaining they are unavailable in ACP mode.
+   - **"Run in shell"** mini-form → inject a command into the side PTY (with a confirm step for destructive-looking commands).
+
+This set replaces the earlier "companion shell as separate session" idea — there is no separate session.
+
+#### GUI keystroke mapping in the chat input
+
+The GUI catches known TUI shortcuts in the chat input and translates them into typed ACP actions. The shell pane is unaffected (it always passes raw bytes).
+
+| GUI keystroke (in chat input) | Translated to | Notes |
+|---|---|---|
+| `ESC, ESC` | `Cancel { session_id }` → ACP `session/cancel` | Cancels the active turn. |
+| `Ctrl-C` during active turn | `Cancel` + clear any embedded terminal-output panels | Mirrors "interrupt and stop" intent. |
+| `Ctrl-C` while idle | Clear chat input | GUI-only; never reaches the wire. |
+| Up arrow at empty input | Replay last prompt | GUI keeps a per-session history store; ACP has no history protocol. |
+| `/<command>` typed in input | Match against `available_commands_update`; if unknown, send as plain text | Adapter advertises slash commands per ACP §7.3. |
+
+Raw bytes never reach the ACP child via this layer. By construction, the JSON-RPC stream is never corrupted.
+
+#### Lifecycle of the two resources
+
+- ACP child ends with `stopReason` → shell pane stays open (user may want to inspect).
+- Shell exits → ACP child keeps running; user can re-open a fresh shell.
+- Session close → both terminated.
+- ACP child crashes → banner in chat panel, shell pane unaffected, "Restart agent" button.
+
+#### Generalization across drivers
+
+The shell pane is a **driver-level capability**, not a CC-specific feature. Every driver advertises whether it has one:
+
+| Driver | Shell pane | Mechanism |
+|---|---|---|
+| `pty` | yes (implicit) | driver IS the shell |
+| `cc-hooks` | yes (implicit) | CC TUI runs in the driver's PTY |
+| `claude-acp` | yes (explicit) | driver provisions a separate side PTY |
+| `codex-acp`, `gemini-acp`, `goose-acp`, `generic-acp` | yes (default on, opt-out per profile) | same as `claude-acp` |
+
+Capability flag `shell_pane: bool` is advertised at session start. The GUI either renders the shell pane or it does not. The same widget renders for all drivers that have a PTY, regardless of why.
+
+### 4.7 What does *not* change
+
+- Existing terminal panel for non-ACP sessions: identical behaviour, same shortcuts, same rendering.
+- Sidebar / activity-panel feed: identical, because drivers feed the same canonical events.
+- Telegram and toast notifications: identical, same `LoopStateUpdate` source.
+- Per-project `permission-policy`: identical, applies to all drivers.
+- Worktree, project hooks, knowledge, MCP: untouched.
+
+---
+
+## 5. Phasing
+
+| Phase | Scope | Deliverable | Effort |
+|---|---|---|---|
+| **P0 — Driver skeleton** | Define `SessionDriver` trait, canonical events, capability flags. Wire one driver — `PtyDriver` — that wraps existing PTY + analyzer. Refactor `connection/mod.rs` to dispatch through the driver. Build the golden-trace replay harness ourselves (no upstream test crate to lean on per Decision 23). **Pure refactor, no user-visible change.** | Connection state collapses from 8 HashMaps to 1. Foundation for everything that follows. | M |
+| **P1 — ClaudeHooksDriver** | Move ownership of `hooks/handler.rs` into a driver impl. The "should I install hooks?" decision becomes "did I instantiate `ClaudeHooksDriver`?" No new behaviour. | Two HashMaps deleted from `connection/mod.rs`. CC sessions look identical. | S |
+| **P2 — ClaudeAcpDriver (spike → ship)** | Add deps `agent-client-protocol = "=0.11.1"` and `agent-client-protocol-tokio = "=0.11.1"` with `features = ["unstable"]`. Spawn `@agentclientprotocol/claude-agent-acp@<pinned>` via `AcpAgent::from_str(...).with_debug(...)` (Decision 19). Vendor Zed's `handle_session_update` translator pattern (Decision 21). Advertise the `_meta` capability keys (`terminal_output`, `terminal-auth` per Decision 22). New launcher entry "Claude Code (ACP)" in the GUI alongside the existing one. CC remains usable via hooks; user picks. | First user-facing ACP capability. Effort dropped from L to M because `-tokio` saves the subprocess plumbing and Zed's translator gives us the SessionUpdate match-arms. | M |
+| **P3 — GenericAcpDriver + Registry** | Reuse the `AcpAgent::from_str` plumbing from P2; parameterize the command via `AgentProfileData`. Pull the [ACP Registry JSON](https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json) for one-click agent install in the profile editor. Document the fallback chain for renamed npm packages (Decision 20). | Codex, Gemini, Goose, Junie, Cline, Cursor, OpenCode, Kimi, Qwen, etc. light up at once. | M |
+| **P4 — Rich UI features** | Tool-call cards, multi-buffer diff review with hunk accept/reject, plan list in sidebar, permission modal, embedded-terminal widget. All driven by capability flags so PTY/CC-hooks sessions don't see them and ACP sessions get the full treatment. See §13 for sub-phase breakdown and decisions. | The qualitative UX leap. Reusable across all ACP drivers. | L |
+| **P5 — Host-side `terminal/*` and `fs/*` providers** | Implement ACP's host-side methods on the agent. Worktree from RFC-009 becomes the FS sandbox root. PTY layer gains `outputByteLimit` ring buffer and `terminalId` namespace. Implement `tool_call.meta.terminal_info` pre-handle for Zed-style terminal embeds (Decision 22). | "ACP over the network" is now user-visible: agents run shell commands and edit files on the *remote* host through standard ACP, no per-agent shims. | M |
+| **Defer** | ACP-as-server (case B in research): expose ACP from `zremote-agent` to external editors. Internal protocol replacement (case C). | Possible later. Not v1. | XL each |
+
+P0 is the hard gate — it lands a refactor with full behavioural parity before any new feature builds on it. P1 is small but unblocks deleting CC-specific branching from shared code. P2 is the proof of value; if P2 ships and feels right, P3–P5 are mechanical extensions.
+
+---
+
+## 6. Decisions Made (with reasoning)
+
+This section captures the load-bearing choices and why we picked them. Implementation should treat these as defaults; any reversal needs a new RFC or amendment.
+
+1. **`SessionDriver` is in the agent crate, not the protocol crate.**
+   *Why:* drivers spawn local processes, manage PTYs, talk to ACP children, hold async state. None of that belongs over the wire. The protocol crate stays a pure types crate.
+
+2. **Drivers run agent-side; the GUI sees only canonical events.**
+   *Why:* this makes server-mode parity automatic. No new `AgentMessage::AcpFrame` tunneling variant; no proxying raw protocol frames. It also keeps ACP's stdio-only constraint (the `agent-client-protocol` crate is tokio + stdio) on the host that has the child process — there's no need to make ACP travel.
+
+3. **Translation from ACP → canonical events lives inside the driver.**
+   *Why:* every existing consumer (sidebar, DB, Telegram, channel bridge) stays untouched. If we pushed translation up to the GUI, every consumer would need an "is-this-ACP?" branch.
+
+4. **Capabilities are immutable per session, set at start.**
+   *Why:* it's what ACP semantically gives us, and "capabilities can change mid-session" would force every UI consumer to reactively re-render. ACP's mid-session signals (slash commands, session modes) are *content within* an advertised capability, not capability changes.
+
+5. **Permission policy is single-source: the channel layer.**
+   *Why:* we already have a per-project `permission-policy` plus auto-approve detector for channels. ACP `request_permission` translates into `ChannelAgentAction::PermissionRequest` and goes through the same path. Two policy engines per session is a footgun.
+
+6. **`AgentLauncher` (RFC-003) is kept and used by drivers, not replaced.**
+   *Why:* the launcher does "kind → command + env + cwd," which is exactly what `PtyDriver` and `ClaudeHooksDriver` need internally. Drivers compose with launchers; reverting RFC-003 would be churn for no gain.
+
+7. **Default driver for `claude` profiles in v1: `cc-hooks` (existing behaviour).**
+   *Why:* hooks are the proven path. ACP-CC is opt-in in v1, soaked for at least one minor release, then promoted to default. No flag day for existing users.
+
+8. **No SQL migration in v1.** The `driver_id` field lives in `AgentProfileData.settings_json`, which is already a free-form JSON blob (RFC-003 §1).
+   *Why:* avoids schema churn. Adding `driver_id` later as a first-class column is reversible.
+
+9. **One new optional `AgentMessage` variant for the ACP-only events (`Plan`, `AgentMessageChunk`); no `AcpFrame` tunneling.**
+   *Why:* preserves the existing tagged-enum + `#[serde(other)] Unknown` forward-compat pattern. Old servers ignore the new variant; new servers use it.
+
+10. **Agent-spawned terminals are visible in the sidebar by default.**
+    *Why:* transparency for long-running side effects. Tagged so the user can tell them apart from interactive sessions.
+
+11. **Capability flags drive UI degradation per feature, not per driver.**
+    *Why:* keeps `ClaudeHooksDriver` (structured loop state + permissions but no diffs or streaming text) eligible for most of the new UI, without lying about being ACP.
+
+12. **No custom user-defined drivers as plugins in v1.**
+    *Why:* trait + dyn registration adds ABI/version pinning concerns we don't need to take on yet. All drivers in-tree.
+
+13. **Bind `agent-client-protocol = "=0.11.1"` and `agent-client-protocol-tokio = "=0.11.1"` exactly, with the `unstable` feature group.**
+    *Why:* ACP is moving and the SDK still gates "stabilized" methods (`session/resume`, `session/close`, `session/list`, etc.) behind unstable cargo features at the type level. The actual feature is `unstable` (forwards all the granular flags) — Zed itself pins exactly this. Adding `-tokio` gives us the subprocess+stdio plumbing for free (Decision 19). Pinning exact version + explicit feature opt-in beats surprise breakage.
+
+14. **ACP wire stays inside the agent host's process boundary.**
+    *Why:* §3.5 cardinal rule. The agent host plays the ACP Client role; the GUI/CLI never speak ACP. fs/* and terminal/* execute locally where files and PTYs live. Tunneling ACP frames over WAN would force two extra round-trips per host-side method call.
+
+15. **Bulk content uses an inline-or-fetch threshold, not a streaming protocol.**
+    *Why:* tool-call content can be 10+ MB (large diffs, build logs). Inline up to ~256 KB in canonical events; above that, send a reference and let the GUI fetch on demand via REST. Keeps event channel small without a new streaming format. Threshold is a configuration knob, not a wire-protocol decision.
+
+16. **Credentials for ACP children live on the agent host, not in the GUI.**
+    *Why:* the ACP child process runs on the agent host, so its API keys / OAuth state must be there. Side benefit: laptop loss does not leak agent credentials. Reuses today's profile/secret storage.
+
+17. **MCP server propagation is automatic for bundled servers, opt-in per profile for user-configured ones.**
+    *Why:* the bundled knowledge MCP server is always wanted; user-configured servers may have side effects the user doesn't want auto-applied to every ACP session. Explicit opt-in keeps the principle of least surprise.
+
+18. **Reconnect uses `session/resume` by default, falls back to `session/load` only after agent restart.**
+    *Why:* ACP `resume` restores context without replay (cheap when state is in memory). `load` replays the full history as `session/update` notifications (expensive but the only correct behaviour after process restart). The agent host knows which case it's in by checking whether the ACP child still has a live PID.
+
+19. **Use `agent-client-protocol-tokio` for child-process plumbing; do not roll our own.**
+    *Why:* the crate ships `AcpAgent::from_str(...).with_debug(...)` which already covers subprocess spawn, line-framed stdio, stderr capture/tee, kill-on-drop (`ChildGuard`), and the `select!` between protocol future and child exit. Reuse research measured this saves ~250–400 LoC vs. building it ourselves and removes a class of bugs around child cleanup. P2 effort drops from L to M as a result. The convenience constructors (`AcpAgent::zed_claude_code()` etc.) hardcode deprecated npm names; we use `from_str` with our own command line (Decision 20).
+
+20. **Spawn `@agentclientprotocol/claude-agent-acp` for the Claude Code adapter; do not use the SDK's `zed_claude_code()` constructor.**
+    *Why:* the adapter has been renamed twice — `@zed-industries/claude-code-acp` (deprecated) → `@zed-industries/claude-agent-acp` (npm mirror) → `@agentclientprotocol/claude-agent-acp@0.31.0` (canonical). The Rust SDK's convenience constructors still hardcode the deprecated name. We pin the canonical name explicitly via `AcpAgent::from_str("npx -y @agentclientprotocol/claude-agent-acp@<pinned-version>")`, with a documented fallback to the npm mirror for environments behind older registries.
+
+21. **Vendor (with attribution) two specific patterns from Zed's open-source `acp_thread` and `agent_servers` crates (Apache-2.0).**
+    The two are: (a) the `handle_session_update` translator match-arms at `zed/crates/acp_thread/src/acp_thread.rs:1428-1504`, including the user-chunk dedup logic and provisional-title handling; (b) the `AcpConnection::stdio` task-ownership pattern at `zed/crates/agent_servers/src/acp.rs:526-902` showing four `Task<()>` fields (`io_task`, `dispatch_task`, `wait_task`, `stderr_task`) on the connection struct.
+    *Why:* these match-arms encode a year of integration learnings against real agents (CC adapter, Codex, Gemini). Re-deriving them from spec alone would mean rediscovering the same edge cases. Zed-specific bits (GPUI `Entity<...>` types, workspace abstractions) are stripped during vendoring. License compliance: add `LICENSES/Apache-2.0-zed.txt`, prefix vendored files with `// Adapted from zed-industries/zed at <commit>, Apache-2.0.`, add workspace `NOTICE` file.
+
+22. **Replicate Zed's undocumented `_meta` interop conventions for terminal embeds and capability extensions.**
+    *Why:* the canonical `claude-agent-acp` adapter checks for `clientCapabilities._meta.terminal_output: true` and `clientCapabilities._meta["terminal-auth"]: true` — without these meta keys, terminal output streaming inside tool calls **does not work**, and there is no fallback. Tool-call terminal embeds also use `tool_call.meta.terminal_info` rather than a first-class spec field. Neither is documented in the ACP spec; both are read from Zed's source. Our `InitializeRequest` advertises both meta keys; our translator handles `tool_call.meta.terminal_info` via a pre-handle hook before the standard `handle_session_update` dispatch. **Without this, we don't interop with the largest agent in the registry.** Captured as a P2/P5 requirement, not a P4 nice-to-have.
+
+23. **`agent-client-protocol-test` is unpublished (`publish = false`); P0's parity test harness is hand-built.**
+    *Why:* an earlier optimistic framing assumed we could ride on the SDK's test crate. The crate is internal to the SDK workspace (verified 404 on crates.io) and contains only mock JSON-RPC types for SDK doctests, not a parity harness. P0 must build its own golden-trace replay against captured PTY+analyzer outputs, as planned in §11.1.
+
+24. **ACP drivers own a side PTY in the same session, not a separate companion session.**
+    *Why:* §4.6 cardinal rule. Decision 4 says *one driver per session*, not *one resource per driver* — a driver may own multiple resources (an ACP child and a side PTY) provided it surfaces them as one session to the rest of the system. Earlier framing (separate companion shell session) was rejected because it added a sidebar row, complicated lifecycle management, risked cwd/permission drift between the two sessions, and obscured a feature most users would benefit from. The unified design also generalizes: every driver advertises a `shell_pane` capability, and every driver that has one (PTY, CC-hooks, ACP) renders the same widget in the GUI.
+
+25. **Driver control surface separates typed prompt from raw PTY input.**
+    *Why:* a consequence of Decision 24. `DriverControl::send_prompt(content_blocks)` carries typed ACP prompts (or analogous typed input for hooks-driver chat). `DriverControl::send_pty_input(bytes)` carries raw bytes for any of the driver's PTYs (main or side, addressed by `PtySource`). PTY-only drivers expose only the second; ACP drivers expose both. Keeping them as distinct methods avoids an enum-discriminator dance at every call site and makes the typed-vs-raw distinction self-documenting.
+
+---
+
+## 7. Risks
+
+1. **Trait-design tax.** `DriverEvent` and `DriverCapabilities` need to cover both PTY and ACP without becoming a mush. Wrong shape and every UI consumer ends up branching on driver kind, defeating the point. Mitigation: P0 lands the trait *with `PtyDriver` only*, before any ACP code. If the trait feels wrong, we change it then.
+
+2. **`connection/mod.rs` refactor scope.** Touching the busiest file in the agent. Mitigation: P0 must be parity-testable with captured traces before merge; CI runs golden replays.
+
+3. **ACP version churn.** SDK is 0.11.x with unstable features for things the spec calls "stable." Mitigation: pin exact version, opt into unstable features explicitly, document in `Cargo.toml`. Re-evaluate every minor release.
+
+4. **Diff-review UI is a real build.** Multi-buffer with hunk-level accept/reject is the largest UX item. Mitigation: P4 phase reflects this; don't conflate P2/P3 (transport works) with P4 (UI is great).
+
+5. **`fs/*` sandbox correctness.** ACP `fs/write_text_file` could in principle let an agent write outside the worktree if we're sloppy. Mitigation: hard path-validation against the worktree root; reject anything that resolves outside. P5 owns this; security-reviewer must sign off before merge.
+
+6. **Server-mode ACP child process management.** Restart semantics, env vars, cwd, signal handling on the agent host need to work the same way RFC-003 launchers work. Mitigation: drivers reuse the launcher utilities for child-process plumbing.
+
+7. **`@zed-industries/claude-agent-acp` is npm-distributed.** We need Node.js on agent hosts to run it. Mitigation: documented dependency; future binary distribution via the registry's `binary.<platform>` mechanism.
+
+8. **Capability advertising drift.** An agent advertising `plan_tracking=true` but never sending a plan is fine; advertising `false` and sending plans anyway is not. Mitigation: drivers ignore protocol events for capabilities they advertised as off; warn-log on mismatch.
+
+9. **Bulk content storms over WAN.** A single `cargo build` tool-call could push 50 MB of terminal output across the event channel before any throttling kicks in. Mitigation: per-event 256 KB inline cap (Decision 15) plus the `outputByteLimit` ring buffer required by ACP's `terminal/create` spec. Hard cap on total per-tool-call accumulated bytes (configurable, default 50 MB) with truncation indicator after.
+
+10. **ACP child auth lifecycle on agent host.** API keys may rotate; OAuth tokens expire. The agent host must surface re-auth requests to the user (who is on the GUI). Mitigation: ACP `authenticate` request from child → driver → canonical `PermissionRequest`-style event surfaced in GUI as inline auth prompt. Auth completes agent-side, GUI never sees the credential. (Mostly future work — `unstable_auth_methods` blocks v1.)
+
+11. **Sandbox bypass via symlinks or relative paths.** A maliciously-crafted prompt could try to make the agent emit `fs/write_text_file` to `../../../etc/passwd`. Mitigation: canonicalize the path, check it's a descendant of the worktree root *after* canonicalization. Reject symlinks pointing outside. P5 owns this; security-reviewer must sign off.
+
+12. **GUI/CLI version skew.** Old GUI connecting to new agent that emits `Plan` / `AgentMessageChunk` variants. Mitigation: `#[serde(other)] Unknown` variant in `AgentMessage` discards them gracefully. New GUI connecting to old agent: capability flags advertise `plan_tracking=false` etc., GUI hides those panels. Both directions handled by the existing forward-compat pattern.
+
+13. **De-facto-spec drift via undocumented `_meta` extensions.** Zed has effectively become the reference implementation by inventing `_meta` keys (`terminal_output`, `terminal-auth`, `tool_call.meta.terminal_info`) that mainstream agents now require. Future agents may invent new ones we don't know about until something silently doesn't work. Mitigation: monitor Zed's `agent_servers` crate at every release for new meta keys; track in a checklist file (e.g., `docs/research/acp-zed-meta-tracking.md`); adopt new keys reactively rather than waiting for spec updates. Reach out to upstream working group to push for spec-level standardization.
+
+14. **npm-package name churn for adapters.** The Claude adapter has been renamed twice in <1 year. Other adapters likely will be too. Mitigation: pin canonical org name (`@agentclientprotocol/...`), document fallback to historical names in the profile editor, surface a startup warning when spawn falls back.
+
+15. **Zed-vendored translator drifts from upstream.** Vendoring `handle_session_update` (Decision 21) means we now own a copy that doesn't auto-update with Zed's fixes. Mitigation: track Zed's `acp_thread.rs` between releases (we re-pull on each ACP minor bump); add prominent comment in the vendored file linking to upstream commit. Any change to upstream's translator is reviewed for our copy in the same PR that bumps the SDK pin.
+
+---
+
+## 8. Open Questions
+
+The following items still need a decision from the user before implementation starts. Recommendations are the team-lead's default; the user can override.
+
+1. **Default driver flip schedule.** When does `claude` profile default switch from `cc-hooks` → `claude-acp`? Options: (a) one minor release of soak with no regressions, (b) measurable parity metric (e.g., loop-state event fidelity), (c) explicit user opt-in via setting forever. Recommendation: (a) — one minor release.
+2. **Long-term coexistence of `cc-hooks` and `claude-acp`.** If both work indefinitely, do we keep them both or remove `cc-hooks` after N releases? Recommendation: keep both for at least one major version after the default flip; remove only if `claude-acp` proves strictly better on every dimension.
+3. **Auth UX for hosted agents in P3.** GitHub Copilot CLI / Cursor / Cline need OAuth or API keys. `unstable_auth_methods` blocks in-protocol auth in v1. Options: (a) ship P3 with "agent's own CLI handles auth externally before zremote sees it," (b) wait for `authenticate` to stabilize. Recommendation: (a). Document the dependency in the profile editor.
+4. **Bulk content threshold tunability.** The 256 KB inline cap is a default. Per-project override? Per-tool-call kind override (e.g., diffs always inline, terminal output always referenced)? Recommendation: workspace-global setting with a sensible default; revisit if user feedback demands more granularity.
+5. **Agent-spawned terminal cleanup.** When the parent ACP session ends, what happens to terminals the agent created via `terminal/create`? Spec says `terminal/release` is required cleanup. If agent crashes mid-turn before releasing, do we kill orphaned PTYs immediately or keep them for the user to inspect? Recommendation: keep for inspection, surface in sidebar with a "released" status; auto-kill after a configurable timeout (default 1 hour).
+6. **Driver lifetime when ACP child exits.** ACP child sends `stopReason: "end_turn"` and the user has not closed the GUI panel. Does the driver hold the resources (PTY allocation if any, MCP server connections) for a possible follow-up `session/prompt`, or tear down? Recommendation: hold for follow-up. The user closing the panel triggers full teardown.
+7. **Telegram and external notification mapping for ACP-only events.** `Plan` and `AgentMessageChunk` are new. Does the existing Telegram bot route them somewhere meaningful, or only consume `LoopStateUpdate` as today? Recommendation: keep Telegram on `LoopStateUpdate` only; new event types are GUI-rich-UI material.
+
+The following were considered open earlier and are now resolved by §3.5 + Decisions 14–18:
+- *MCP servers in `session/new`* → Decision 17 (auto for bundled, opt-in for user-configured)
+- *Session resume policy* → Decision 18 (`resume` if child alive, `load` if restarted)
+- *Headless / standalone mode parity* → §3.5.8 (one driver path across all three modes)
+
+---
+
+## 9. Tradeoffs vs. ACP-native GUIs (Zed, JetBrains)
+
+The driver-on-host model means the GUI sees a curated, normalized view of an ACP session, never the raw protocol. This buys us multi-host / daemon / server mode for free; it costs us things ACP-native clients get out of the box. Honest accounting:
+
+### Inherent (cannot be fixed without changing the model)
+
+1. **`fs/read_text_file` cannot return unsaved editor buffers.** Spec §5.1 expects the client to return open dirty buffer content rather than disk. Zed does this; we cannot, because the user's editor is on the laptop and zremote isn't an editor. Agent always sees disk state on the remote host.
+2. **No agent-following live cursor.** When a tool call carries `locations[]`, Zed moves its editor cursor to that path:line live. We render clickable links instead; there's no editor to follow.
+3. **Edits don't flow through the user's undo stack.** `fs/write_text_file` lands directly on the agent host's disk. Undo for an agent edit is `git revert`, not Ctrl-Z.
+4. **No LSP context in tool-call rendering.** Zed has local language servers, so diffs render with full LSP awareness. We can ship tree-sitter syntax highlighting from the agent host, but cross-symbol context is out of reach.
+5. **Streaming-text latency is WAN-bound.** Token streaming feels slower than local (50–150 ms RTT typical). Throughput is fine; the *feel* is different.
+
+### Fixable, but as ongoing UX work
+
+6. **Forward-compat lag.** A new ACP feature in upstream means a four-step rollout for us — bump SDK pin → extend driver translator → add canonical event variant if needed → extend GUI rendering — vs. one step for Zed. Expect to be one minor release behind upstream.
+7. **Translator fidelity loss for new content types.** When ACP adds, say, an "embedded notebook" tool-call content type, we have to decide: add it to `ExecutionNode`, drop it, or tunnel as opaque. Each new content type is a small design decision rather than free.
+8. **Custom ACP extensions silently dropped by default.** `_zed.dev/*` methods and `_meta` fields are for vendor-specific data. Our translator strips them. Adding generic `_meta` passthrough is doable but extra work.
+9. **Slash command UI, mode picker, config-option picker, image/audio rendering** all need to be built. Zed has these polished. Scoped to P4.
+10. **No profile-level tool permissions.** Zed has granular per-tool permissions for its first-party agent; for external agents only runtime prompts. We have no first-party agent at all — runtime prompts via channel-permission flow are our only level.
+
+### What zremote gains in exchange
+
+Listed for balance — this is why we accept the costs above:
+
+- ACP over the network (stdio-only protocol now reaches remote hosts via canonical events)
+- Agent runs where the project lives — no file sync, no sshfs
+- Multi-host fan-out from a single GUI/server
+- Daemon mode survives laptop close/reconnect
+- Credentials stay server-side
+- Same session reachable from laptop GUI, CLI, Telegram bot
+
+### The one inherent tradeoff
+
+Everything in "Inherent" above traces to a single fact: **zremote GUI is not the user's editor.** It is the operator console for a remote development environment. ACP features that assume "the GUI holds the files in dirty buffers with an LSP attached" — `fs/read_text_file` unsaved-buffer semantics, agent-following cursor, undo integration, LSP-aware diffs — degrade for us by construction. That is the structural cost of solving remote development rather than local editing. The driver framing does not introduce this tradeoff; it merely makes it explicit.
+
+### A separate tradeoff: same agent, ACP mode vs. native-CLI mode
+
+For agents we already support natively (today: Claude Code via hooks), choosing the ACP driver loses **TUI affordances** that are agent-specific and have no protocol channel. Concretely for CC: `ESC, ESC` semantics, `!`-prefix bash mode, `/cost`, `/compact`, prompt-history arrows — these live in CC's TUI which the ACP adapter does not expose (it uses CC's SDK, not the binary).
+
+Mitigations land in §4.6:
+
+- The ACP driver provisions a side PTY in the same session, so users get a real shell on the same host and cwd as the agent. `!`-prefix-style ad-hoc shell needs are covered there.
+- The GUI keystroke layer remaps known TUI shortcuts in the chat input to typed ACP equivalents (`ESC, ESC` → `session/cancel`, slash commands → `available_commands_update` matches, etc.).
+- For CC-specific TUI features without any typed equivalent *and* not coverable by the side PTY, the user-controlled fallback is Decision 7 — the launcher dropdown lets them pick `cc-hooks` per session.
+
+This tradeoff is **per agent**: ACP-only agents (Codex, Gemini, Goose, Junie, …) have nothing to lose because they have no native zremote integration to compare against. Only `cc-hooks` ↔ `claude-acp` carries the choice. As more agents move to ACP-as-primary upstream, the tradeoff narrows to legacy CC affordances specifically.
+
+---
+
+## 10. Out of Scope
+
+- Custom transports for ACP itself. We don't ship our own HTTP/WS-ACP — we ship canonical events.
+- Exposing ACP from `zremote-agent` to external editors (Zed, JetBrains). Possible future RFC.
+- Replacing the GUI↔agent REST/WS protocol with ACP. Not justified.
+- A user-facing plugin SDK for third-party drivers. v1 drivers are in-tree.
+- `fs/read_binary_file` and other not-yet-stable ACP methods. Bound to spec stability.
+
+---
+
+## 11. Testing Strategy
+
+The refactor in P0 + P1 plus the new ACP layer in P2+ create three distinct testing surfaces. Each phase blocks merge on its own gate.
+
+### 11.1 P0 parity tests (golden-replay) — built in-house
+
+The connection-state refactor must not change observable behaviour. Strategy:
+
+- Capture canonical event traces from a representative set of current sessions (PTY, plain shell; PTY + CC hooks active; PTY with various agentic tool detections).
+- After the refactor, replay the same PTY input bytes and shell timing through the new `PtyDriver` pipeline.
+- Diff the resulting canonical event traces. Any divergence blocks merge. Allow only intentional differences (e.g., reordering of events that were never causally ordered in the first place — these need explicit acknowledgement).
+
+**No upstream test crate to lean on** (Decision 23): `agent-client-protocol-test` is `publish = false` and contains only mock JSON-RPC types for SDK doctests, not a parity harness. We build this ourselves. Lives in `crates/zremote-agent/tests/golden_replay/`. Captured fixtures in `crates/zremote-agent/tests/fixtures/`.
+
+### 11.2 Driver-trait conformance tests
+
+A small test harness exercises every driver against the same scripted scenarios:
+
+- Start, send simple prompt, receive at least one event, end cleanly
+- Cancel mid-prompt, verify clean shutdown
+- Reject permission, verify the agent does not proceed
+- Capability advertising matches what the driver actually emits
+
+Each driver must pass the suite. Lives in `crates/zremote-agent/src/session_driver/conformance/`.
+
+### 11.3 ACP translator unit tests
+
+The ACP→canonical translator is the most subtle component. Test against captured `session/update` JSON fixtures from real Claude Code adapter runs:
+
+- Each ACP `sessionUpdate` variant maps to the expected canonical event(s)
+- Tool-call content (text / diff / terminal embed) translates correctly into `ExecutionNode` shape
+- Permission requests round-trip through the channel-permission policy
+- Unknown / `_meta` fields are dropped silently with a debug log
+- Capability advertising at `initialize` is preserved on the driver handle
+
+Lives in `crates/zremote-agent/src/session_driver/acp/translator/tests/`.
+
+### 11.4 End-to-end with real Claude Code adapter
+
+In CI, a smoke test that spawns `@zed-industries/claude-agent-acp` with a recorded prompt against a stub model endpoint, drives one full prompt-turn through `ClaudeAcpDriver`, and asserts canonical events arrive in the expected shape and order. Skipped if Node.js is unavailable.
+
+This catches: SDK-version mismatches, environment / cwd / args drift in our spawn code, permission flow integration bugs.
+
+Lives in `crates/zremote-agent/tests/e2e_acp.rs`.
+
+### 11.5 Server-mode tunneling test
+
+Two-process test: spin up a `zremote-agent local` and a GUI mock that connects via the `zremote-client` SDK. Drive a `ClaudeAcpDriver` session from the mock GUI and verify all canonical events arrive over the WS bridge unchanged.
+
+Lives in `crates/zremote-agent/tests/server_mode_acp.rs`.
+
+### 11.6 Security / sandbox tests for `fs/*` (P5)
+
+Adversarial inputs against the sandboxed file IO module:
+
+- Absolute paths outside the worktree → reject
+- Relative paths with `..` → reject after canonicalization
+- Symlinks pointing outside the worktree root → reject
+- Path encoding tricks (URL-encoded slashes, NUL bytes) → reject
+- Reads on world-readable system files (`/etc/passwd`) when worktree is `/tmp/foo` → reject
+
+Security-reviewer signs off before P5 merges.
+
+Lives in `crates/zremote-agent/src/session_driver/acp/host_methods/fs/tests/`.
+
+### 11.7 What's NOT tested
+
+- Real model output. We use stub responses; testing actual LLM behaviour is out of scope.
+- Network failure modes. Existing daemon-mode tests already cover WS reconnect; we ride on those.
+- Performance / latency. Measured by deployment metrics, not asserted in CI.
+
+---
+
+## 12. Per-Crate Work Map
+
+Where work lands across the workspace. Use this when sizing PRs and assigning reviewers.
+
+| Crate | What changes | Phase |
+|---|---|---|
+| `zremote-protocol` | Two new `AgentMessage` variants (`Plan`, `AgentMessageChunk`); two new `ServerMessage` variants for ACP commands (`StartAcpSession`, `AnswerPermission` extensions if needed). New REST shape for bulk content fetch. **No removal of existing variants.** | P2 (events), P4 (REST endpoint), P5 (none) |
+| `zremote-core` | Possibly: a `driver_id` column on session rows if we promote it from JSON blob in a later release. **Not in v1** (Decision 8). New event handlers for `Plan` / `AgentMessageChunk` to persist to DB. | P2, P4 |
+| `zremote-client` | New convenience methods on the SDK for `StartAcpSession`, `AnswerPermission`. New polling helpers for new event variants. Optional: registry-fetch helper. | P2, P3 |
+| `zremote-agent` | All driver work: new `session_driver/` module, refactor of `connection/mod.rs`, ACP child spawn, translator, host-side providers. **The bulk of the RFC.** | P0–P5 |
+| `zremote-server` | Forward new `AgentMessage` variants to GUI subscribers via the existing event firehose. Same forward-compat pattern as today; no new logic. | P2 |
+| `zremote-gui` | New views: tool-call cards (P4), multi-buffer diff reviewer (P4), plan list widget (P4), permission modal (P4), embedded-terminal widget (P4), launcher dropdown including ACP entries (P2). Capability-flag-driven degradation throughout. | P2 (basic), P4 (rich) |
+| `Cargo.toml` (workspace) | Add `agent-client-protocol = "=0.11.1"` and `agent-client-protocol-tokio = "=0.11.1"`, both with `features = ["unstable"]`. **Do not** add `agent-client-protocol-test` (unpublished per Decision 23) or `agent-client-protocol-conductor` (proxy-chain protocol, wrong shape per reuse research). For dev only: `cargo install agent-client-protocol-trace-viewer` for inspecting JSON-RPC traces. | P2 |
+| `LICENSES/Apache-2.0-zed.txt` (new) + workspace `NOTICE` (new) | Required by Apache-2.0 §4 for the vendored translator pattern from Zed (Decision 21). | P2 |
+| `docs/research/acp-zed-meta-tracking.md` (new) | Living document tracking which `_meta` extension keys mainstream agents require, derived from Zed's `agent_servers` source (Risk #13). Updated whenever we bump the SDK pin. | P2 onwards |
+| `docs/rfc/` | This file. Future amendments as decisions evolve. | — |
+| `docs/research/` | Research lives here; don't move it into `rfc/`. | — |
+
+### File-level hot spots
+
+The files most likely to balloon in size or churn during this RFC:
+
+- `crates/zremote-agent/src/connection/mod.rs` — refactored in P0; expect a 30–50% line reduction as the per-session HashMaps collapse
+- `crates/zremote-agent/src/session_driver/mod.rs` (new) — the trait + dispatcher
+- `crates/zremote-agent/src/session_driver/acp/translator.rs` (new) — vendored from Zed's `handle_session_update` (Decision 21); most subtle code; needs §11.3 unit-test density. Header comment links to upstream commit per Apache-2.0 §4.
+- `crates/zremote-agent/src/session_driver/acp/connection.rs` (new) — modelled on Zed's `AcpConnection::stdio` task-ownership pattern (Decision 21); holds `_io_task`, `_dispatch_task`, `_wait_task`, `_stderr_task` as `Task<()>` fields per CLAUDE.md async-task convention.
+- `crates/zremote-gui/src/views/agent_session/` (new) — most UX work; expect to live in a dedicated module
+
+### Files explicitly NOT touched
+
+- `crates/zremote-agent/src/mcp/` — MCP integration stays as-is. ACP-driven sessions configure MCP servers via `session/new` (Decision 17).
+- `crates/zremote-agent/src/worktree/` — provides the FS sandbox root for P5 (RFC-009); no changes needed.
+- `crates/zremote-agent/src/projects/`, `knowledge/`, `linear/`, `hooks/` (the project hooks system from RFC-008) — orthogonal to this RFC.
+- Database schema — Decision 8.
+
+---
+
+## 13. References
+
+- Research synthesis: [`docs/research/README.md`](../research/README.md)
+- Driver-architecture proposal: [`docs/research/driver-architecture.md`](../research/driver-architecture.md)
+- ACP spec deep-dive: [`docs/research/acp-spec.md`](../research/acp-spec.md)
+- ACP ecosystem survey: [`docs/research/acp-ecosystem.md`](../research/acp-ecosystem.md)
+- zremote integration points: [`docs/research/zremote-acp-integration-points.md`](../research/zremote-acp-integration-points.md)
+- Adjacent RFCs:
+  - RFC-001 (agentic loops fix)
+  - RFC-003 (agent profiles + `LauncherRegistry`)
+  - RFC-008 (project hooks)
+  - RFC-009 (worktree UX) — provides FS sandbox root for P5
+- External: [agentclientprotocol.com](https://agentclientprotocol.com), [agent-client-protocol crate](https://crates.io/crates/agent-client-protocol), [ACP Registry JSON](https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json), [`@zed-industries/claude-agent-acp`](https://github.com/zed-industries/claude-agent-acp)


### PR DESCRIPTION
## Summary

- Introduces RFC-010 proposing a `SessionDriver` abstraction where PTY, CC-hooks, and ACP are sibling per-session drivers — replaces `connection/mod.rs` HashMap sprawl with a single dispatcher.
- Lands the research backing the RFC: protocol spec, ecosystem survey, zremote integration points, driver-architecture proposal, and Rust crate-level reuse strategy in `docs/research/`.
- No code changes yet. RFC status: **Draft**.

## What this RFC decides

**Architecture**
- ACP wire stays inside the agent host's process boundary; the GUI/CLI never speak ACP — they consume canonical events (`LoopStateUpdate`, `ExecutionNode`, `PermissionRequest`, plus new `Plan` and `AgentMessageChunk`).
- Server mode works without `AcpFrame` tunneling: drivers run agent-side, host-side `fs/*` and `terminal/*` execute locally, only canonical events traverse WAN.
- ACP drivers own a side PTY in the same session for raw shell needs (`!`-prefix-style use cases) — Decision 4 (one driver per session) preserved.

**Reuse**
- Depend on `agent-client-protocol = "=0.11.1"` and `agent-client-protocol-tokio = "=0.11.1"` with `features = ["unstable"]`.
- Vendor (Apache-2.0 attribution) Zed's `handle_session_update` translator pattern and `AcpConnection::stdio` task-ownership pattern.
- Replicate Zed's undocumented `_meta` interop conventions (`terminal_output`, `terminal-auth`, `tool_call.meta.terminal_info`).
- Skip `agent-client-protocol-conductor` (proxy-chain protocol, wrong shape) and `agent-client-protocol-test` (unpublished).

**Phasing**
- P0 — driver skeleton refactor (parity-tested via golden-replay)
- P1 — ClaudeHooksDriver (refactor only)
- P2 — ClaudeAcpDriver (effort dropped L→M after reuse research)
- P3 — GenericAcpDriver + ACP Registry
- P4 — rich UI (tool-call cards, diff reviewer, plan list, permission modal, embedded terminals) — to be planned in detail
- P5 — host-side `terminal/*` and `fs/*` providers (worktree from RFC-009 = sandbox root)

## Files

- `docs/research/README.md` — synthesis, read first
- `docs/research/acp-spec.md` — protocol deep-dive
- `docs/research/acp-ecosystem.md` — clients, agents, SDKs, UX patterns
- `docs/research/zremote-acp-integration-points.md` — current architecture mapping
- `docs/research/driver-architecture.md` — driver framing proposal
- `docs/research/acp-rust-reuse.md` — build vs depend vs vendor analysis
- `docs/rfc/rfc-010-session-drivers-and-acp.md` — the RFC itself

## Open questions

7 items captured in §8 of the RFC (default driver flip schedule, long-term coexistence of cc-hooks and claude-acp, auth UX for hosted agents, bulk content threshold tunability, agent-spawned terminal cleanup, driver lifetime when ACP child exits, Telegram event mapping for new variants). Need user decisions before P2 starts.

## Test plan

- [ ] Read `docs/research/README.md` (synthesis) end-to-end
- [ ] Read `docs/rfc/rfc-010-session-drivers-and-acp.md` end-to-end
- [ ] Resolve §8 open questions
- [ ] Plan P4 sub-phases (P4a/P4b/P4c) with explicit UX decisions for tool-call cards, diff reviewer, plan list, permission modal, embedded terminals
- [ ] Promote RFC status from Draft to Approved before P0 implementation begins