### PR TITLE
[codex] refactor agent profile routes

### DIFF
--- a/crates/zremote-agent/src/local/routes/agent_profiles.rs
+++ b/crates/zremote-agent/src/local/routes/agent_profiles.rs
@@ -1,115 +1,28 @@
 //! REST CRUD for `/api/agent-profiles` (local mode).
 //!
-//! Thin wrapper over [`zremote_core::queries::agent_profiles`] that adds:
+//! Thin wrapper over [`zremote_core::services::agent_profiles`] that adds:
 //!
-//! - Input validation via
-//!   [`zremote_core::validation::agent_profile::validate_profile_fields`] and
-//!   the per-launcher `validate_settings` hook from
+//! - The per-launcher `validate_settings` hook from
 //!   [`crate::agents::LauncherRegistry`]. Validation runs **before** any DB
 //!   write so a malformed profile can never land in SQLite.
-//! - HTTP-shaped errors via [`AppError`] (unique constraint violations become
-//!   409 Conflict, unknown kinds and shell-metachar injection become 400 Bad
-//!   Request, missing rows become 404 Not Found).
+//! - HTTP-shaped extraction via [`AppJson`], while shared DTOs, common field
+//!   validation, duplicate-name conflict mapping, and CRUD flow live in core.
 //!
 //! The handlers here are deliberately symmetric with the server-mode routes
-//! in `zremote-server/src/routes/agent_profiles.rs` — same validator, same
-//! error mapping, different state extractor. Any new behavior must land in
-//! both files (grep `validate_profile_fields` to catch drift).
+//! in `zremote-server/src/routes/agent_profiles.rs` — same core service,
+//! different settings validator and state extractor.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::Deserialize;
-use uuid::Uuid;
 use zremote_core::error::{AppError, AppJson};
-use zremote_core::queries::agent_profiles as q;
-use zremote_core::validation::agent_profile::{
-    validate_profile_fields, validate_profile_length_limits,
-};
-use zremote_protocol::agents::{KindInfo, SUPPORTED_KINDS, supported_kinds};
+use zremote_core::services::agent_profiles as profiles;
 
 use crate::agents::LauncherError;
 use crate::local::state::LocalAppState;
-
-/// JSON body accepted by `POST /api/agent-profiles`. All fields mirror
-/// [`q::AgentProfile`] except for auto-managed columns (`id`, `created_at`,
-/// `updated_at`). Optional fields default to sensible empty values so a
-/// minimal `{"name": "...", "agent_kind": "claude"}` body is valid.
-#[derive(Debug, Deserialize)]
-pub struct CreateProfileRequest {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    pub agent_kind: String,
-    #[serde(default)]
-    pub is_default: bool,
-    #[serde(default)]
-    pub sort_order: i64,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default)]
-    pub initial_prompt: Option<String>,
-    #[serde(default)]
-    pub skip_permissions: bool,
-    #[serde(default)]
-    pub allowed_tools: Vec<String>,
-    #[serde(default)]
-    pub extra_args: Vec<String>,
-    #[serde(default)]
-    pub env_vars: BTreeMap<String, String>,
-    #[serde(default)]
-    pub settings: serde_json::Value,
-}
-
-/// JSON body accepted by `PUT /api/agent-profiles/{id}`. `agent_kind` is
-/// intentionally omitted — the kind is immutable after insert (see
-/// `q::update_profile`'s rationale).
-#[derive(Debug, Deserialize)]
-pub struct UpdateProfileRequest {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub sort_order: i64,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default)]
-    pub initial_prompt: Option<String>,
-    #[serde(default)]
-    pub skip_permissions: bool,
-    #[serde(default)]
-    pub allowed_tools: Vec<String>,
-    #[serde(default)]
-    pub extra_args: Vec<String>,
-    #[serde(default)]
-    pub env_vars: BTreeMap<String, String>,
-    #[serde(default)]
-    pub settings: serde_json::Value,
-}
-
-/// Shape returned by `GET /api/agent-profiles/kinds`. Mirrors
-/// [`zremote_protocol::agents::KindInfo`] but owns its strings so callers can
-/// serialize freely without worrying about `'static` lifetimes.
-#[derive(Debug, serde::Serialize)]
-pub struct KindInfoResponse {
-    pub kind: String,
-    pub display_name: String,
-    pub description: String,
-}
-
-impl From<&KindInfo> for KindInfoResponse {
-    fn from(k: &KindInfo) -> Self {
-        Self {
-            kind: k.kind.to_string(),
-            display_name: k.display_name.to_string(),
-            description: k.description.to_string(),
-        }
-    }
-}
 
 /// Convert a `LauncherError` into an `AppError`. Unknown kinds and invalid
 /// settings both map to 400 — the wire contract for both is "client sent a
@@ -126,69 +39,11 @@ fn launcher_error_to_app(err: LauncherError) -> AppError {
     }
 }
 
-/// Map a SQLite unique-constraint error to a 409 Conflict. Any other SQL
-/// error bubbles through as [`AppError::Database`] (500) via the `?`
-/// operator. This lets the UI show "a profile with this name already exists"
-/// without exposing SQL internals.
-fn map_insert_err(err: AppError) -> AppError {
-    match err {
-        AppError::Database(sqlx::Error::Database(dbe)) if is_unique_violation(dbe.as_ref()) => {
-            AppError::Conflict(
-                "a profile with this name already exists for the given agent kind".to_string(),
-            )
-        }
-        AppError::Database(e) => AppError::Database(e),
-        other => other,
-    }
-}
-
-fn is_unique_violation(err: &dyn sqlx::error::DatabaseError) -> bool {
-    // SQLite reports unique violations as code "2067" (SQLITE_CONSTRAINT_UNIQUE)
-    // or "1555" (SQLITE_CONSTRAINT_PRIMARYKEY). `sqlx` exposes this via
-    // `code()`; a substring match on the message is the fallback because
-    // older sqlite builds don't always populate the extended code.
-    if let Some(code) = err.code()
-        && (code == "2067" || code == "1555")
-    {
-        return true;
-    }
-    let msg = err.message().to_ascii_lowercase();
-    msg.contains("unique constraint") || msg.contains("unique index")
-}
-
-/// Validate the cross-cutting profile fields plus the kind-specific settings
-/// blob. Called by both `create_profile` and `update_profile` so field-level
-/// rules stay in sync between the two codepaths.
-#[allow(clippy::too_many_arguments)]
-fn validate_all(
+fn validate_local_settings(
     registry: &crate::agents::LauncherRegistry,
     agent_kind: &str,
-    name: &str,
-    description: Option<&str>,
-    initial_prompt: Option<&str>,
-    model: Option<&str>,
-    allowed_tools: &[String],
-    extra_args: &[String],
-    env_vars: &BTreeMap<String, String>,
     settings: &serde_json::Value,
 ) -> Result<(), AppError> {
-    let kinds = supported_kinds();
-    validate_profile_fields(
-        agent_kind,
-        &kinds,
-        model,
-        allowed_tools,
-        extra_args,
-        env_vars,
-    )
-    .map_err(AppError::BadRequest)?;
-
-    validate_profile_length_limits(name, description, initial_prompt)
-        .map_err(AppError::BadRequest)?;
-
-    // Per-launcher settings validation. Unknown-kind was already rejected by
-    // `validate_profile_fields`, so `registry.get` failing here is an internal
-    // mismatch — surface it as 500 rather than 400.
     let launcher = registry
         .get(agent_kind)
         .map_err(|e| AppError::Internal(format!("launcher registry mismatch: {e}")))?;
@@ -199,35 +54,23 @@ fn validate_all(
     Ok(())
 }
 
-/// Query params for `GET /api/agent-profiles`. The `kind` filter narrows
-/// the result set to a single `agent_kind`; omitting it returns every
-/// profile across every kind.
-#[derive(Debug, Deserialize, Default)]
-pub struct ListProfilesQuery {
-    #[serde(default)]
-    pub kind: Option<String>,
-}
-
 /// `GET /api/agent-profiles` - List all profiles, optionally filtered by kind.
 ///
 /// Sorted by (sort_order ASC, name ASC). Empty list is a valid response.
 pub async fn list_profiles(
     State(state): State<Arc<LocalAppState>>,
-    Query(query): Query<ListProfilesQuery>,
+    Query(query): Query<profiles::ListProfilesQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    let profiles = match query.kind.as_deref() {
-        Some(k) => q::list_by_kind(&state.db, k).await?,
-        None => q::list_profiles(&state.db).await?,
-    };
-    Ok(Json(profiles))
+    Ok(Json(
+        profiles::list_profiles(&state.db, query.kind.as_deref()).await?,
+    ))
 }
 
 /// `GET /api/agent-profiles/kinds` - List the kinds supported by this agent
 /// binary. Driven by `SUPPORTED_KINDS` in the protocol crate, which is the
 /// single source of truth for accepted `agent_kind` values.
 pub async fn list_kinds() -> impl IntoResponse {
-    let kinds: Vec<KindInfoResponse> = SUPPORTED_KINDS.iter().map(KindInfoResponse::from).collect();
-    Json(kinds)
+    Json(profiles::list_kinds())
 }
 
 /// `GET /api/agent-profiles/{id}` - Fetch a single profile by id.
@@ -235,10 +78,7 @@ pub async fn get_profile(
     State(state): State<Arc<LocalAppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    let profile = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-    Ok(Json(profile))
+    Ok(Json(profiles::get_profile(&state.db, &id).await?))
 }
 
 /// `POST /api/agent-profiles` - Create a new profile.
@@ -247,54 +87,13 @@ pub async fn get_profile(
 /// `(agent_kind, name)` collisions are reported as 409.
 pub async fn create_profile(
     State(state): State<Arc<LocalAppState>>,
-    AppJson(body): AppJson<CreateProfileRequest>,
+    AppJson(body): AppJson<profiles::CreateProfileRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    validate_all(
-        &state.launcher_registry,
-        &body.agent_kind,
-        &body.name,
-        body.description.as_deref(),
-        body.initial_prompt.as_deref(),
-        body.model.as_deref(),
-        &body.allowed_tools,
-        &body.extra_args,
-        &body.env_vars,
-        &body.settings,
-    )?;
-
-    let id = Uuid::new_v4().to_string();
-    let profile = q::AgentProfile {
-        id: id.clone(),
-        name: body.name,
-        description: body.description,
-        agent_kind: body.agent_kind,
-        is_default: false, // use set_default to assign; inserts never auto-promote
-        sort_order: body.sort_order,
-        model: body.model,
-        initial_prompt: body.initial_prompt,
-        skip_permissions: body.skip_permissions,
-        allowed_tools: body.allowed_tools,
-        extra_args: body.extra_args,
-        env_vars: body.env_vars,
-        settings: body.settings,
-        created_at: String::new(),
-        updated_at: String::new(),
-    };
-
-    q::insert_profile(&state.db, &profile)
-        .await
-        .map_err(map_insert_err)?;
-
-    // Honour the explicit `is_default = true` hint from the request body.
-    // Routed through `set_default` so the partial unique index is satisfied
-    // atomically instead of letting the INSERT race another writer.
-    if body.is_default {
-        q::set_default(&state.db, &id).await?;
-    }
-
-    let created = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::Internal("profile vanished after insert".to_string()))?;
+    let registry = state.launcher_registry.clone();
+    let created = profiles::create_profile(&state.db, body, |agent_kind, settings| {
+        validate_local_settings(&registry, agent_kind, settings)
+    })
+    .await?;
 
     Ok((StatusCode::CREATED, Json(created)))
 }
@@ -307,50 +106,13 @@ pub async fn create_profile(
 pub async fn update_profile(
     State(state): State<Arc<LocalAppState>>,
     Path(id): Path<String>,
-    AppJson(body): AppJson<UpdateProfileRequest>,
+    AppJson(body): AppJson<profiles::UpdateProfileRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let existing = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-
-    validate_all(
-        &state.launcher_registry,
-        &existing.agent_kind,
-        &body.name,
-        body.description.as_deref(),
-        body.initial_prompt.as_deref(),
-        body.model.as_deref(),
-        &body.allowed_tools,
-        &body.extra_args,
-        &body.env_vars,
-        &body.settings,
-    )?;
-
-    let updated = q::AgentProfile {
-        id: existing.id.clone(),
-        name: body.name,
-        description: body.description,
-        agent_kind: existing.agent_kind.clone(),
-        is_default: existing.is_default,
-        sort_order: body.sort_order,
-        model: body.model,
-        initial_prompt: body.initial_prompt,
-        skip_permissions: body.skip_permissions,
-        allowed_tools: body.allowed_tools,
-        extra_args: body.extra_args,
-        env_vars: body.env_vars,
-        settings: body.settings,
-        created_at: existing.created_at,
-        updated_at: String::new(),
-    };
-
-    q::update_profile(&state.db, &id, &updated)
-        .await
-        .map_err(map_insert_err)?;
-
-    let refreshed = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::Internal("profile vanished after update".to_string()))?;
+    let registry = state.launcher_registry.clone();
+    let refreshed = profiles::update_profile(&state.db, &id, body, |agent_kind, settings| {
+        validate_local_settings(&registry, agent_kind, settings)
+    })
+    .await?;
 
     Ok(Json(refreshed))
 }
@@ -363,7 +125,7 @@ pub async fn delete_profile(
     State(state): State<Arc<LocalAppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    q::delete_profile(&state.db, &id).await?;
+    profiles::delete_profile(&state.db, &id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -373,11 +135,7 @@ pub async fn set_default(
     State(state): State<Arc<LocalAppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    q::set_default(&state.db, &id).await?;
-    let profile = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-    Ok(Json(profile))
+    Ok(Json(profiles::set_default(&state.db, &id).await?))
 }
 
 #[cfg(test)]
@@ -386,6 +144,8 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode as HttpStatus};
     use tower::ServiceExt;
+    use uuid::Uuid;
+    use zremote_core::queries::agent_profiles as q;
 
     async fn test_state() -> Arc<LocalAppState> {
         let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();

--- a/crates/zremote-core/src/lib.rs
+++ b/crates/zremote-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod processing;
 pub mod queries;
 #[cfg(feature = "axum")]
 pub mod request_id;
+pub mod services;
 pub mod snapshot_parser;
 pub mod state;
 #[cfg(feature = "axum")]

--- a/crates/zremote-core/src/services/agent_profiles.rs
+++ b/crates/zremote-core/src/services/agent_profiles.rs
@@ -1,0 +1,446 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+use zremote_protocol::agents::{KindInfo, SUPPORTED_KINDS, supported_kinds};
+
+use crate::error::AppError;
+use crate::queries::agent_profiles as q;
+use crate::validation::agent_profile::{validate_profile_fields, validate_profile_length_limits};
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProfileRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub agent_kind: String,
+    #[serde(default)]
+    pub is_default: bool,
+    #[serde(default)]
+    pub sort_order: i64,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub initial_prompt: Option<String>,
+    #[serde(default)]
+    pub skip_permissions: bool,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
+    #[serde(default)]
+    pub settings: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub sort_order: i64,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub initial_prompt: Option<String>,
+    #[serde(default)]
+    pub skip_permissions: bool,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
+    #[serde(default)]
+    pub settings: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListProfilesQuery {
+    #[serde(default)]
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KindInfoResponse {
+    pub kind: String,
+    pub display_name: String,
+    pub description: String,
+}
+
+impl From<&KindInfo> for KindInfoResponse {
+    fn from(k: &KindInfo) -> Self {
+        Self {
+            kind: k.kind.to_string(),
+            display_name: k.display_name.to_string(),
+            description: k.description.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct CommonProfileFields<'a> {
+    pub agent_kind: &'a str,
+    pub name: &'a str,
+    pub description: Option<&'a str>,
+    pub initial_prompt: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub allowed_tools: &'a [String],
+    pub extra_args: &'a [String],
+    pub env_vars: &'a BTreeMap<String, String>,
+}
+
+impl<'a> CommonProfileFields<'a> {
+    pub fn for_create(body: &'a CreateProfileRequest) -> Self {
+        Self {
+            agent_kind: &body.agent_kind,
+            name: &body.name,
+            description: body.description.as_deref(),
+            initial_prompt: body.initial_prompt.as_deref(),
+            model: body.model.as_deref(),
+            allowed_tools: &body.allowed_tools,
+            extra_args: &body.extra_args,
+            env_vars: &body.env_vars,
+        }
+    }
+
+    pub fn for_update(agent_kind: &'a str, body: &'a UpdateProfileRequest) -> Self {
+        Self {
+            agent_kind,
+            name: &body.name,
+            description: body.description.as_deref(),
+            initial_prompt: body.initial_prompt.as_deref(),
+            model: body.model.as_deref(),
+            allowed_tools: &body.allowed_tools,
+            extra_args: &body.extra_args,
+            env_vars: &body.env_vars,
+        }
+    }
+}
+
+pub fn validate_common_profile_fields(fields: CommonProfileFields<'_>) -> Result<(), AppError> {
+    let kinds = supported_kinds();
+    validate_profile_fields(
+        fields.agent_kind,
+        &kinds,
+        fields.model,
+        fields.allowed_tools,
+        fields.extra_args,
+        fields.env_vars,
+    )
+    .map_err(AppError::BadRequest)?;
+
+    validate_profile_length_limits(fields.name, fields.description, fields.initial_prompt)
+        .map_err(AppError::BadRequest)
+}
+
+pub async fn list_profiles(
+    pool: &SqlitePool,
+    kind: Option<&str>,
+) -> Result<Vec<q::AgentProfile>, AppError> {
+    match kind {
+        Some(kind) => q::list_by_kind(pool, kind).await,
+        None => q::list_profiles(pool).await,
+    }
+}
+
+pub fn list_kinds() -> Vec<KindInfoResponse> {
+    SUPPORTED_KINDS.iter().map(KindInfoResponse::from).collect()
+}
+
+pub async fn get_profile(pool: &SqlitePool, id: &str) -> Result<q::AgentProfile, AppError> {
+    q::get_profile(pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))
+}
+
+pub async fn create_profile<F>(
+    pool: &SqlitePool,
+    body: CreateProfileRequest,
+    validate_settings: F,
+) -> Result<q::AgentProfile, AppError>
+where
+    F: FnOnce(&str, &serde_json::Value) -> Result<(), AppError>,
+{
+    validate_common_profile_fields(CommonProfileFields::for_create(&body))?;
+    validate_settings(&body.agent_kind, &body.settings)?;
+
+    let id = Uuid::new_v4().to_string();
+    let profile = q::AgentProfile {
+        id: id.clone(),
+        name: body.name,
+        description: body.description,
+        agent_kind: body.agent_kind,
+        is_default: false,
+        sort_order: body.sort_order,
+        model: body.model,
+        initial_prompt: body.initial_prompt,
+        skip_permissions: body.skip_permissions,
+        allowed_tools: body.allowed_tools,
+        extra_args: body.extra_args,
+        env_vars: body.env_vars,
+        settings: body.settings,
+        created_at: String::new(),
+        updated_at: String::new(),
+    };
+
+    q::insert_profile(pool, &profile)
+        .await
+        .map_err(map_profile_write_err)?;
+
+    if body.is_default {
+        q::set_default(pool, &id).await?;
+    }
+
+    q::get_profile(pool, &id)
+        .await?
+        .ok_or_else(|| AppError::Internal("profile vanished after insert".to_string()))
+}
+
+pub async fn update_profile<F>(
+    pool: &SqlitePool,
+    id: &str,
+    body: UpdateProfileRequest,
+    validate_settings: F,
+) -> Result<q::AgentProfile, AppError>
+where
+    F: FnOnce(&str, &serde_json::Value) -> Result<(), AppError>,
+{
+    let existing = get_profile(pool, id).await?;
+    validate_common_profile_fields(CommonProfileFields::for_update(&existing.agent_kind, &body))?;
+    validate_settings(&existing.agent_kind, &body.settings)?;
+
+    let updated = q::AgentProfile {
+        id: existing.id.clone(),
+        name: body.name,
+        description: body.description,
+        agent_kind: existing.agent_kind,
+        is_default: existing.is_default,
+        sort_order: body.sort_order,
+        model: body.model,
+        initial_prompt: body.initial_prompt,
+        skip_permissions: body.skip_permissions,
+        allowed_tools: body.allowed_tools,
+        extra_args: body.extra_args,
+        env_vars: body.env_vars,
+        settings: body.settings,
+        created_at: existing.created_at,
+        updated_at: String::new(),
+    };
+
+    q::update_profile(pool, id, &updated)
+        .await
+        .map_err(map_profile_write_err)?;
+
+    q::get_profile(pool, id)
+        .await?
+        .ok_or_else(|| AppError::Internal("profile vanished after update".to_string()))
+}
+
+pub async fn delete_profile(pool: &SqlitePool, id: &str) -> Result<(), AppError> {
+    q::delete_profile(pool, id).await
+}
+
+pub async fn set_default(pool: &SqlitePool, id: &str) -> Result<q::AgentProfile, AppError> {
+    q::set_default(pool, id).await?;
+    get_profile(pool, id).await
+}
+
+fn map_profile_write_err(err: AppError) -> AppError {
+    match err {
+        AppError::Database(sqlx::Error::Database(dbe)) if is_unique_violation(dbe.as_ref()) => {
+            AppError::Conflict(
+                "a profile with this name already exists for the given agent kind".to_string(),
+            )
+        }
+        AppError::Database(e) => AppError::Database(e),
+        other => other,
+    }
+}
+
+fn is_unique_violation(err: &dyn sqlx::error::DatabaseError) -> bool {
+    if let Some(code) = err.code()
+        && (code == "2067" || code == "1555")
+    {
+        return true;
+    }
+    let msg = err.message().to_ascii_lowercase();
+    msg.contains("unique constraint") || msg.contains("unique index")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::db;
+
+    async fn setup_db() -> SqlitePool {
+        db::init_db("sqlite::memory:").await.unwrap()
+    }
+
+    fn create_request(name: &str) -> CreateProfileRequest {
+        CreateProfileRequest {
+            name: name.to_string(),
+            description: None,
+            agent_kind: "claude".to_string(),
+            is_default: false,
+            sort_order: 0,
+            model: None,
+            initial_prompt: None,
+            skip_permissions: false,
+            allowed_tools: Vec::new(),
+            extra_args: Vec::new(),
+            env_vars: BTreeMap::new(),
+            settings: serde_json::json!({}),
+        }
+    }
+
+    fn update_request(name: &str) -> UpdateProfileRequest {
+        UpdateProfileRequest {
+            name: name.to_string(),
+            description: None,
+            sort_order: 0,
+            model: None,
+            initial_prompt: None,
+            skip_permissions: false,
+            allowed_tools: Vec::new(),
+            extra_args: Vec::new(),
+            env_vars: BTreeMap::new(),
+            settings: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_profile_returns_persisted_row() {
+        let pool = setup_db().await;
+        let created = create_profile(&pool, create_request("Review mode"), |_, _| Ok(()))
+            .await
+            .unwrap();
+
+        let fetched = get_profile(&pool, &created.id).await.unwrap();
+        assert_eq!(fetched.name, "Review mode");
+        assert_eq!(fetched.agent_kind, "claude");
+    }
+
+    #[tokio::test]
+    async fn create_profile_promotes_default_when_requested() {
+        let pool = setup_db().await;
+        let mut request = create_request("New default");
+        request.is_default = true;
+
+        let created = create_profile(&pool, request, |_, _| Ok(())).await.unwrap();
+        assert!(created.is_default);
+
+        let default = q::get_default(&pool, "claude").await.unwrap().unwrap();
+        assert_eq!(default.id, created.id);
+    }
+
+    #[tokio::test]
+    async fn update_profile_preserves_existing_agent_kind() {
+        let pool = setup_db().await;
+        let created = create_profile(&pool, create_request("Before"), |_, _| Ok(()))
+            .await
+            .unwrap();
+
+        let updated = update_profile(&pool, &created.id, update_request("After"), |_, _| Ok(()))
+            .await
+            .unwrap();
+
+        assert_eq!(updated.name, "After");
+        assert_eq!(updated.agent_kind, "claude");
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_maps_to_conflict() {
+        let pool = setup_db().await;
+        create_profile(&pool, create_request("Duplicate"), |_, _| Ok(()))
+            .await
+            .unwrap();
+
+        let err = create_profile(&pool, create_request("Duplicate"), |_, _| Ok(()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn invalid_common_fields_are_bad_request() {
+        let pool = setup_db().await;
+        let mut request = create_request("Bad model");
+        request.model = Some("opus;rm -rf /".to_string());
+
+        let err = create_profile(&pool, request, |_, _| Ok(()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn settings_validator_is_called_for_create_and_update() {
+        let pool = setup_db().await;
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let create_calls = calls.clone();
+
+        let created = create_profile(&pool, create_request("Tracked"), move |kind, settings| {
+            create_calls
+                .lock()
+                .unwrap()
+                .push((kind.to_string(), settings.clone()));
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let update_calls = calls.clone();
+        update_profile(
+            &pool,
+            &created.id,
+            update_request("Tracked 2"),
+            move |kind, settings| {
+                update_calls
+                    .lock()
+                    .unwrap()
+                    .push((kind.to_string(), settings.clone()));
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].0, "claude");
+        assert_eq!(calls[1].0, "claude");
+    }
+
+    #[tokio::test]
+    async fn settings_validator_error_is_returned_before_write() {
+        let pool = setup_db().await;
+        let err = create_profile(&pool, create_request("Rejected"), |_, _| {
+            Err(AppError::BadRequest("invalid settings".to_string()))
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, AppError::BadRequest(_)));
+
+        let rows = list_profiles(&pool, Some("claude")).await.unwrap();
+        assert!(!rows.iter().any(|row| row.name == "Rejected"));
+    }
+
+    #[tokio::test]
+    async fn set_default_missing_profile_returns_not_found() {
+        let pool = setup_db().await;
+        let err = set_default(&pool, "missing-profile").await.unwrap_err();
+
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+}

--- a/crates/zremote-core/src/services/mod.rs
+++ b/crates/zremote-core/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod agent_profiles;

--- a/crates/zremote-server/src/routes/agent_profiles.rs
+++ b/crates/zremote-server/src/routes/agent_profiles.rs
@@ -1,188 +1,53 @@
 //! REST CRUD for `/api/agent-profiles` (server mode).
 //!
 //! Symmetric to `zremote-agent::local::routes::agent_profiles`: same
-//! request/response shapes, same validator, same error mapping. The key
+//! core service, same request/response shapes, same error mapping. The key
 //! difference is scope of settings validation:
 //!
 //! - Cross-cutting fields (model, allowed_tools, extra_args, env_vars, and
-//!   `supported_kinds` membership) are validated **on the server** via
-//!   [`validate_profile_fields`], so malformed rows can never land in SQLite.
+//!   `supported_kinds` membership) are validated in
+//!   [`zremote_core::services::agent_profiles`], so malformed rows can never
+//!   land in SQLite.
 //! - Per-launcher `settings_json` validation runs **on the agent** at spawn
 //!   time, because the server crate does not depend on `zremote-agent`
 //!   (where the launchers live). This matches the deployment model — each
 //!   agent version only has to know its own launchers' settings schema.
 //!
-//! Keeping this file in lockstep with the local-mode handler is a hard
-//! requirement: grep `validate_profile_fields` across the workspace to catch
-//! any drift between the two.
+//! Keeping this file in lockstep with the local-mode handler now means using
+//! the same core service and only swapping the settings validator.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::Deserialize;
-use uuid::Uuid;
-use zremote_core::queries::agent_profiles as q;
-use zremote_core::validation::agent_profile::{
-    validate_profile_fields, validate_profile_length_limits, validate_settings_for_kind,
-};
-use zremote_protocol::agents::{KindInfo, SUPPORTED_KINDS, supported_kinds};
+use zremote_core::services::agent_profiles as profiles;
+use zremote_core::validation::agent_profile::validate_settings_for_kind;
 
 use crate::error::{AppError, AppJson};
 use crate::state::AppState;
 
-/// See mirror struct in `zremote-agent::local::routes::agent_profiles`.
-#[derive(Debug, Deserialize)]
-pub struct CreateProfileRequest {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    pub agent_kind: String,
-    #[serde(default)]
-    pub is_default: bool,
-    #[serde(default)]
-    pub sort_order: i64,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default)]
-    pub initial_prompt: Option<String>,
-    #[serde(default)]
-    pub skip_permissions: bool,
-    #[serde(default)]
-    pub allowed_tools: Vec<String>,
-    #[serde(default)]
-    pub extra_args: Vec<String>,
-    #[serde(default)]
-    pub env_vars: BTreeMap<String, String>,
-    #[serde(default)]
-    pub settings: serde_json::Value,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct UpdateProfileRequest {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub sort_order: i64,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default)]
-    pub initial_prompt: Option<String>,
-    #[serde(default)]
-    pub skip_permissions: bool,
-    #[serde(default)]
-    pub allowed_tools: Vec<String>,
-    #[serde(default)]
-    pub extra_args: Vec<String>,
-    #[serde(default)]
-    pub env_vars: BTreeMap<String, String>,
-    #[serde(default)]
-    pub settings: serde_json::Value,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct KindInfoResponse {
-    pub kind: String,
-    pub display_name: String,
-    pub description: String,
-}
-
-impl From<&KindInfo> for KindInfoResponse {
-    fn from(k: &KindInfo) -> Self {
-        Self {
-            kind: k.kind.to_string(),
-            display_name: k.display_name.to_string(),
-            description: k.description.to_string(),
-        }
-    }
-}
-
-fn map_insert_err(err: AppError) -> AppError {
-    match err {
-        AppError::Database(sqlx::Error::Database(dbe)) if is_unique_violation(dbe.as_ref()) => {
-            AppError::Conflict(
-                "a profile with this name already exists for the given agent kind".to_string(),
-            )
-        }
-        AppError::Database(e) => AppError::Database(e),
-        other => other,
-    }
-}
-
-fn is_unique_violation(err: &dyn sqlx::error::DatabaseError) -> bool {
-    if let Some(code) = err.code()
-        && (code == "2067" || code == "1555")
-    {
-        return true;
-    }
-    let msg = err.message().to_ascii_lowercase();
-    msg.contains("unique constraint") || msg.contains("unique index")
-}
-
-#[allow(clippy::too_many_arguments)]
-fn validate_all(
+fn validate_server_settings(
     agent_kind: &str,
-    name: &str,
-    description: Option<&str>,
-    initial_prompt: Option<&str>,
-    model: Option<&str>,
-    allowed_tools: &[String],
-    extra_args: &[String],
-    env_vars: &BTreeMap<String, String>,
     settings: &serde_json::Value,
 ) -> Result<(), AppError> {
-    let kinds = supported_kinds();
-    validate_profile_fields(
-        agent_kind,
-        &kinds,
-        model,
-        allowed_tools,
-        extra_args,
-        env_vars,
-    )
-    .map_err(AppError::BadRequest)?;
-
-    validate_profile_length_limits(name, description, initial_prompt)
-        .map_err(AppError::BadRequest)?;
-
-    // Kind-specific settings validation. The server crate cannot depend on
-    // the agent-side launcher registry, so the claude settings shape lives
-    // in `zremote-core`. The agent-side launcher is still the final arbiter
-    // at spawn time (defense in depth).
-    validate_settings_for_kind(agent_kind, settings).map_err(AppError::BadRequest)?;
-
-    Ok(())
-}
-
-/// Query params for `GET /api/agent-profiles`. The `kind` filter narrows
-/// the result set to a single `agent_kind`; omitting it returns every
-/// profile across every kind.
-#[derive(Debug, Deserialize, Default)]
-pub struct ListProfilesQuery {
-    #[serde(default)]
-    pub kind: Option<String>,
+    validate_settings_for_kind(agent_kind, settings).map_err(AppError::BadRequest)
 }
 
 /// `GET /api/agent-profiles` - List all profiles, optionally filtered by kind.
 pub async fn list_profiles(
     State(state): State<Arc<AppState>>,
-    Query(query): Query<ListProfilesQuery>,
+    Query(query): Query<profiles::ListProfilesQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    let profiles = match query.kind.as_deref() {
-        Some(k) => q::list_by_kind(&state.db, k).await?,
-        None => q::list_profiles(&state.db).await?,
-    };
-    Ok(Json(profiles))
+    Ok(Json(
+        profiles::list_profiles(&state.db, query.kind.as_deref()).await?,
+    ))
 }
 
 /// `GET /api/agent-profiles/kinds` - Supported agent kinds metadata.
 pub async fn list_kinds() -> impl IntoResponse {
-    let kinds: Vec<KindInfoResponse> = SUPPORTED_KINDS.iter().map(KindInfoResponse::from).collect();
-    Json(kinds)
+    Json(profiles::list_kinds())
 }
 
 /// `GET /api/agent-profiles/{id}` - Fetch a single profile.
@@ -190,60 +55,15 @@ pub async fn get_profile(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    let profile = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-    Ok(Json(profile))
+    Ok(Json(profiles::get_profile(&state.db, &id).await?))
 }
 
 /// `POST /api/agent-profiles` - Create a new profile.
 pub async fn create_profile(
     State(state): State<Arc<AppState>>,
-    AppJson(body): AppJson<CreateProfileRequest>,
+    AppJson(body): AppJson<profiles::CreateProfileRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    validate_all(
-        &body.agent_kind,
-        &body.name,
-        body.description.as_deref(),
-        body.initial_prompt.as_deref(),
-        body.model.as_deref(),
-        &body.allowed_tools,
-        &body.extra_args,
-        &body.env_vars,
-        &body.settings,
-    )?;
-
-    let id = Uuid::new_v4().to_string();
-    let profile = q::AgentProfile {
-        id: id.clone(),
-        name: body.name,
-        description: body.description,
-        agent_kind: body.agent_kind,
-        is_default: false,
-        sort_order: body.sort_order,
-        model: body.model,
-        initial_prompt: body.initial_prompt,
-        skip_permissions: body.skip_permissions,
-        allowed_tools: body.allowed_tools,
-        extra_args: body.extra_args,
-        env_vars: body.env_vars,
-        settings: body.settings,
-        created_at: String::new(),
-        updated_at: String::new(),
-    };
-
-    q::insert_profile(&state.db, &profile)
-        .await
-        .map_err(map_insert_err)?;
-
-    if body.is_default {
-        q::set_default(&state.db, &id).await?;
-    }
-
-    let created = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::Internal("profile vanished after insert".to_string()))?;
-
+    let created = profiles::create_profile(&state.db, body, validate_server_settings).await?;
     Ok((StatusCode::CREATED, Json(created)))
 }
 
@@ -251,50 +71,10 @@ pub async fn create_profile(
 pub async fn update_profile(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
-    AppJson(body): AppJson<UpdateProfileRequest>,
+    AppJson(body): AppJson<profiles::UpdateProfileRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let existing = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-
-    validate_all(
-        &existing.agent_kind,
-        &body.name,
-        body.description.as_deref(),
-        body.initial_prompt.as_deref(),
-        body.model.as_deref(),
-        &body.allowed_tools,
-        &body.extra_args,
-        &body.env_vars,
-        &body.settings,
-    )?;
-
-    let updated = q::AgentProfile {
-        id: existing.id.clone(),
-        name: body.name,
-        description: body.description,
-        agent_kind: existing.agent_kind.clone(),
-        is_default: existing.is_default,
-        sort_order: body.sort_order,
-        model: body.model,
-        initial_prompt: body.initial_prompt,
-        skip_permissions: body.skip_permissions,
-        allowed_tools: body.allowed_tools,
-        extra_args: body.extra_args,
-        env_vars: body.env_vars,
-        settings: body.settings,
-        created_at: existing.created_at,
-        updated_at: String::new(),
-    };
-
-    q::update_profile(&state.db, &id, &updated)
-        .await
-        .map_err(map_insert_err)?;
-
-    let refreshed = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::Internal("profile vanished after update".to_string()))?;
-
+    let refreshed =
+        profiles::update_profile(&state.db, &id, body, validate_server_settings).await?;
     Ok(Json(refreshed))
 }
 
@@ -303,7 +83,7 @@ pub async fn delete_profile(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    q::delete_profile(&state.db, &id).await?;
+    profiles::delete_profile(&state.db, &id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -312,11 +92,7 @@ pub async fn set_default(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    q::set_default(&state.db, &id).await?;
-    let profile = q::get_profile(&state.db, &id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent profile {id} not found")))?;
-    Ok(Json(profile))
+    Ok(Json(profiles::set_default(&state.db, &id).await?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Move shared agent profile request DTOs, common validation, CRUD flow, duplicate-name conflict mapping, and default promotion into `zremote-core::services::agent_profiles`.
- Thin both server-mode and local-mode `agent_profiles` routes so they only handle HTTP extraction/state and provide their mode-specific settings validator.
- Add core service tests covering persistence, default promotion, immutable agent kind updates, conflict mapping, validation, injected settings validation, and missing default lookup.

## Why

The audit identified duplicated local/server route behavior as the highest-impact refactoring target. `agent_profiles` was the safest first slice because both routes intentionally mirrored each other while only differing in settings validation scope.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --exclude zremote-gui --exclude zremote -- -D warnings`
- `cargo test -p zremote-core services::agent_profiles --quiet`
- `cargo test -p zremote-server routes::agent_profiles --quiet`
- `cargo test -p zremote-agent local::routes::agent_profiles --quiet`
- `cargo test --workspace --quiet`
- Pre-commit hook also reran `cargo fmt`, `cargo clippy`, and `cargo test`.
