### PR TITLE
[codex] Implement Codex integration polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Remote machine management platform with interactive terminal sessions, AI agent 
 
 **AI Agent Monitoring**
 - Agentic loop tracking: tool calls, transcripts, token usage, costs
+- Generic agent profiles and project-row quick launch for Claude Code and Codex
 - Tool permissions: approve, reject, or auto-approve agent tool calls
 - Claude Code hooks integration for real-time event capture
 - Claude task lifecycle management

--- a/crates/zremote-agent/src/agentic/adapters/codex.rs
+++ b/crates/zremote-agent/src/agentic/adapters/codex.rs
@@ -22,12 +22,7 @@ impl ProviderAdapter for CodexAdapter {
         // Token parsing
         if let Some(caps) = patterns::CODEX_TOKEN_RE.captures(line) {
             let total = patterns::parse_token_count(&caps[1]);
-            let input = caps
-                .get(2)
-                .map_or(0, |m| patterns::parse_token_count(m.as_str()));
-            let output = caps
-                .get(3)
-                .map_or(0, |m| patterns::parse_token_count(m.as_str()));
+            let (input, output) = codex_token_breakdown(line).unwrap_or((0, 0));
 
             // If we have a breakdown, use it; otherwise split total evenly
             let (final_input, final_output) = if input > 0 || output > 0 {
@@ -44,6 +39,13 @@ impl ProviderAdapter for CodexAdapter {
                 model: String::new(),
                 is_cumulative: true,
             });
+            return analysis;
+        }
+
+        // Codex startup/readiness failures. LineAnalysis has no error payload,
+        // so surface these as a blocked/input-needed phase for now.
+        if is_codex_startup_error(line) {
+            analysis.phase_hint = Some(PhaseHint::InputNeeded);
             return analysis;
         }
 
@@ -97,6 +99,33 @@ impl ProviderAdapter for CodexAdapter {
     }
 }
 
+fn codex_token_breakdown(line: &str) -> Option<(u64, u64)> {
+    let caps = patterns::CODEX_TOKEN_IO_RE.captures(line)?;
+    let input = caps
+        .name("input_label")
+        .or_else(|| caps.name("input_prefix"))
+        .map(|m| patterns::parse_token_count(m.as_str()))
+        .unwrap_or(0);
+    let output = caps
+        .name("output_label")
+        .or_else(|| caps.name("output_prefix"))
+        .map(|m| patterns::parse_token_count(m.as_str()))
+        .unwrap_or(0);
+
+    if input > 0 || output > 0 {
+        Some((input, output))
+    } else {
+        None
+    }
+}
+
+fn is_codex_startup_error(line: &str) -> bool {
+    patterns::CODEX_LAUNCH_ERROR_RE.is_match(line)
+        || patterns::CODEX_AUTH_ERROR_RE.is_match(line)
+        || patterns::CODEX_CONFIG_ERROR_RE.is_match(line)
+        || patterns::CODEX_UNKNOWN_OPTION_RE.is_match(line)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,14 +166,32 @@ mod tests {
     }
 
     #[test]
-    fn token_usage_codex_format_falls_back_to_total_split() {
+    fn token_usage_codex_format_uses_breakdown() {
         let adapter = CodexAdapter;
-        // Codex's actual format "1K input + 900 output" — regex only captures total
         let analysis = adapter.analyze_line("Token usage: 1.9K total (1K input + 900 output)");
         let update = analysis.token_update.unwrap();
-        // Falls back to splitting total evenly
-        assert_eq!(update.input_tokens, 950);
-        assert_eq!(update.output_tokens, 950);
+        assert_eq!(update.input_tokens, 1000);
+        assert_eq!(update.output_tokens, 900);
+    }
+
+    #[test]
+    fn token_usage_comma_breakdown() {
+        let adapter = CodexAdapter;
+        let analysis =
+            adapter.analyze_line("Token usage: 12,345 total, input: 10,000, output: 2,345");
+        let update = analysis.token_update.unwrap();
+        assert_eq!(update.input_tokens, 10_000);
+        assert_eq!(update.output_tokens, 2_345);
+    }
+
+    #[test]
+    fn token_usage_comma_codex_format() {
+        let adapter = CodexAdapter;
+        let analysis =
+            adapter.analyze_line("Token usage: 12,345 total (10,000 input + 2,345 output)");
+        let update = analysis.token_update.unwrap();
+        assert_eq!(update.input_tokens, 10_000);
+        assert_eq!(update.output_tokens, 2_345);
     }
 
     #[test]
@@ -213,5 +260,33 @@ mod tests {
     fn prompt_empty_not_prompt() {
         let adapter = CodexAdapter;
         assert!(!adapter.is_prompt(""));
+    }
+
+    #[test]
+    fn startup_error_command_not_found_needs_input() {
+        let adapter = CodexAdapter;
+        let analysis = adapter.analyze_line("zsh: command not found: codex");
+        assert_eq!(analysis.phase_hint, Some(PhaseHint::InputNeeded));
+    }
+
+    #[test]
+    fn startup_error_auth_needs_input() {
+        let adapter = CodexAdapter;
+        let analysis = adapter.analyze_line("Error: authentication required. Please log in.");
+        assert_eq!(analysis.phase_hint, Some(PhaseHint::InputNeeded));
+    }
+
+    #[test]
+    fn startup_error_config_needs_input() {
+        let adapter = CodexAdapter;
+        let analysis = adapter.analyze_line("error: failed to parse ~/.codex/config.toml");
+        assert_eq!(analysis.phase_hint, Some(PhaseHint::InputNeeded));
+    }
+
+    #[test]
+    fn startup_error_unknown_option_needs_input() {
+        let adapter = CodexAdapter;
+        let analysis = adapter.analyze_line("error: unknown option '--ask-for-approval'");
+        assert_eq!(analysis.phase_hint, Some(PhaseHint::InputNeeded));
     }
 }

--- a/crates/zremote-agent/src/agentic/patterns.rs
+++ b/crates/zremote-agent/src/agentic/patterns.rs
@@ -78,9 +78,24 @@ pub static CODEX_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Matches Codex token usage: "Token usage: 12.5K total"
 pub static CODEX_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)Token usage:\s*([\d,.]+[KMBT]?)\s*total").expect("CODEX_TOKEN_RE")
+});
+
+/// Matches Codex token breakdowns after the total count.
+pub static CODEX_TOKEN_IO_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?i)Token usage:\s*([\d.]+[KMBT]?)\s*total(?:.*?input[:\s]*([\d.]+[KMBT]?))?(?:.*?output[:\s]*([\d.]+[KMBT]?))?"
-    ).expect("CODEX_TOKEN_RE")
+        r"(?ix)
+        (?:
+            input[:\s]+(?P<input_label>[\d,.]+[KMBT]?).*?
+            output[:\s]+(?P<output_label>[\d,.]+[KMBT]?)
+        )
+        |
+        (?:
+            (?P<input_prefix>[\d,.]+[KMBT]?)\s+input\s*\+\s*
+            (?P<output_prefix>[\d,.]+[KMBT]?)\s+output
+        )",
+    )
+    .expect("CODEX_TOKEN_IO_RE")
 });
 
 /// Matches Codex tool run lines: "• Running ls -la" or "• Ran ls -la"
@@ -91,6 +106,30 @@ pub static CODEX_TOOL_RE: LazyLock<Regex> =
 pub static CODEX_FILE_OP_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[•◦]\s*(Edited|Added|Deleted)\s+(.+?)(?:\s*\((\+\d+),\s*(-\d+)\))?$")
         .expect("CODEX_FILE_OP_RE")
+});
+
+/// Matches Codex launch failures where the executable is unavailable.
+pub static CODEX_LAUNCH_ERROR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:codex:\s+command not found|command not found:\s+codex|codex:\s+not found|no such file or directory.*\bcodex\b)")
+        .expect("CODEX_LAUNCH_ERROR_RE")
+});
+
+/// Matches Codex authentication failures that require user action.
+pub static CODEX_AUTH_ERROR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:not authenticated|authentication required|login required|please log in|please login|sign in to codex|openai api key.*(?:missing|required|not set)|missing api key)")
+        .expect("CODEX_AUTH_ERROR_RE")
+});
+
+/// Matches Codex configuration/profile/model startup failures.
+pub static CODEX_CONFIG_ERROR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:(?:failed|error).*(?:config|configuration|config\.toml)|invalid\s+(?:config|configuration|profile|model)|profile .* not found|model .* not found|unknown model)")
+        .expect("CODEX_CONFIG_ERROR_RE")
+});
+
+/// Matches Codex CLI option incompatibilities.
+pub static CODEX_UNKNOWN_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:unknown (?:option|argument|flag)|unexpected (?:argument|option)|unrecognized (?:option|argument|flag)|(?:invalid|unexpected) value).*")
+        .expect("CODEX_UNKNOWN_OPTION_RE")
 });
 
 // ---------------------------------------------------------------------------
@@ -546,6 +585,32 @@ mod tests {
     }
 
     #[test]
+    fn codex_token_re_matches_comma_total() {
+        let caps = CODEX_TOKEN_RE
+            .captures("Token usage: 12,345 total (10,000 input + 2,345 output)")
+            .unwrap();
+        assert_eq!(&caps[1], "12,345");
+    }
+
+    #[test]
+    fn codex_token_io_re_matches_codex_format() {
+        let caps = CODEX_TOKEN_IO_RE
+            .captures("Token usage: 1.9K total (1K input + 900 output)")
+            .unwrap();
+        assert_eq!(&caps["input_prefix"], "1K");
+        assert_eq!(&caps["output_prefix"], "900");
+    }
+
+    #[test]
+    fn codex_token_io_re_matches_label_format() {
+        let caps = CODEX_TOKEN_IO_RE
+            .captures("Token usage: 1.9K total, input: 1K, output: 900")
+            .unwrap();
+        assert_eq!(&caps["input_label"], "1K");
+        assert_eq!(&caps["output_label"], "900");
+    }
+
+    #[test]
     fn codex_token_re_no_match() {
         assert!(CODEX_TOKEN_RE.captures("no usage").is_none());
     }
@@ -584,6 +649,14 @@ mod tests {
     #[test]
     fn codex_file_op_re_no_match() {
         assert!(CODEX_FILE_OP_RE.captures("nothing here").is_none());
+    }
+
+    #[test]
+    fn codex_startup_error_patterns_match_common_failures() {
+        assert!(CODEX_LAUNCH_ERROR_RE.is_match("zsh: command not found: codex"));
+        assert!(CODEX_AUTH_ERROR_RE.is_match("Error: authentication required. Please log in."));
+        assert!(CODEX_CONFIG_ERROR_RE.is_match("error: failed to parse ~/.codex/config.toml"));
+        assert!(CODEX_UNKNOWN_OPTION_RE.is_match("error: unknown option '--foo'"));
     }
 
     // -- Gemini patterns --

--- a/crates/zremote-agent/src/local/router.rs
+++ b/crates/zremote-agent/src/local/router.rs
@@ -51,6 +51,10 @@ pub(crate) fn build_router(
         // Hosts endpoints (synthetic local host)
         .route("/api/hosts", get(routes::hosts::list_hosts))
         .route("/api/hosts/{host_id}", get(routes::hosts::get_host))
+        .route(
+            "/api/hosts/{host_id}/agent-capabilities/codex",
+            get(routes::hosts::get_codex_capability),
+        )
         // Session CRUD
         .route(
             "/api/hosts/{host_id}/sessions",

--- a/crates/zremote-agent/src/local/routes/agent_profiles.rs
+++ b/crates/zremote-agent/src/local/routes/agent_profiles.rs
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(resp.status(), HttpStatus::OK);
         let json = read_json(resp).await;
         let arr = json.as_array().unwrap();
-        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.len(), 6);
         assert!(
             arr.iter()
                 .any(|row| row["agent_kind"] == "claude" && row["is_default"] == true)
@@ -299,7 +299,7 @@ mod tests {
 
         // Round-trip through list to confirm persistence
         let profiles = q::list_profiles(&state.db).await.unwrap();
-        assert_eq!(profiles.len(), 3);
+        assert_eq!(profiles.len(), 7);
     }
 
     #[tokio::test]

--- a/crates/zremote-agent/src/local/routes/hosts.rs
+++ b/crates/zremote-agent/src/local/routes/hosts.rs
@@ -1,10 +1,16 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Json;
 use axum::extract::{Path, State};
+use chrono::Utc;
+use std::collections::BTreeSet;
+use tokio::process::Command;
+use tokio::time::timeout;
 use uuid::Uuid;
 use zremote_core::error::AppError;
 use zremote_core::queries::hosts as q;
+use zremote_protocol::AgentCapabilityInfo;
 
 use crate::local::state::LocalAppState;
 
@@ -31,6 +37,124 @@ pub async fn get_host(
 
     let host = q::get_host(&state.db, &host_id).await?;
     Ok(Json(host))
+}
+
+/// `GET /api/hosts/:host_id/agent-capabilities/codex` - best-effort local
+/// Codex CLI capability probe.
+pub async fn get_codex_capability(
+    State(state): State<Arc<LocalAppState>>,
+    Path(host_id): Path<String>,
+) -> Result<Json<AgentCapabilityInfo>, AppError> {
+    let parsed: Uuid = host_id
+        .parse()
+        .map_err(|_| AppError::BadRequest(format!("invalid host ID: {host_id}")))?;
+
+    if parsed != state.host_id {
+        return Err(AppError::NotFound(format!("host {host_id} not found")));
+    }
+
+    Ok(Json(detect_codex_capability().await))
+}
+
+async fn detect_codex_capability() -> AgentCapabilityInfo {
+    let config_profiles = read_codex_config_profiles().await.unwrap_or_default();
+    let last_checked_at = Utc::now().to_rfc3339();
+    let mut info = AgentCapabilityInfo {
+        kind: "codex".to_string(),
+        installed: false,
+        version: None,
+        authenticated: None,
+        config_profiles,
+        last_checked_at,
+        error: None,
+    };
+
+    match timeout(
+        Duration::from_secs(2),
+        Command::new("codex").arg("--version").output(),
+    )
+    .await
+    {
+        Ok(Ok(output)) if output.status.success() => {
+            info.installed = true;
+            info.version =
+                first_nonempty_line(&output.stdout).or_else(|| first_nonempty_line(&output.stderr));
+        }
+        Ok(Ok(output)) => {
+            info.installed = true;
+            info.error = first_nonempty_line(&output.stderr)
+                .or_else(|| first_nonempty_line(&output.stdout))
+                .or_else(|| Some("codex --version failed".to_string()));
+        }
+        Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            info.error = Some("codex executable not found".to_string());
+        }
+        Ok(Err(e)) => {
+            info.error = Some(format!("failed to run codex --version: {e}"));
+        }
+        Err(_) => {
+            info.error = Some("codex --version timed out".to_string());
+        }
+    }
+
+    info
+}
+
+fn first_nonempty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToString::to_string)
+}
+
+async fn read_codex_config_profiles() -> Option<Vec<String>> {
+    const MAX_CODEX_CONFIG_BYTES: u64 = 1024 * 1024;
+
+    let path = dirs::home_dir()?.join(".codex").join("config.toml");
+    let metadata = tokio::fs::metadata(&path).await.ok()?;
+    if metadata.len() > MAX_CODEX_CONFIG_BYTES {
+        return Some(Vec::new());
+    }
+    let contents = tokio::fs::read_to_string(path).await.ok()?;
+    Some(extract_codex_config_profiles(&contents))
+}
+
+fn extract_codex_config_profiles(contents: &str) -> Vec<String> {
+    let mut profiles = BTreeSet::new();
+
+    for raw_line in contents.lines() {
+        let line = raw_line
+            .split_once('#')
+            .map_or(raw_line, |(before_comment, _)| before_comment)
+            .trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(section) = line
+            .strip_prefix("[profiles.")
+            .and_then(|s| s.strip_suffix(']'))
+        {
+            let name = section.trim().trim_matches('"').trim_matches('\'');
+            if !name.is_empty() {
+                profiles.insert(name.to_string());
+            }
+            continue;
+        }
+
+        if let Some(value) = line
+            .strip_prefix("profile")
+            .and_then(|s| s.trim_start().strip_prefix('='))
+        {
+            let name = value.trim().trim_matches('"').trim_matches('\'');
+            if !name.is_empty() {
+                profiles.insert(name.to_string());
+            }
+        }
+    }
+
+    profiles.into_iter().collect()
 }
 
 #[cfg(test)]
@@ -157,5 +281,19 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn extracts_codex_config_profiles() {
+        let profiles = extract_codex_config_profiles(
+            r#"
+            profile = "work"
+            [profiles.review]
+            model = "gpt-5.1-codex"
+            [profiles."full-trust"]
+            approval_policy = "never"
+            "#,
+        );
+        assert_eq!(profiles, vec!["full-trust", "review", "work"]);
     }
 }

--- a/crates/zremote-client/src/client.rs
+++ b/crates/zremote-client/src/client.rs
@@ -5,13 +5,13 @@ use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use crate::error::ApiError;
 use crate::terminal::TerminalSession;
 use crate::types::{
-    ActionsResponse, AddProjectRequest, AgentKindInfo, AgentProfile, AgenticLoop,
-    ClaudeSessionInfo, ClaudeTask, ConfigValue, CreateAgentProfileRequest, CreateClaudeTaskRequest,
-    CreateSessionRequest, CreateSessionResponse, CreateWorktreeRequest, DirectoryEntry,
-    ExtractRequest, ExtractedMemory, Host, IndexRequest, KnowledgeBase, ListClaudeTasksFilter,
-    ListLoopsFilter, Memory, ModeResponse, PreviewSnapshot, Project, ProjectSettings,
-    ResumeClaudeTaskRequest, SearchRequest, SearchResult, ServiceControlRequest, Session,
-    SessionPreviewsResponse, SetConfigRequest, StartAgentRequest, StartAgentResponse,
+    ActionsResponse, AddProjectRequest, AgentCapabilityInfo, AgentKindInfo, AgentProfile,
+    AgenticLoop, ClaudeSessionInfo, ClaudeTask, ConfigValue, CreateAgentProfileRequest,
+    CreateClaudeTaskRequest, CreateSessionRequest, CreateSessionResponse, CreateWorktreeRequest,
+    DirectoryEntry, ExtractRequest, ExtractedMemory, Host, IndexRequest, KnowledgeBase,
+    ListClaudeTasksFilter, ListLoopsFilter, Memory, ModeResponse, PreviewSnapshot, Project,
+    ProjectSettings, ResumeClaudeTaskRequest, SearchRequest, SearchResult, ServiceControlRequest,
+    Session, SessionPreviewsResponse, SetConfigRequest, StartAgentRequest, StartAgentResponse,
     UpdateAgentProfileRequest, UpdateHostRequest, UpdateMemoryRequest, UpdateProjectRequest,
     UpdateSessionRequest,
 };
@@ -214,6 +214,24 @@ impl ApiClient {
             .client
             .get(format!(
                 "{}/api/hosts/{}",
+                self.base_url,
+                encode_path(host_id)
+            ))
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    /// Probe Codex capability on a host.
+    pub async fn get_host_codex_capability(
+        &self,
+        host_id: &str,
+    ) -> Result<AgentCapabilityInfo, ApiError> {
+        let resp = self
+            .client
+            .get(format!(
+                "{}/api/hosts/{}/agent-capabilities/codex",
                 self.base_url,
                 encode_path(host_id)
             ))

--- a/crates/zremote-client/src/lib.rs
+++ b/crates/zremote-client/src/lib.rs
@@ -23,6 +23,7 @@ pub use flume;
 pub use types::{
     ActionsResponse,
     AddProjectRequest,
+    AgentCapabilityInfo,
     AgentKindInfo,
     AgentProfile,
     // SDK types

--- a/crates/zremote-client/src/types.rs
+++ b/crates/zremote-client/src/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 // Re-export protocol types used in SDK API
 pub use zremote_protocol::{
-    AgenticLoopId, HostId, NodeStatus, SessionId,
+    AgentCapabilityInfo, AgenticLoopId, HostId, NodeStatus, SessionId,
     agentic::AgenticStatus,
     claude::{ClaudeSessionInfo, ClaudeTaskStatus},
     knowledge::{

--- a/crates/zremote-core/migrations/028_codex_profile_presets.sql
+++ b/crates/zremote-core/migrations/028_codex_profile_presets.sql
@@ -1,0 +1,95 @@
+-- Seed useful Codex presets. Existing profiles with the same per-kind name are
+-- left untouched so user edits and earlier local experiments win.
+INSERT INTO agent_profiles (
+    id,
+    name,
+    description,
+    agent_kind,
+    is_default,
+    sort_order,
+    initial_prompt,
+    skip_permissions,
+    settings_json
+)
+SELECT
+    lower(hex(randomblob(16))),
+    'Review',
+    'Read-only Codex review profile',
+    'codex',
+    0,
+    10,
+    'Review the current worktree for bugs, regressions, missing tests, and risky assumptions. Report findings first with file and line references.',
+    0,
+    '{"sandbox":"read-only","approval_policy":"on-request","no_alt_screen":true}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM agent_profiles WHERE agent_kind = 'codex' AND name = 'Review'
+);
+
+INSERT INTO agent_profiles (
+    id,
+    name,
+    description,
+    agent_kind,
+    is_default,
+    sort_order,
+    skip_permissions,
+    settings_json
+)
+SELECT
+    lower(hex(randomblob(16))),
+    'Implement',
+    'Workspace-write Codex implementation profile',
+    'codex',
+    0,
+    20,
+    0,
+    '{"sandbox":"workspace-write","approval_policy":"on-request","no_alt_screen":true}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM agent_profiles WHERE agent_kind = 'codex' AND name = 'Implement'
+);
+
+INSERT INTO agent_profiles (
+    id,
+    name,
+    description,
+    agent_kind,
+    is_default,
+    sort_order,
+    skip_permissions,
+    settings_json
+)
+SELECT
+    lower(hex(randomblob(16))),
+    'Autonomous',
+    'Workspace-write Codex profile that asks after failures',
+    'codex',
+    0,
+    30,
+    0,
+    '{"sandbox":"workspace-write","approval_policy":"on-failure","no_alt_screen":true}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM agent_profiles WHERE agent_kind = 'codex' AND name = 'Autonomous'
+);
+
+INSERT INTO agent_profiles (
+    id,
+    name,
+    description,
+    agent_kind,
+    is_default,
+    sort_order,
+    skip_permissions,
+    settings_json
+)
+SELECT
+    lower(hex(randomblob(16))),
+    'Full Trust',
+    'High-trust Codex profile that bypasses approvals and sandboxing',
+    'codex',
+    0,
+    40,
+    1,
+    '{"no_alt_screen":true}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM agent_profiles WHERE agent_kind = 'codex' AND name = 'Full Trust'
+);

--- a/crates/zremote-core/src/queries/agent_profiles.rs
+++ b/crates/zremote-core/src/queries/agent_profiles.rs
@@ -456,6 +456,35 @@ mod tests {
         assert_eq!(codex.agent_kind, "codex");
         assert_eq!(codex.name, "Default");
         assert_eq!(codex.settings["no_alt_screen"], serde_json::json!(true));
+
+        let codex_profiles = list_by_kind(&pool, "codex").await.unwrap();
+        let names: Vec<&str> = codex_profiles.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Default", "Review", "Implement", "Autonomous", "Full Trust"]
+        );
+
+        let review = codex_profiles
+            .iter()
+            .find(|p| p.name == "Review")
+            .expect("Review preset should be seeded");
+        assert_eq!(review.settings["sandbox"], serde_json::json!("read-only"));
+        assert_eq!(
+            review.settings["approval_policy"],
+            serde_json::json!("on-request")
+        );
+        assert!(
+            review
+                .initial_prompt
+                .as_deref()
+                .is_some_and(|p| p.contains("Review"))
+        );
+
+        let full_trust = codex_profiles
+            .iter()
+            .find(|p| p.name == "Full Trust")
+            .expect("Full Trust preset should be seeded");
+        assert!(full_trust.skip_permissions);
     }
 
     #[tokio::test]
@@ -671,9 +700,9 @@ mod tests {
     async fn test_list_profiles_and_by_kind() {
         let pool = test_db().await;
 
-        // The seed adds one default profile per built-in launcher.
+        // The seed adds one default claude profile and Codex defaults/presets.
         let seeded = list_profiles(&pool).await.unwrap();
-        assert_eq!(seeded.len(), 2);
+        assert_eq!(seeded.len(), 6);
         assert!(seeded.iter().any(|p| p.agent_kind == "claude"));
         assert!(seeded.iter().any(|p| p.agent_kind == "codex"));
 
@@ -691,14 +720,14 @@ mod tests {
         .unwrap();
 
         let all = list_profiles(&pool).await.unwrap();
-        assert_eq!(all.len(), 5);
+        assert_eq!(all.len(), 9);
 
         let claude_only = list_by_kind(&pool, "claude").await.unwrap();
         assert_eq!(claude_only.len(), 3);
         assert!(claude_only.iter().all(|p| p.agent_kind == "claude"));
 
         let codex_only = list_by_kind(&pool, "codex").await.unwrap();
-        assert_eq!(codex_only.len(), 2);
+        assert_eq!(codex_only.len(), 6);
         assert!(codex_only.iter().any(|p| p.id == "k-3"));
     }
 

--- a/crates/zremote-gui/src/views/settings/agent_profiles_tab.rs
+++ b/crates/zremote-gui/src/views/settings/agent_profiles_tab.rs
@@ -94,11 +94,24 @@ enum ActiveInput {
     ClaudeOutputFormat,
     ClaudeCustomFlags,
     CodexConfigProfile,
-    CodexSandbox,
-    CodexApprovalPolicy,
     NewCodexConfigOverride,
     CodexCustomFlags,
 }
+
+const CODEX_SANDBOX_OPTIONS: &[(&str, &str)] = &[
+    ("", "Default"),
+    ("read-only", "Read-only"),
+    ("workspace-write", "Workspace write"),
+    ("danger-full-access", "Danger full access"),
+];
+
+const CODEX_APPROVAL_POLICY_OPTIONS: &[(&str, &str)] = &[
+    ("", "Default"),
+    ("untrusted", "Untrusted"),
+    ("on-failure", "On failure"),
+    ("on-request", "On request"),
+    ("never", "Never"),
+];
 
 /// Mutable form state for the editor pane.
 ///
@@ -788,20 +801,6 @@ impl AgentProfilesTab {
                     validate_codex_config_profile(&self.edit_form.codex_config_profile)
                 }
             }
-            ActiveInput::CodexSandbox => {
-                if self.edit_form.codex_sandbox.is_empty() {
-                    Ok(())
-                } else {
-                    validate_codex_sandbox(&self.edit_form.codex_sandbox)
-                }
-            }
-            ActiveInput::CodexApprovalPolicy => {
-                if self.edit_form.codex_approval_policy.is_empty() {
-                    Ok(())
-                } else {
-                    validate_codex_approval_policy(&self.edit_form.codex_approval_policy)
-                }
-            }
             ActiveInput::NewCodexConfigOverride => {
                 if self.edit_form.new_codex_config_override_input.is_empty() {
                     Ok(())
@@ -1258,8 +1257,6 @@ impl AgentProfilesTab {
             ActiveInput::ClaudeOutputFormat => &mut self.edit_form.claude_output_format,
             ActiveInput::ClaudeCustomFlags => &mut self.edit_form.claude_custom_flags,
             ActiveInput::CodexConfigProfile => &mut self.edit_form.codex_config_profile,
-            ActiveInput::CodexSandbox => &mut self.edit_form.codex_sandbox,
-            ActiveInput::CodexApprovalPolicy => &mut self.edit_form.codex_approval_policy,
             ActiveInput::CodexCustomFlags => &mut self.edit_form.codex_custom_flags,
             // `handle_key_down` early-exits when `active_input` is `None`,
             // so this arm can only be reached from a future call site that
@@ -1410,6 +1407,7 @@ impl AgentProfilesTab {
         let name = profile.name.clone();
         let description = profile.description.clone();
         let is_default = profile.is_default;
+        let is_high_trust = profile.skip_permissions;
 
         div()
             .id(SharedString::from(format!("profile-row-{}", profile.id)))
@@ -1431,18 +1429,38 @@ impl AgentProfilesTab {
                             .text_color(theme::text_primary())
                             .child(name),
                     )
-                    .when(is_default, |s| {
-                        s.child(
-                            div()
-                                .px(px(4.0))
-                                .py(px(1.0))
-                                .rounded(px(3.0))
-                                .bg(theme::accent())
-                                .text_size(px(9.0))
-                                .text_color(theme::text_primary())
-                                .child("default"),
-                        )
-                    }),
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap(px(4.0))
+                            .when(is_high_trust, |s| {
+                                s.child(
+                                    div()
+                                        .px(px(4.0))
+                                        .py(px(1.0))
+                                        .rounded(px(3.0))
+                                        .bg(theme::warning_bg())
+                                        .border_1()
+                                        .border_color(theme::warning())
+                                        .text_size(px(9.0))
+                                        .text_color(theme::warning())
+                                        .child("high trust"),
+                                )
+                            })
+                            .when(is_default, |s| {
+                                s.child(
+                                    div()
+                                        .px(px(4.0))
+                                        .py(px(1.0))
+                                        .rounded(px(3.0))
+                                        .bg(theme::accent())
+                                        .text_size(px(9.0))
+                                        .text_color(theme::text_primary())
+                                        .child("default"),
+                                )
+                            }),
+                    ),
             )
             .when(description.is_some(), |s| {
                 s.child(
@@ -1603,6 +1621,9 @@ impl AgentProfilesTab {
                 cx.notify();
             }),
         ));
+        if self.edit_form.skip_permissions {
+            body = body.child(Self::render_high_trust_warning());
+        }
 
         // --- Tools ---------------------------------------------------------
         body = body.child(Self::render_section_header("Tools"));
@@ -1766,8 +1787,6 @@ impl AgentProfilesTab {
                                 this.field_errors.remove(&ActiveInput::ClaudeOutputFormat);
                                 this.field_errors.remove(&ActiveInput::ClaudeCustomFlags);
                                 this.field_errors.remove(&ActiveInput::CodexConfigProfile);
-                                this.field_errors.remove(&ActiveInput::CodexSandbox);
-                                this.field_errors.remove(&ActiveInput::CodexApprovalPolicy);
                                 this.field_errors
                                     .remove(&ActiveInput::NewCodexConfigOverride);
                                 this.field_errors.remove(&ActiveInput::CodexCustomFlags);
@@ -1996,6 +2015,107 @@ impl AgentProfilesTab {
             wrapper = wrapper.child(div().pl(px(22.0)).child(Self::render_hint(h)));
         }
         wrapper.into_any_element()
+    }
+
+    fn render_choice_selector(
+        &self,
+        label: &str,
+        hint: &str,
+        current_value: &str,
+        options: &'static [(&'static str, &'static str)],
+        set_value: fn(&mut EditForm, String),
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let mut picker = div().flex().flex_wrap().gap(px(6.0));
+        let current_is_known = options.iter().any(|(value, _)| *value == current_value);
+
+        for (value, option_label) in options {
+            let value = (*value).to_string();
+            let is_active = value == current_value;
+            picker = picker.child(
+                div()
+                    .id(SharedString::from(format!("choice-{label}-{value}")))
+                    .cursor_pointer()
+                    .px(px(10.0))
+                    .py(px(4.0))
+                    .rounded(px(4.0))
+                    .border_1()
+                    .border_color(if is_active {
+                        theme::accent()
+                    } else {
+                        theme::border()
+                    })
+                    .text_size(px(12.0))
+                    .when(is_active, |s| {
+                        s.bg(theme::accent()).text_color(theme::text_primary())
+                    })
+                    .when(!is_active, |s| {
+                        s.bg(theme::bg_tertiary())
+                            .text_color(theme::text_secondary())
+                    })
+                    .hover(|s| s.text_color(theme::text_primary()))
+                    .child((*option_label).to_string())
+                    .on_click(cx.listener(move |this, _: &ClickEvent, _w, cx| {
+                        set_value(&mut this.edit_form, value.clone());
+                        this.active_input = ActiveInput::None;
+                        this.mark_dirty();
+                        cx.notify();
+                    })),
+            );
+        }
+
+        if !current_value.is_empty() && !current_is_known {
+            picker = picker.child(
+                div()
+                    .px(px(10.0))
+                    .py(px(4.0))
+                    .rounded(px(4.0))
+                    .border_1()
+                    .border_color(theme::error())
+                    .bg(theme::bg_tertiary())
+                    .text_size(px(12.0))
+                    .text_color(theme::error())
+                    .child(format!("Unknown: {current_value}")),
+            );
+        }
+
+        let mut wrapper = div()
+            .flex()
+            .flex_col()
+            .gap(px(4.0))
+            .child(Self::render_label(label, false))
+            .child(picker);
+        if !hint.is_empty() {
+            wrapper = wrapper.child(Self::render_hint(hint));
+        }
+        if !current_value.is_empty() && !current_is_known {
+            wrapper = wrapper.child(Self::render_field_error(
+                "Select one of the supported values before saving.",
+            ));
+        }
+        wrapper.into_any_element()
+    }
+
+    fn render_high_trust_warning() -> AnyElement {
+        div()
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .px(px(8.0))
+            .py(px(6.0))
+            .rounded(px(4.0))
+            .border_1()
+            .border_color(theme::warning())
+            .bg(theme::warning_bg())
+            .text_size(px(11.0))
+            .text_color(theme::warning())
+            .child(
+                icon(Icon::AlertTriangle)
+                    .size(px(12.0))
+                    .text_color(theme::warning()),
+            )
+            .child("High trust: approvals and sandboxing may be bypassed for this launcher.")
+            .into_any_element()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2353,21 +2473,21 @@ impl AgentProfilesTab {
             cx,
         ));
 
-        section = section.child(self.render_text_input(
+        section = section.child(self.render_choice_selector(
             "Sandbox",
-            false,
-            "Optional: read-only, workspace-write, or danger-full-access.",
+            "Controls Codex filesystem/network sandboxing. Use danger-full-access only for trusted worktrees.",
             &self.edit_form.codex_sandbox,
-            ActiveInput::CodexSandbox,
+            CODEX_SANDBOX_OPTIONS,
+            |form, value| form.codex_sandbox = value,
             cx,
         ));
 
-        section = section.child(self.render_text_input(
+        section = section.child(self.render_choice_selector(
             "Approval policy",
-            false,
-            "Optional: untrusted, on-failure, on-request, or never.",
+            "Controls when Codex asks before privileged actions.",
             &self.edit_form.codex_approval_policy,
-            ActiveInput::CodexApprovalPolicy,
+            CODEX_APPROVAL_POLICY_OPTIONS,
+            |form, value| form.codex_approval_policy = value,
             cx,
         ));
 
@@ -2802,6 +2922,21 @@ mod tests {
             settings.get("custom_flags").and_then(|v| v.as_str()),
             Some("--enable experimental")
         );
+    }
+
+    #[core::prelude::rust_2021::test]
+    fn codex_selector_options_match_validation_allowlists() {
+        for (value, _) in CODEX_SANDBOX_OPTIONS {
+            if !value.is_empty() {
+                validate_codex_sandbox(value).expect("selector sandbox value must be valid");
+            }
+        }
+        for (value, _) in CODEX_APPROVAL_POLICY_OPTIONS {
+            if !value.is_empty() {
+                validate_codex_approval_policy(value)
+                    .expect("selector approval value must be valid");
+            }
+        }
     }
 
     #[core::prelude::rust_2021::test]

--- a/crates/zremote-gui/src/views/sidebar.rs
+++ b/crates/zremote-gui/src/views/sidebar.rs
@@ -102,6 +102,8 @@ pub struct SidebarView {
     /// re-clicking a host while its task is still alive replaces (cancels)
     /// the previous one instead of leaving a parallel future running.
     scan_http_tasks: HashMap<String, Task<()>>,
+    /// Project id whose inline agent profile launcher menu is currently open.
+    agent_menu_project_id: Option<String>,
 }
 
 /// Per-host project rescan progress. `total` is `0` until the agent has
@@ -140,6 +142,41 @@ impl SidebarView {
         self.agent_profiles
             .iter()
             .find(|p| p.agent_kind == agent_kind && p.is_default)
+    }
+
+    fn kind_display_name(&self, agent_kind: &str) -> String {
+        self.agent_kinds
+            .iter()
+            .find(|k| k.kind == agent_kind)
+            .map(|k| k.display_name.clone())
+            .unwrap_or_else(|| agent_kind.to_string())
+    }
+
+    fn sorted_agent_profiles(&self) -> Vec<AgentProfile> {
+        let mut profiles = self.agent_profiles.iter().cloned().collect::<Vec<_>>();
+        profiles.sort_by(|a, b| {
+            b.is_default
+                .cmp(&a.is_default)
+                .then_with(|| {
+                    self.kind_display_name(&a.agent_kind)
+                        .cmp(&self.kind_display_name(&b.agent_kind))
+                })
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        profiles
+    }
+
+    fn is_agent_menu_open(&self, project_id: &str) -> bool {
+        self.agent_menu_project_id.as_deref() == Some(project_id)
+    }
+
+    fn toggle_agent_menu(&mut self, project_id: &str, cx: &mut Context<Self>) {
+        if self.is_agent_menu_open(project_id) {
+            self.agent_menu_project_id = None;
+        } else {
+            self.agent_menu_project_id = Some(project_id.to_string());
+        }
+        cx.notify();
     }
 
     pub fn selected_session_id(&self) -> Option<&str> {
@@ -395,6 +432,7 @@ impl SidebarView {
             preview_snapshots: HashMap::new(),
             scan_progress: HashMap::new(),
             scan_http_tasks: HashMap::new(),
+            agent_menu_project_id: None,
         };
         view.load_data(cx);
         view.poll_previews(cx);
@@ -1499,16 +1537,24 @@ impl SidebarView {
         project_id: &str,
         host_id: &str,
         project_path: &str,
-        profile: &AgentProfile,
-        kind_display: String,
+        profiles: &[AgentProfile],
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let project_id = project_id.to_string();
         let host_id = host_id.to_string();
         let project_path = project_path.to_string();
-        let profile_id = profile.id.clone();
-        let profile_name = profile.name.clone();
-        let tooltip_text = format!("Start {kind_display} ({profile_name})");
+        let profile_count = profiles.len();
+        let profile_id = profiles.first().map(|p| p.id.clone());
+        let tooltip_text = if profile_count == 1 {
+            let profile = &profiles[0];
+            format!(
+                "Start {} ({})",
+                self.kind_display_name(&profile.agent_kind),
+                profile.name
+            )
+        } else {
+            "Start agent".to_string()
+        };
 
         div()
             .invisible()
@@ -1532,9 +1578,110 @@ impl SidebarView {
                         cx.new(|_| SidebarTextTooltip(tooltip_text.clone())).into()
                     })
                     .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
-                        this.launch_agent_for_project(&host_id, &project_path, &profile_id, cx);
+                        cx.stop_propagation();
+                        if profile_count == 1 {
+                            if let Some(profile_id) = profile_id.as_deref() {
+                                this.launch_agent_for_project(
+                                    &host_id,
+                                    &project_path,
+                                    profile_id,
+                                    cx,
+                                );
+                            }
+                        } else {
+                            this.toggle_agent_menu(&project_id, cx);
+                        }
                     })),
             )
+    }
+
+    fn render_project_agent_menu(
+        &self,
+        project_id: &str,
+        host_id: &str,
+        project_path: &str,
+        indent: f32,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        if !self.is_agent_menu_open(project_id) {
+            return None;
+        }
+
+        let profiles = self.sorted_agent_profiles();
+        if profiles.len() <= 1 {
+            return None;
+        }
+
+        let mut menu = div()
+            .ml(px(indent + 22.0))
+            .mr(px(8.0))
+            .my(px(2.0))
+            .py(px(3.0))
+            .border_1()
+            .border_color(theme::border())
+            .rounded(px(4.0))
+            .bg(theme::bg_secondary())
+            .flex()
+            .flex_col();
+
+        for profile in profiles {
+            let profile_id = profile.id.clone();
+            let host_id = host_id.to_string();
+            let project_path = project_path.to_string();
+            let row_id = SharedString::from(format!("agent-menu-{project_id}-{profile_id}"));
+            let label = format!(
+                "{} / {}",
+                self.kind_display_name(&profile.agent_kind),
+                profile.name
+            );
+            let description = profile.description.clone();
+            let mut item = div()
+                .id(row_id)
+                .px(px(8.0))
+                .py(px(5.0))
+                .cursor_pointer()
+                .hover(|s| s.bg(theme::bg_tertiary()))
+                .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                    cx.stop_propagation();
+                    this.agent_menu_project_id = None;
+                    this.launch_agent_for_project(&host_id, &project_path, &profile_id, cx);
+                }))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .justify_between()
+                        .gap(px(8.0))
+                        .child(
+                            div()
+                                .text_size(px(12.0))
+                                .text_color(theme::text_primary())
+                                .truncate()
+                                .child(label),
+                        )
+                        .when(profile.is_default, |el| {
+                            el.child(
+                                div()
+                                    .text_size(px(10.0))
+                                    .text_color(theme::text_tertiary())
+                                    .child("Default"),
+                            )
+                        }),
+                );
+            if let Some(description) = description {
+                item = item.child(
+                    div()
+                        .pt(px(1.0))
+                        .text_size(px(10.0))
+                        .text_color(theme::text_tertiary())
+                        .truncate()
+                        .child(description),
+                );
+            }
+            menu = menu.child(item);
+        }
+
+        Some(menu.into_any_element())
     }
 
     /// Hover-visible "New worktree" button rendered only on parent project
@@ -1611,6 +1758,15 @@ impl SidebarView {
         );
 
         let mut container = div().flex().flex_col().w_full().child(row);
+        if let Some(menu) = self.render_project_agent_menu(
+            &project_id,
+            host_id,
+            &node.project.path,
+            indents.project,
+            cx,
+        ) {
+            container = container.child(menu);
+        }
 
         // Parent's own sessions appear directly below the parent row.
         for session in &node.sessions {
@@ -1653,6 +1809,15 @@ impl SidebarView {
             cx,
         );
         let mut container = div().flex().flex_col().w_full().child(row);
+        if let Some(menu) = self.render_project_agent_menu(
+            &project_id,
+            host_id,
+            &node.project.path,
+            indents.worktree,
+            cx,
+        ) {
+            container = container.child(menu);
+        }
         for session in &node.sessions {
             container = container.child(
                 self.render_session_item(session, host_id, px(indents.worktree_session), cx)
@@ -1844,9 +2009,9 @@ impl SidebarView {
         )
     }
 
-    /// Right-side action cluster for a project row: agent launcher (if a
-    /// default Claude profile exists), the "New session" button, and, for
-    /// parent projects, a "New worktree" hover action.
+    /// Right-side action cluster for a project row: agent launcher (if any
+    /// profile exists), the "New session" button, and, for parent projects,
+    /// a "New worktree" hover action.
     fn render_row_actions(
         &self,
         project_id: &str,
@@ -1856,6 +2021,7 @@ impl SidebarView {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let is_parent = matches!(kind, RowKind::Parent { .. });
+        let profiles = self.sorted_agent_profiles();
         div()
             .flex()
             .items_center()
@@ -1863,25 +2029,15 @@ impl SidebarView {
             .when(is_parent, |el| {
                 el.child(self.render_new_worktree_button(project_id, host_id, cx))
             })
-            .when_some(
-                self.default_profile_for_kind("claude").cloned(),
-                |el, profile| {
-                    let kind_display = self
-                        .agent_kinds
-                        .iter()
-                        .find(|k| k.kind == profile.agent_kind)
-                        .map(|k| k.display_name.clone())
-                        .unwrap_or_else(|| "Claude".to_string());
-                    el.child(self.render_project_agent_button(
-                        project_id,
-                        host_id,
-                        project_path,
-                        &profile,
-                        kind_display,
-                        cx,
-                    ))
-                },
-            )
+            .when(!profiles.is_empty(), |el| {
+                el.child(self.render_project_agent_button(
+                    project_id,
+                    host_id,
+                    project_path,
+                    &profiles,
+                    cx,
+                ))
+            })
             .child(self.render_project_new_session_button(project_id, host_id, project_path, cx))
     }
 
@@ -1893,6 +2049,7 @@ impl SidebarView {
     /// `SessionSelected` event arrives and swaps the terminal once the
     /// backend responds.
     fn on_project_row_click(&mut self, project_id: &str, host_id: &str, cx: &mut Context<Self>) {
+        self.agent_menu_project_id = None;
         self.set_selected_project(Some(project_id.to_string()), Some(host_id.to_string()), cx);
 
         // Pick the most recently created active session for this project;

--- a/crates/zremote-protocol/src/agents.rs
+++ b/crates/zremote-protocol/src/agents.rs
@@ -105,6 +105,22 @@ pub struct KindInfo {
     pub description: &'static str,
 }
 
+/// Best-effort host-side capability information for one agent CLI.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentCapabilityInfo {
+    pub kind: String,
+    pub installed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authenticated: Option<bool>,
+    #[serde(default)]
+    pub config_profiles: Vec<String>,
+    pub last_checked_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// Single source of truth for the `agent_kind` values the server and agent
 /// accept. REST validation in `zremote-core` is handed this list as
 /// `&[&str]`; `GET /api/agent-profiles/kinds` returns the full metadata.

--- a/crates/zremote-protocol/src/lib.rs
+++ b/crates/zremote-protocol/src/lib.rs
@@ -11,8 +11,8 @@ mod terminal;
 
 pub use agentic::{AgenticAgentMessage, AgenticStatus};
 pub use agents::{
-    AgentLifecycleMessage, AgentProfileData, AgentServerMessage, KindInfo, SUPPORTED_KINDS,
-    supported_kinds,
+    AgentCapabilityInfo, AgentLifecycleMessage, AgentProfileData, AgentServerMessage, KindInfo,
+    SUPPORTED_KINDS, supported_kinds,
 };
 pub use claude::*;
 pub use events::{HostInfo, LoopInfo, NodeStatus, ServerEvent, SessionInfo};

--- a/crates/zremote-server/src/routes/agent_profiles.rs
+++ b/crates/zremote-server/src/routes/agent_profiles.rs
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(resp.status(), HttpStatus::OK);
         let json = read_json(resp).await;
         let arr = json.as_array().unwrap();
-        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.len(), 6);
     }
 
     #[tokio::test]

--- a/docs/rfc/rfc-codex-integration-polish.md
+++ b/docs/rfc/rfc-codex-integration-polish.md
@@ -1,0 +1,640 @@
+# RFC: Codex Integration Polish
+
+## Status: Draft
+
+## Date: 2026-05-14
+
+## Problem Statement
+
+ZRemote already has a working generic agent launcher architecture and a first
+Codex integration:
+
+- `agent_kind = "codex"` is in the protocol-level supported kinds.
+- A default Codex profile is seeded by migration `027_codex_agent_profile.sql`.
+- `CodexLauncher` builds a `codex` CLI command from an agent profile.
+- The profile editor exposes Codex-specific fields.
+- The command palette can launch every saved agent profile, including Codex.
+- The agentic output analyzer has a Codex adapter.
+
+The integration is usable, but still feels second-class compared with Claude
+Code. The remaining gaps are mostly around GUI ergonomics, runtime readiness,
+permission prompts, output parsing accuracy, and operational visibility.
+
+The goal of this RFC is to plan the work needed to make Codex feel like a
+first-class ZRemote agent without weakening the generic launcher model.
+
+## Goals
+
+1. Make Codex easy to launch from project rows via a small agent profile menu.
+2. Improve Codex runtime detection so failed launches become visible errors,
+   not silent terminal sessions.
+3. Parse Codex output accurately enough for tokens, tools, touched files,
+   model, approvals, and common errors.
+4. Relay Codex permission/input prompts into ZRemote UI and notifications.
+5. Improve Codex profile UX with safer controls and useful presets.
+6. Add host capability detection for installed/authenticated Codex.
+7. Add tests and real-output fixtures so parser and launch regressions are
+   caught.
+8. Document how to configure and use Codex in local and server mode.
+
+## Non-Goals
+
+- Replacing the generic `AgentLauncher` abstraction.
+- Removing the legacy Claude task flow.
+- Implementing a Codex-specific non-PTY transport.
+- Auto-installing Codex on remote hosts.
+- Automatically bypassing approvals. Profiles may expose approval/sandbox
+  choices, but the user remains in control.
+- Building project-specific profile inheritance in this pass.
+
+## Current State
+
+### Launcher
+
+`crates/zremote-agent/src/agents/codex.rs` maps generic profile fields and
+Codex-specific `settings_json` into a shell command:
+
+- `model` -> `codex --model`
+- `settings.config_profile` -> `codex --profile`
+- `settings.sandbox` -> `codex --sandbox`
+- `settings.approval_policy` -> `codex --ask-for-approval`
+- `skip_permissions` -> `--dangerously-bypass-approvals-and-sandbox`
+- `settings.search` -> `--search`
+- `settings.no_alt_screen` -> `--no-alt-screen`
+- `settings.config_overrides[]` -> repeated `-c key=value`
+- `settings.custom_flags` -> appended free-form flags
+- `extra_args[]` -> appended quoted args
+- `initial_prompt` -> appended prompt, with a temp file path for long prompts
+
+This is functional, but command construction still depends on shell string
+composition. The launcher also has no post-spawn behavior.
+
+### UI
+
+The command palette already emits one `StartAgent` action per profile. This is
+good and should remain the power-user path.
+
+The project-row quick launch is still hard-coded to the default Claude profile.
+That makes Codex discoverable in settings and command palette, but not in the
+main project workflow.
+
+### Monitoring
+
+`crates/zremote-agent/src/agentic/adapters/codex.rs` detects a small set of
+Codex lines:
+
+- version banner
+- token usage
+- shell commands
+- file operations
+- generic input-needed lines
+- a bare prompt
+
+The token parser currently falls back to splitting total tokens when Codex
+reports `input + output` in formats the regex does not capture. That is good
+as a fallback, but not good enough for analytics.
+
+### Lifecycle
+
+Local mode returns success after the PTY is created and the launcher command is
+written. Server mode similarly reports `Started` after command write. Neither
+path proves that `codex` started successfully, found auth/config, or reached an
+interactive prompt.
+
+## Design
+
+### 1. Project Row Agent Menu
+
+#### Decision
+
+Use a small menu on the project row agent button.
+
+The row should keep a single compact agent action next to the existing new
+session button. Clicking it opens a small menu listing launchable profiles,
+grouped or labeled by agent kind. This avoids adding one icon per tool and
+keeps project rows dense.
+
+#### Behavior
+
+- If there are no agent profiles, hide the agent button.
+- If there is exactly one profile, clicking the button launches it directly.
+- If there are multiple profiles, clicking opens the menu.
+- The menu lists profiles as:
+  - `Claude Code / Default`
+  - `Codex / Default`
+  - `Codex / Review`
+- Default profiles appear first, then profiles sorted by kind display name and
+  profile name.
+- Disabled entries show a reason when host capability detection says the tool
+  is unavailable.
+- Selecting a profile calls the existing generic `launch_agent_for_project`
+  path with `profile_id`, `host_id`, and `project_path`.
+
+#### UI Notes
+
+- Keep the button icon as `Zap` or change to `Bot` if `Zap` becomes overloaded.
+- Tooltip when closed: `Start agent`.
+- Tooltip when only one profile exists: `Start {kind} ({profile})`.
+- The menu should be keyboard reachable through the command palette path even
+  if the row menu itself is mouse-first.
+
+#### Implementation Scope
+
+- Replace `default_profile_for_kind("claude")` usage in sidebar row actions
+  with a generic profile list.
+- Add a lightweight project-row menu component or reuse an existing GPUI popover
+  pattern if present.
+- Keep `launch_agent_for_project` unchanged.
+- Add tests for profile ordering and empty/single/multiple profile behavior
+  where the current UI test surface allows it.
+
+### 2. Codex Readiness and Launch Errors
+
+#### Problem
+
+Writing `codex ...\n` into a PTY does not mean Codex is running. Common failure
+cases include:
+
+- `codex: command not found`
+- auth missing or expired
+- invalid `~/.codex/config.toml`
+- unsupported CLI flag after a Codex CLI update
+- model/profile not found
+- network unavailable
+
+#### Design
+
+Introduce a launch readiness detector for generic agent tasks.
+
+For Codex, watch the early terminal output after spawn for:
+
+- success signals:
+  - Codex banner
+  - interactive prompt
+  - first assistant/status event
+- failure signals:
+  - command not found
+  - unknown option
+  - auth/login required
+  - config parse error
+  - profile not found
+  - model not found
+
+The detector should update session status and surface a UI toast or activity
+event. Server mode should continue to send `Started` after PTY creation for
+backwards compatibility, but then emit a follow-up status/error event when
+readiness fails.
+
+#### Implementation Scope
+
+- Add provider-specific readiness patterns under the agentic/adapters layer or
+  a small launcher readiness module.
+- Store a short launch diagnostic in `sessions.error_message` when startup
+  clearly fails.
+- Add a timeout state: if no success or failure signal appears within a short
+  window, keep the session active but mark readiness as unknown.
+
+### 3. Codex Output Parser Accuracy
+
+#### Token Usage
+
+Improve `CODEX_TOKEN_RE` to parse the known Codex formats:
+
+- `Token usage: 1.9K total (1K input + 900 output)`
+- `Token usage: 1.9K total, input: 1K, output: 900`
+- future variants with cached/read/write token fields when available
+
+The parser should only split totals as a final fallback.
+
+#### Tool Calls
+
+Expand tool-call detection beyond:
+
+- `Running ...`
+- `Ran ...`
+
+Expected categories:
+
+- shell command
+- file edit/add/delete
+- file read/search if Codex prints it
+- web/search when `--search` is enabled
+- MCP/tool calls if exposed in Codex output
+
+#### Files Touched
+
+Keep `file_touched`, but add support for:
+
+- paths with spaces
+- multi-file edit summaries
+- file paths in diff/apply-patch summaries
+
+#### Model Detection
+
+Runtime model should come from:
+
+1. explicit profile model, when present
+2. Codex output line, when present
+3. config profile or default fallback, if discoverable
+
+#### Implementation Scope
+
+- Update `patterns.rs` and `adapters/codex.rs`.
+- Add golden fixtures from real Codex terminal output.
+- Add parser unit tests for every fixture.
+
+### 4. Permission and Input Prompt Relay
+
+#### Problem
+
+Codex can ask for approval or user input in the terminal. ZRemote currently has
+generic input-needed detection, but Codex approvals are not represented as
+first-class actionable events.
+
+#### Design
+
+Codex adapter should classify approval prompts into structured events:
+
+- command approval
+- file edit approval
+- network/search approval
+- escalation/sandbox approval
+- generic text input needed
+
+The UI should display these as actionable pending items where possible:
+
+- approve
+- reject
+- open terminal
+
+The first implementation should use PTY input injection only for deterministic
+command approval prompts. File edit, network, sandbox escalation, and generic
+text prompts should fall back to opening the terminal until they can be handled
+reliably. If Codex exposes a structured approval API later, this layer can
+switch transports without changing the UI event model.
+
+#### Implementation Scope
+
+- Extend prompt detection patterns for Codex approval text.
+- Map prompt events into the existing activity/notification system.
+- Add Telegram notification support for pending Codex approval if the existing
+  notification primitives already support generic agent events.
+- Keep auto-approval policy separate from Codex CLI approval policy. The
+  profile decides what Codex is allowed to ask; ZRemote decides whether to
+  notify, auto-approve, or require manual action.
+
+### 5. Codex Profile UX
+
+#### Current Pain
+
+Codex settings are mostly text fields. That is flexible, but it puts too much
+burden on users to remember exact values.
+
+#### Design
+
+Replace free-text fields with safer controls where the option set is known:
+
+- `sandbox`: dropdown
+  - empty/default
+  - `read-only`
+  - `workspace-write`
+  - `danger-full-access`
+- `approval_policy`: dropdown
+  - empty/default
+  - `untrusted`
+  - `on-failure`
+  - `on-request`
+  - `never`
+- `search`: checkbox
+- `no_alt_screen`: checkbox
+- `config_profile`: text input with validation
+- `config_overrides`: tag list
+- `custom_flags`: advanced text input
+
+Add profile templates:
+
+- `Codex / Review`
+  - sandbox: `read-only`
+  - approval: `on-request`
+  - prompt: review-oriented
+- `Codex / Implement`
+  - sandbox: `workspace-write`
+  - approval: `on-request`
+- `Codex / Autonomous`
+  - sandbox: `workspace-write`
+  - approval: `on-failure`
+- `Codex / Full Trust`
+  - skip permissions enabled
+  - visually marked as high trust
+
+These presets should be created automatically through migration/seeding so a
+fresh install has useful Codex profiles immediately. High-trust profiles need
+clear UI labeling, but they do not require an extra first-launch confirmation.
+
+#### Config Import
+
+Add an import action that reads `~/.codex/config.toml` and suggests matching
+ZRemote profiles. In server mode this must run on the target host, not the GUI
+machine.
+
+### 6. Host Capability Detection
+
+#### Problem
+
+The protocol advertises Codex support statically, but a specific host may not
+have Codex installed or authenticated.
+
+#### Design
+
+Add host-level agent capabilities:
+
+```json
+{
+  "host_id": "...",
+  "agents": {
+    "codex": {
+      "installed": true,
+      "version": "0.98.0",
+      "authenticated": true,
+      "config_profiles": ["default", "work"],
+      "last_checked_at": "..."
+    },
+    "claude": {
+      "installed": true,
+      "version": "...",
+      "authenticated": null
+    }
+  }
+}
+```
+
+Capabilities should be best-effort. Failure to check capabilities should not
+break manual launch.
+
+Capability detection may read `~/.codex/config.toml` on the target host to
+discover configured Codex profiles. In server mode, this must run on the remote
+agent host, not the GUI machine.
+
+#### Implementation Scope
+
+- Local and remote agents run lightweight commands:
+  - `codex --version`
+  - config inspection from `~/.codex/config.toml`
+  - optional auth/status probe if Codex has a safe command for it
+- Server stores or caches the latest capability snapshot.
+- GUI uses capabilities to disable menu entries or show warnings.
+
+### 7. Safer Launcher Internals
+
+#### Current Risk
+
+The launcher builds a shell command string. Validation blocks known dangerous
+characters for custom flags, but structured arguments are still safer and
+easier to reason about.
+
+#### Design
+
+Keep the PTY write model, but reduce shell-string risk:
+
+- Build an internal structured argv first.
+- Quote every argv segment with one shared shell quoting helper.
+- Split `custom_flags` into argv using a shell-words parser instead of
+  appending the raw string.
+- Create long prompt temp files with restrictive permissions.
+- Delete prompt temp files after command construction when possible, or use a
+  lifecycle cleanup path.
+- Avoid `$(cat file)` if a Codex-native prompt-file flag exists in the CLI
+  version ZRemote supports.
+
+#### Implementation Scope
+
+- Introduce a small `CommandLine` helper shared by Claude/Codex only if it
+  reduces duplication.
+- Add tests for prompt values containing quotes, newlines, and shell-looking
+  strings.
+- Keep compatibility with existing profiles.
+
+### 8. Analytics
+
+#### Design
+
+Codex sessions should feed the same agentic metrics surface as Claude where
+possible:
+
+- cumulative input/output tokens
+- estimated cost when model is known
+- file touches
+- tool calls
+- approval wait time
+- session readiness/failure reason
+
+Cost estimation should be explicitly marked estimated unless Codex reports an
+authoritative cost.
+
+#### Implementation Scope
+
+- Improve model propagation from profile to metrics.
+- Add known OpenAI model pricing entries only when stable enough for this app.
+- Prefer config-driven pricing or versioned constants over hard-coded guesses
+  when possible.
+
+### 9. Documentation
+
+Add user-facing docs:
+
+- how to install/login to Codex on each host
+- how to create a Codex profile
+- recommended sandbox/approval combinations
+- local mode vs server mode behavior
+- how project-row menu and command palette launch differ
+- troubleshooting:
+  - command not found
+  - auth required
+  - invalid profile
+  - missing model
+  - approvals not appearing
+
+Update README feature bullets so AI agent support does not read as
+Claude-only.
+
+## Implementation Plan
+
+### Phase 1: Launch UX
+
+Deliver the project-row small menu.
+
+Tasks:
+
+1. Replace hard-coded default Claude quick launch with a generic agent menu.
+2. Sort profiles with defaults first.
+3. Launch selected profile through existing `launch_agent_for_project`.
+4. Keep command palette behavior unchanged.
+5. Add focused tests for profile ordering and menu action construction where
+   feasible.
+
+Acceptance:
+
+- A project row can launch Codex without opening command palette.
+- Multiple profiles are selectable from one compact menu.
+- Empty profile state does not show a broken button.
+
+### Phase 2: Parser Fixtures
+
+Deliver accurate Codex parsing for current real output.
+
+Tasks:
+
+1. Capture representative Codex terminal logs into `test-data`.
+2. Fix token parsing for `total (input + output)` formats.
+3. Add model, common error, and approval prompt detection.
+4. Add tests around the fixtures.
+
+Acceptance:
+
+- Token breakdown no longer falls back to 50/50 split for known Codex formats.
+- Common launch/auth/config errors are classified.
+- Approval prompts create input-needed or approval events.
+
+### Phase 3: Readiness Lifecycle
+
+Deliver visible launch success/failure state.
+
+Tasks:
+
+1. Add a startup readiness detector for generic agent sessions.
+2. Wire Codex success/failure patterns into it.
+3. Persist clear failure messages in session state.
+4. Surface local/server failures in UI toasts or activity panel.
+
+Acceptance:
+
+- `codex: command not found` results in an errored session or visible launch
+  diagnostic.
+- Successful Codex startup becomes distinguishable from "PTY command written".
+- Unknown startup remains non-fatal.
+
+### Phase 4: Permission Relay
+
+Deliver actionable Codex approval prompts.
+
+Tasks:
+
+1. Classify Codex approval prompts.
+2. Reuse existing pending-action/notification surfaces where possible.
+3. Implement approve/reject PTY responses for deterministic command approval
+   prompts only.
+4. Add Telegram notifications if the generic event path supports it cleanly.
+
+Acceptance:
+
+- User sees a pending Codex approval outside the raw terminal.
+- Approve/reject works for at least the common command approval prompt.
+- Non-command and non-deterministic prompts fall back to "open terminal".
+
+### Phase 5: Profile UX and Presets
+
+Deliver safer Codex profile editing.
+
+Tasks:
+
+1. Replace known-value text fields with dropdowns.
+2. Add Codex profile templates.
+3. Add clear high-trust warning for skip permissions/full trust profile.
+4. Add host-side Codex config profile import.
+
+Acceptance:
+
+- A user can create a useful Codex profile without remembering flag values.
+- Invalid sandbox/approval values cannot be entered through normal controls.
+- Existing profiles continue to load and save.
+- High-trust profiles are clearly marked in UI; no extra first-launch
+  confirmation is required.
+
+### Phase 6: Capabilities and Docs
+
+Deliver host capability visibility and onboarding docs.
+
+Tasks:
+
+1. Add best-effort host capability checks for Codex.
+2. Show disabled/warning state in the project-row menu.
+3. Document install/login/profile setup.
+4. Update README feature language.
+
+Acceptance:
+
+- A host without Codex installed is visibly different from a host where Codex
+  is ready.
+- Users have a clear troubleshooting path.
+
+## Test Plan
+
+- Unit tests:
+  - Codex command builder flags and quoting.
+  - Codex settings validation.
+  - Codex parser token formats.
+  - Codex parser approval/error detection.
+  - Profile menu ordering helper.
+- Integration tests:
+  - `POST /api/agent-tasks` with Codex profile.
+  - server-mode `StartAgent` dispatch for Codex.
+  - failed launch path marks session diagnostic.
+- Fixture tests:
+  - real Codex startup output.
+  - real Codex token summary output.
+  - real approval prompt output.
+  - common failure output.
+- Manual QA:
+  - local mode with Codex installed.
+  - local mode without Codex installed.
+  - server mode with Codex installed only on remote host.
+  - multiple profiles in project-row menu.
+  - command palette launch remains unchanged.
+
+## Risks and Mitigations
+
+### Codex CLI Output Changes
+
+Risk: Regex parsing can break when Codex changes TUI text.
+
+Mitigation: Keep parser permissive, add fixtures, and treat unknown output as
+non-fatal. Prefer structured Codex output if the CLI exposes one later.
+
+### Approval Prompt Automation Is Fragile
+
+Risk: PTY injection for approve/reject may be prompt-format dependent.
+
+Mitigation: Start with detection and "open terminal"; add approve/reject only
+for deterministic command approval prompts. Keep the event model
+transport-agnostic.
+
+### Menu Could Become Too Busy
+
+Risk: Many profiles make project-row menu long.
+
+Mitigation: Defaults first, grouped by kind, and command palette remains the
+fast search path. Add filtering later only if real usage needs it.
+
+### Capability Checks May Be Slow
+
+Risk: Running CLI probes on many hosts can delay UI refresh.
+
+Mitigation: Cache results, run checks asynchronously, and never block manual
+launch on capability lookup.
+
+### Shell Command Construction
+
+Risk: Free-form flags and shell quoting are easy to get wrong.
+
+Mitigation: Move toward structured argv, shared quoting tests, and shell-words
+parsing for advanced flags.
+
+## Resolved Decisions
+
+1. When only one agent profile is available for a project row, the agent button
+   launches it directly instead of opening the menu.
+2. Capability detection may read `~/.codex/config.toml` on the target host.
+3. Phase 4 approve/reject buttons cover only common command approval prompts.
+4. Codex profile presets should be created automatically by migration/seeding.
+5. High-trust profiles only need clear UI labeling; no extra first-launch
+   confirmation is required.


### PR DESCRIPTION
## Summary
- Add an RFC for Codex integration polish and update README agent feature language.
- Replace the project-row Claude-only quick launch with a generic agent profile launcher that opens a compact menu when multiple profiles exist and launches directly when only one exists.
- Seed Codex profile presets, tighten Codex settings controls, and label high-trust profiles.
- Improve Codex token/error parsing and add local Codex capability probing via codex --version plus ~/.codex/config.toml profile discovery.

## Validation
- Pre-commit hook passed: cargo fmt, cargo clippy, cargo test.
- Additional targeted checks run during development: cargo check --workspace, cargo check -p zremote-gui, Codex parser tests, agent profile route tests, host route tests, and GUI agent profile tests.

## Notes
- The Codex capability endpoint is implemented for local mode and client support. Server-mode capability proxying is left as future protocol plumbing.