### PR TITLE
Resumable agent sessions + universal native session capture (RFC-012/013)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,14 @@ change goes into `zremote-protocol` -- never duplicate types between core and cl
 
 ### Local Mode
 
-Local mode CLI flags: `--port` (3000), `--db` (~/.zremote/local.db), `--bind` (127.0.0.1). Only env: `RUST_LOG`.
+Local mode CLI flags: `--port` (3000), `--db` (~/.zremote/local.db), `--bind` (127.0.0.1).
+
+| Variable | Default | Description |
+|---|---|---|
+| `RUST_LOG` | `info` | Tracing filter level |
+| `ZREMOTE_SESSION_BACKEND` | `daemon` | Session persistence backend: `daemon` or `none`/`pty` |
+| `ZREMOTE_RESUME_AGENTS_ON_RESTART` | `true` | Auto-resume a `resumable` agent session on attach (RFC-013). Accepts `1`/`true`/`0`/`false`; unparseable falls back to default. When off, attach surfaces a typed resumable result for an explicit "Continue" action |
+| `ZREMOTE_RECREATE_SHELL_ON_RESTART` | `false` | Re-create a plain shell at the original `working_dir` for non-agent sessions whose daemon did not survive a restart (RFC-013). Accepts `1`/`true`/`0`/`false` |
 
 ### GUI CLI
 

--- a/crates/zremote-agent/src/agents/codex_rollout.rs
+++ b/crates/zremote-agent/src/agents/codex_rollout.rs
@@ -1,0 +1,346 @@
+//! Filesystem fallback for resolving a Codex native session id.
+//!
+//! When Codex hooks are unavailable or untrusted (no live capture), ZRemote can
+//! still recover the native session id by reading Codex's on-disk rollout files.
+//! Each session writes
+//! `<codex_home>/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO8601>-<UUID>.jsonl`, whose
+//! first JSONL line is a `session_meta` record carrying the session `id` and the
+//! `cwd` it ran in (verified against `codex-cli` 0.135.0).
+//!
+//! Resolution strategy (RFC-012 Open Question #2): among rollouts whose
+//! `session_meta.cwd` matches the requested working dir, pick the one with the
+//! newest `session_meta.timestamp` (falling back to file mtime when the
+//! timestamp is absent). This is a best-effort recovery path, not the primary
+//! capture mechanism.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Parsed `session_meta` fields we care about (first line of a rollout file).
+///
+/// Codex wraps the meta in a small envelope; the fields we need (`id`, `cwd`,
+/// `timestamp`) appear either at the top level or nested under a `payload`
+/// object depending on the codex version, so we accept both shapes.
+#[derive(Debug, Clone, Deserialize)]
+struct SessionMeta {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+/// One resolved rollout candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RolloutSession {
+    /// Native codex session id from `session_meta.id`.
+    pub session_id: String,
+    /// Working directory the session ran in (`session_meta.cwd`).
+    pub cwd: String,
+    /// `session_meta.timestamp` if present (used for tie-breaking).
+    pub timestamp: Option<String>,
+    /// Absolute path to the rollout file.
+    pub path: PathBuf,
+}
+
+/// Resolve the Codex config/home directory, honoring `$CODEX_HOME`.
+///
+/// When `CODEX_HOME` is set and non-empty it is used verbatim; otherwise
+/// `<home>/.codex`.
+#[must_use]
+pub fn codex_home(home: &Path) -> PathBuf {
+    codex_home_with_override(home, std::env::var("CODEX_HOME").ok().as_deref())
+}
+
+/// Pure core of [`codex_home`]: resolve against an explicit override instead of
+/// reading the process environment (keeps the env-honoring logic unit-testable
+/// without mutating global env, which the workspace's `unsafe_code = "deny"`
+/// forbids).
+#[must_use]
+fn codex_home_with_override(home: &Path, override_dir: Option<&str>) -> PathBuf {
+    match override_dir {
+        Some(dir) if !dir.trim().is_empty() => PathBuf::from(dir),
+        _ => home.join(".codex"),
+    }
+}
+
+/// Find the newest Codex rollout whose `session_meta.cwd` equals
+/// `working_dir`, searching under `<codex_home>/sessions`.
+///
+/// Returns `None` when the sessions directory is absent, no rollout matches the
+/// `cwd`, or none carry a parseable `session_meta.id`. Among matches, the one
+/// with the lexicographically greatest `timestamp` wins (ISO-8601 sorts
+/// chronologically); candidates without a timestamp fall back to file mtime and
+/// rank below any timestamped match.
+#[must_use]
+pub fn newest_rollout_for_cwd(codex_home: &Path, working_dir: &str) -> Option<RolloutSession> {
+    let sessions_dir = codex_home.join("sessions");
+    let mut best: Option<(RolloutSession, RankKey)> = None;
+
+    for path in rollout_files(&sessions_dir) {
+        let Some(meta) = read_session_meta(&path) else {
+            continue;
+        };
+        let (Some(id), Some(cwd)) = (meta.id, meta.cwd) else {
+            continue;
+        };
+        if cwd != working_dir {
+            continue;
+        }
+        let rank = rank_key(meta.timestamp.as_deref(), &path);
+        let candidate = RolloutSession {
+            session_id: id,
+            cwd,
+            timestamp: meta.timestamp,
+            path,
+        };
+        match &best {
+            Some((_, best_rank)) if *best_rank >= rank => {}
+            _ => best = Some((candidate, rank)),
+        }
+    }
+
+    best.map(|(session, _)| session)
+}
+
+/// Ranking key for tie-breaking. A present ISO-8601 timestamp always outranks a
+/// missing one; within each class, larger sorts newer (timestamp string, then
+/// mtime nanos).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum RankKey {
+    /// No `session_meta.timestamp`; rank by file mtime (nanos since epoch).
+    Mtime(u128),
+    /// Has a timestamp; rank by the raw ISO-8601 string (chronological order).
+    Timestamp(String),
+}
+
+fn rank_key(timestamp: Option<&str>, path: &Path) -> RankKey {
+    match timestamp {
+        Some(ts) if !ts.is_empty() => RankKey::Timestamp(ts.to_string()),
+        _ => RankKey::Mtime(file_mtime_nanos(path)),
+    }
+}
+
+fn file_mtime_nanos(path: &Path) -> u128 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |d| d.as_nanos())
+}
+
+/// Maximum bytes read from a rollout's first line. A `session_meta` record is
+/// small; cap the read so a malformed/hostile rollout (no newline, or a
+/// gigabyte first line) cannot OOM the resolver (CWE-400).
+const MAX_META_LINE_BYTES: u64 = 1_048_576;
+
+/// Read and parse the first line of a rollout file as a `session_meta` record.
+///
+/// Accepts both the flat shape (`{"id":..,"cwd":..}`) and the enveloped shape
+/// (`{"type":"session_meta","payload":{"id":..,"cwd":..}}`). Returns `None` on
+/// any I/O or parse failure (the caller skips the candidate). The read is
+/// bounded to [`MAX_META_LINE_BYTES`] via a `Take` so a missing newline cannot
+/// pull an unbounded amount into memory.
+fn read_session_meta(path: &Path) -> Option<SessionMeta> {
+    use std::io::{BufRead, BufReader, Read};
+
+    let file = std::fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(file.take(MAX_META_LINE_BYTES));
+    let mut first_line = String::new();
+    // Read just the first line, capped by the `Take` above; rollouts can be large.
+    if reader.read_line(&mut first_line).ok()? == 0 {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(first_line.trim()).ok()?;
+
+    // Prefer a nested `payload` object when present, else parse the top level.
+    let target = value.get("payload").unwrap_or(&value);
+    serde_json::from_value::<SessionMeta>(target.clone()).ok()
+}
+
+/// Enumerate `rollout-*.jsonl` files under `sessions_dir` (recursively through
+/// the `<Y>/<M>/<D>` layout). Returns an empty vec if the directory is absent.
+fn rollout_files(sessions_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_rollouts(sessions_dir, &mut out, 0);
+    out
+}
+
+/// Bounded recursive walk. Codex nests rollouts three levels deep
+/// (`<Y>/<M>/<D>`); cap depth at 4 to stay defensive against symlink loops or
+/// unexpected layouts without an unbounded walk.
+fn collect_rollouts(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    const MAX_DEPTH: usize = 4;
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_rollouts(&path, out, depth + 1);
+        } else if file_type.is_file() && is_rollout_file(&path) {
+            out.push(path);
+        }
+    }
+}
+
+/// `true` for files named `rollout-*.jsonl`.
+fn is_rollout_file(path: &Path) -> bool {
+    let has_jsonl_ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("jsonl"));
+    let has_rollout_prefix = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("rollout-"));
+    has_rollout_prefix && has_jsonl_ext
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Create `<root>/sessions/<y>/<m>/<d>/rollout-<ts>-<uuid>.jsonl` with a
+    /// `session_meta` first line, returning the file path.
+    fn write_rollout(
+        root: &Path,
+        date: (&str, &str, &str),
+        file_stamp: &str,
+        meta_line: &str,
+    ) -> PathBuf {
+        let dir = root.join("sessions").join(date.0).join(date.1).join(date.2);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("rollout-{file_stamp}.jsonl"));
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{meta_line}").unwrap();
+        // A couple of non-meta lines to ensure we only read the first.
+        writeln!(f, r#"{{"type":"message","role":"user"}}"#).unwrap();
+        path
+    }
+
+    #[test]
+    fn codex_home_honors_override() {
+        // Override set + non-empty -> used verbatim.
+        assert_eq!(
+            codex_home_with_override(Path::new("/home/u"), Some("/custom/codex")),
+            PathBuf::from("/custom/codex")
+        );
+        // Absent -> default under home.
+        assert_eq!(
+            codex_home_with_override(Path::new("/home/u"), None),
+            PathBuf::from("/home/u/.codex")
+        );
+        // Empty/whitespace override -> falls back to default.
+        assert_eq!(
+            codex_home_with_override(Path::new("/home/u"), Some("   ")),
+            PathBuf::from("/home/u/.codex")
+        );
+    }
+
+    #[test]
+    fn newest_rollout_picks_matching_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "2026-06-04T10-00-00-11111111-1111-1111-1111-111111111111",
+            r#"{"id":"11111111-1111-1111-1111-111111111111","cwd":"/work/a","timestamp":"2026-06-04T10:00:00Z"}"#,
+        );
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "2026-06-04T11-00-00-22222222-2222-2222-2222-222222222222",
+            r#"{"id":"22222222-2222-2222-2222-222222222222","cwd":"/work/b","timestamp":"2026-06-04T11:00:00Z"}"#,
+        );
+
+        let got = newest_rollout_for_cwd(tmp.path(), "/work/a").expect("match for /work/a");
+        assert_eq!(got.session_id, "11111111-1111-1111-1111-111111111111");
+        assert_eq!(got.cwd, "/work/a");
+    }
+
+    #[test]
+    fn newest_rollout_tie_breaks_by_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Two rollouts in the SAME cwd; the later timestamp must win.
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "older-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            r#"{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","cwd":"/work/same","timestamp":"2026-06-04T09:00:00Z"}"#,
+        );
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "newer-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            r#"{"id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","cwd":"/work/same","timestamp":"2026-06-04T12:30:00Z"}"#,
+        );
+
+        let got = newest_rollout_for_cwd(tmp.path(), "/work/same").expect("match");
+        assert_eq!(
+            got.session_id, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "newest timestamp must win the tie-break"
+        );
+    }
+
+    #[test]
+    fn newest_rollout_accepts_enveloped_session_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "env-cccccccc-cccc-cccc-cccc-cccccccccccc",
+            r#"{"type":"session_meta","payload":{"id":"cccccccc-cccc-cccc-cccc-cccccccccccc","cwd":"/work/env","timestamp":"2026-06-04T08:00:00Z"}}"#,
+        );
+        let got = newest_rollout_for_cwd(tmp.path(), "/work/env").expect("enveloped match");
+        assert_eq!(got.session_id, "cccccccc-cccc-cccc-cccc-cccccccccccc");
+    }
+
+    #[test]
+    fn newest_rollout_none_when_no_cwd_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "x-dddddddd-dddd-dddd-dddd-dddddddddddd",
+            r#"{"id":"dddddddd-dddd-dddd-dddd-dddddddddddd","cwd":"/work/other","timestamp":"2026-06-04T08:00:00Z"}"#,
+        );
+        assert!(newest_rollout_for_cwd(tmp.path(), "/work/nope").is_none());
+    }
+
+    #[test]
+    fn newest_rollout_none_when_sessions_dir_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(newest_rollout_for_cwd(tmp.path(), "/anything").is_none());
+    }
+
+    #[test]
+    fn newest_rollout_skips_missing_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rollout(
+            tmp.path(),
+            ("2026", "06", "04"),
+            "noid-eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            r#"{"cwd":"/work/noid","timestamp":"2026-06-04T08:00:00Z"}"#,
+        );
+        assert!(newest_rollout_for_cwd(tmp.path(), "/work/noid").is_none());
+    }
+
+    #[test]
+    fn is_rollout_file_matches_expected_names() {
+        assert!(is_rollout_file(Path::new(
+            "/x/rollout-2026-06-04-uuid.jsonl"
+        )));
+        assert!(!is_rollout_file(Path::new("/x/notes.jsonl")));
+        assert!(!is_rollout_file(Path::new("/x/rollout-2026.json")));
+    }
+}

--- a/crates/zremote-agent/src/agents/mod.rs
+++ b/crates/zremote-agent/src/agents/mod.rs
@@ -17,13 +17,287 @@ use std::fmt;
 use std::sync::Arc;
 
 use uuid::Uuid;
+use zremote_protocol::AgentKind;
 use zremote_protocol::agents::AgentProfileData;
 
 pub mod claude;
 pub mod codex;
+pub mod codex_rollout;
+pub mod resume;
 
 pub use claude::ClaudeLauncher;
 pub use codex::CodexLauncher;
+pub use resume::resume_argv;
+
+/// One hook event ZRemote registers with an agent, plus whether the agent
+/// should run it asynchronously. Mirrors the per-event config the installer
+/// writes into the agent's hooks file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HookEventSpec {
+    /// Hook event name (e.g. `"PreToolUse"`). Must match the agent's event set.
+    pub event: &'static str,
+    /// Matcher string for the event (`""` for "all").
+    pub matcher: &'static str,
+    /// `true` to mark the hook `async` in the agent config (fire-and-forget).
+    pub async_hook: bool,
+}
+
+/// Per-agent specifics the hook handler would otherwise hard-code for Claude.
+///
+/// The hook HTTP handler (`crate::hooks::handler`) is agent-agnostic: it parses
+/// the common hook payload and dispatches the genuinely agent-specific bits
+/// through a `&dyn AgentIntegration`. This is the extension point for adding new
+/// agents (Codex, ...) without scattering `AgentKind` branches across the
+/// handler.
+///
+/// Only the parts that actually vary per agent live here. The native session id
+/// is **not** a method: both Claude and Codex deliver it in the hook payload's
+/// `session_id` field (RFC-012 §5), so the handler reads it directly.
+pub trait AgentIntegration: Send + Sync {
+    /// Which agent this integration represents. Used as the `agent` field of
+    /// `AgenticAgentMessage::AgentSessionRefCaptured`.
+    fn agent_kind(&self) -> AgentKind;
+
+    /// Path prefix (relative to `$HOME`) under which this agent writes session
+    /// transcripts. The handler validates a hook-supplied `transcript_path`
+    /// against `"$HOME/<root>"` before reading it (CWE-22 path-traversal guard),
+    /// so this must end with a trailing slash. For Claude: `.claude/projects/`.
+    fn transcript_root(&self) -> &'static str;
+
+    /// Extract a human-readable task name from the agent's transcript file,
+    /// resuming from byte `offset`. Returns `(task_name, new_offset)`.
+    ///
+    /// The caller has already validated `transcript_path` lies under
+    /// [`Self::transcript_root`]. For Claude this reads the `slug` field from the
+    /// JSONL transcript; other agents may use a different format.
+    ///
+    /// # Errors
+    /// Propagates I/O errors from reading the transcript file.
+    fn extract_task_name(
+        &self,
+        transcript_path: &str,
+        offset: u64,
+    ) -> std::io::Result<(Option<String>, u64)>;
+
+    /// Build the argv that resumes a native session for this agent, or `None`
+    /// if the agent has no known resume command. The native id is always a
+    /// separate argv element (injection-safe); see [`resume::resume_argv`].
+    fn resume_argv(&self, native_session_id: &str) -> Option<Vec<String>>;
+
+    /// Config directory name (relative to `$HOME`) where this agent reads its
+    /// hook configuration. For Claude: `.claude`; for Codex: `.codex`.
+    fn config_dir(&self) -> &'static str;
+
+    /// Optional environment variable that overrides [`Self::config_dir`] with an
+    /// absolute path. Claude honours `CLAUDE_CONFIG_DIR`; Codex honours
+    /// `CODEX_HOME`. When set and non-empty, the installer uses it verbatim
+    /// instead of `$HOME/<config_dir>`.
+    fn config_dir_env(&self) -> Option<&'static str>;
+
+    /// The hook events ZRemote registers for this agent, with per-event matcher
+    /// and async flag. Order is preserved when writing the config.
+    fn hook_events(&self) -> &'static [HookEventSpec];
+}
+
+/// [`AgentIntegration`] for Claude Code: `~/.claude/projects` transcripts with a
+/// `slug` field, and `claude --resume <id>`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ClaudeIntegration;
+
+impl AgentIntegration for ClaudeIntegration {
+    fn agent_kind(&self) -> AgentKind {
+        AgentKind::Claude
+    }
+
+    fn transcript_root(&self) -> &'static str {
+        ".claude/projects/"
+    }
+
+    fn extract_task_name(
+        &self,
+        transcript_path: &str,
+        offset: u64,
+    ) -> std::io::Result<(Option<String>, u64)> {
+        crate::hooks::transcript::extract_slug(transcript_path, offset)
+    }
+
+    fn resume_argv(&self, native_session_id: &str) -> Option<Vec<String>> {
+        resume::resume_argv(AgentKind::Claude, native_session_id)
+    }
+
+    fn config_dir(&self) -> &'static str {
+        ".claude"
+    }
+
+    fn config_dir_env(&self) -> Option<&'static str> {
+        Some("CLAUDE_CONFIG_DIR")
+    }
+
+    fn hook_events(&self) -> &'static [HookEventSpec] {
+        CLAUDE_HOOK_EVENTS
+    }
+}
+
+/// Hook events ZRemote registers with Claude Code. Kept in lockstep with the
+/// installer's claude config (a test asserts parity), so the trait surface and
+/// the live install never drift. The `Notification` event is registered twice
+/// by the installer with distinct matchers/endpoints (idle vs permission);
+/// here it appears once since the trait models the event set, not endpoints.
+const CLAUDE_HOOK_EVENTS: &[HookEventSpec] = &[
+    HookEventSpec {
+        event: "PreToolUse",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "PostToolUse",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "Stop",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "Notification",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "Elicitation",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "UserPromptSubmit",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "SessionStart",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "SubagentStart",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "SubagentStop",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "StopFailure",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "FileChanged",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "CwdChanged",
+        matcher: "",
+        async_hook: false,
+    },
+];
+
+/// Hook events ZRemote registers with Codex (`codex-cli` 0.135.0). Codex's event
+/// set differs from Claude's: it has `PermissionRequest` (not Claude's
+/// `Notification` matchers), no `Elicitation`/`FileChanged`/`CwdChanged`/
+/// `StopFailure`, and adds `PreCompact`/`PostCompact`. ZRemote registers the
+/// subset it actually consumes for state + capture. `SessionStart`,
+/// `PreToolUse`, and `UserPromptSubmit` are the capture entry points; the rest
+/// feed RFC-011 state.
+const CODEX_HOOK_EVENTS: &[HookEventSpec] = &[
+    HookEventSpec {
+        event: "SessionStart",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "PreToolUse",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "PostToolUse",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "UserPromptSubmit",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "PermissionRequest",
+        matcher: "",
+        async_hook: false,
+    },
+    HookEventSpec {
+        event: "SubagentStart",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "SubagentStop",
+        matcher: "",
+        async_hook: true,
+    },
+    HookEventSpec {
+        event: "Stop",
+        matcher: "",
+        async_hook: false,
+    },
+];
+
+/// [`AgentIntegration`] for OpenAI Codex (`codex-cli`): `~/.codex/sessions`
+/// rollout transcripts, `~/.codex/hooks.json` config, and `codex resume <id>`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CodexIntegration;
+
+impl AgentIntegration for CodexIntegration {
+    fn agent_kind(&self) -> AgentKind {
+        AgentKind::Codex
+    }
+
+    fn transcript_root(&self) -> &'static str {
+        // Codex stores per-session rollouts under ~/.codex/sessions/<Y>/<M>/<D>/.
+        ".codex/sessions/"
+    }
+
+    fn extract_task_name(
+        &self,
+        _transcript_path: &str,
+        offset: u64,
+    ) -> std::io::Result<(Option<String>, u64)> {
+        // Codex rollouts do not carry a Claude-style `slug`; ZRemote derives no
+        // task name from them in v1. Returning `None` (with the offset unchanged)
+        // keeps the handler's generic flow intact.
+        Ok((None, offset))
+    }
+
+    fn resume_argv(&self, native_session_id: &str) -> Option<Vec<String>> {
+        resume::resume_argv(AgentKind::Codex, native_session_id)
+    }
+
+    fn config_dir(&self) -> &'static str {
+        ".codex"
+    }
+
+    fn config_dir_env(&self) -> Option<&'static str> {
+        Some("CODEX_HOME")
+    }
+
+    fn hook_events(&self) -> &'static [HookEventSpec] {
+        CODEX_HOOK_EVENTS
+    }
+}
 
 /// Errors returned by the launcher registry and individual launchers.
 ///

--- a/crates/zremote-agent/src/agents/resume.rs
+++ b/crates/zremote-agent/src/agents/resume.rs
@@ -1,0 +1,92 @@
+//! Native-session resume argv builder.
+//!
+//! Translates a captured native session id (Claude `cc_session_id`, Codex
+//! rollout id, ...) into the argv that resumes that session. The native id is
+//! always returned as a separate argv element, never interpolated into a shell
+//! string, so an attacker-controlled id cannot inject extra commands or flags.
+
+use zremote_protocol::AgentKind;
+
+/// Build the argv to resume an agent's native session. The native id is always
+/// a separate argv element, never interpolated into a shell string.
+///
+/// Returns `None` for [`AgentKind::Unknown`], which has no known resume command.
+#[must_use]
+pub fn resume_argv(agent: AgentKind, native_session_id: &str) -> Option<Vec<String>> {
+    match agent {
+        AgentKind::Claude => Some(vec![
+            "claude".into(),
+            "--resume".into(),
+            native_session_id.into(),
+        ]),
+        AgentKind::Codex => Some(vec![
+            "codex".into(),
+            "resume".into(),
+            native_session_id.into(),
+        ]),
+        AgentKind::Unknown => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_resume_argv() {
+        assert_eq!(
+            resume_argv(AgentKind::Claude, "abc123"),
+            Some(vec![
+                "claude".to_string(),
+                "--resume".to_string(),
+                "abc123".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn codex_resume_argv() {
+        assert_eq!(
+            resume_argv(AgentKind::Codex, "abc123"),
+            Some(vec![
+                "codex".to_string(),
+                "resume".to_string(),
+                "abc123".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn unknown_agent_has_no_resume_argv() {
+        assert_eq!(resume_argv(AgentKind::Unknown, "abc123"), None);
+    }
+
+    #[test]
+    fn native_id_stays_a_single_argv_element_when_it_contains_shell_metacharacters() {
+        // A malicious native id must remain ONE argv element — it is data, not
+        // shell text. If it were ever concatenated into a shell string this id
+        // would run `rm -rf /`.
+        let evil = "abc; rm -rf /";
+        let argv = resume_argv(AgentKind::Claude, evil).expect("claude has resume argv");
+        assert_eq!(
+            argv,
+            vec![
+                "claude".to_string(),
+                "--resume".to_string(),
+                "abc; rm -rf /".to_string(),
+            ]
+        );
+        // The dangerous string is exactly one element, untouched.
+        assert_eq!(argv.len(), 3);
+        assert_eq!(argv[2], evil);
+    }
+
+    #[test]
+    fn empty_native_id_stays_a_single_element() {
+        let argv = resume_argv(AgentKind::Codex, "").expect("codex has resume argv");
+        assert_eq!(
+            argv,
+            vec!["codex".to_string(), "resume".to_string(), String::new()]
+        );
+    }
+}

--- a/crates/zremote-agent/src/claude/mod.rs
+++ b/crates/zremote-agent/src/claude/mod.rs
@@ -98,7 +98,7 @@ impl CommandBuilder {
         // in lockstep with REST validation — a profile that was accepted into
         // SQLite is guaranteed to pass here.
         use zremote_core::validation::agent_profile::{
-            validate_env_var_key, validate_env_var_value, validate_extra_arg,
+            validate_custom_flags, validate_env_var_key, validate_env_var_value, validate_extra_arg,
         };
         for (k, v) in *env_vars {
             validate_env_var_key(k)?;
@@ -106,6 +106,12 @@ impl CommandBuilder {
         }
         for arg in *extra_args {
             validate_extra_arg(arg)?;
+        }
+        // custom_flags is a free-form blob appended verbatim and re-executed via
+        // `sh -c` on resume — reject shell metacharacters so it cannot break out
+        // of its intended position (consistent with extra_args hardening).
+        if let Some(flags) = custom_flags {
+            validate_custom_flags(flags)?;
         }
 
         let mut parts = vec!["cd".to_string(), shell_quote(working_dir), "&&".to_string()];
@@ -148,7 +154,8 @@ impl CommandBuilder {
         }
 
         if let Some(flags) = custom_flags {
-            // Custom flags are appended as-is (user is responsible for correctness)
+            // Appended as-is, but validated above (no shell metacharacters) so it
+            // cannot inject commands when the built string is run via `sh -c`.
             parts.push(flags.to_string());
         }
 
@@ -565,6 +572,32 @@ mod tests {
         };
         let cmd = CommandBuilder::build(&opts).unwrap();
         assert!(cmd.contains("--model 'claude-sonnet-4-20250514'"));
+    }
+
+    #[test]
+    fn build_rejects_custom_flags_with_shell_metacharacters() {
+        // MEDIUM #5: custom_flags is re-executed via `sh -c` on resume, so a
+        // metachar-laden value must be rejected, not passed through raw.
+        let opts = CommandOptions {
+            custom_flags: Some("--verbose; rm -rf /"),
+            ..minimal_opts("/tmp")
+        };
+        let err = CommandBuilder::build(&opts).unwrap_err();
+        assert!(
+            err.contains("shell metacharacters") || err.contains("custom flags"),
+            "expected a custom_flags metachar rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_accepts_plain_custom_flags() {
+        // A normal multi-token flags blob (no metachars) still works.
+        let opts = CommandOptions {
+            custom_flags: Some("--foo bar --baz"),
+            ..minimal_opts("/tmp")
+        };
+        let cmd = CommandBuilder::build(&opts).unwrap();
+        assert!(cmd.contains("--foo bar --baz"));
     }
 
     #[test]

--- a/crates/zremote-agent/src/config.rs
+++ b/crates/zremote-agent/src/config.rs
@@ -150,6 +150,49 @@ pub fn detect_persistence_backend() -> PersistenceBackend {
     PersistenceBackend::Daemon
 }
 
+/// Parse a boolean env var, accepting `1`/`true` and `0`/`false`
+/// (case-insensitive). Returns `default` when the var is unset; on an
+/// unparseable value, logs a warning and falls back to `default` (never a
+/// silent invented value).
+fn parse_bool_env(var: &str, default: bool) -> bool {
+    match std::env::var(var) {
+        Err(_) => default,
+        Ok(raw) => match raw.trim().to_lowercase().as_str() {
+            "1" | "true" => true,
+            "0" | "false" => false,
+            other => {
+                tracing::warn!(
+                    var,
+                    value = other,
+                    default,
+                    "unparseable boolean env value, using default"
+                );
+                default
+            }
+        },
+    }
+}
+
+/// Whether the agent should automatically resume a `resumable` agent session
+/// when the GUI attaches to it (RFC-013).
+///
+/// Defaults to `true`. Override via `ZREMOTE_RESUME_AGENTS_ON_RESTART`
+/// (`1`/`true`/`0`/`false`). When off, attach returns a typed `SessionResumable`
+/// result so the GUI can offer an explicit "Continue" action instead.
+#[must_use]
+pub fn resume_agents_on_restart() -> bool {
+    parse_bool_env("ZREMOTE_RESUME_AGENTS_ON_RESTART", true)
+}
+
+/// Whether the agent should re-create a plain shell at the original
+/// `working_dir` for non-agent sessions whose daemon did not survive a restart
+/// (RFC-013). Defaults to `false`. Override via
+/// `ZREMOTE_RECREATE_SHELL_ON_RESTART` (`1`/`true`/`0`/`false`).
+#[must_use]
+pub fn recreate_shell_on_restart() -> bool {
+    parse_bool_env("ZREMOTE_RECREATE_SHELL_ON_RESTART", false)
+}
+
 #[cfg(test)]
 #[allow(unsafe_code)]
 mod tests {
@@ -275,6 +318,62 @@ mod tests {
         unsafe {
             remove_env("ZREMOTE_SERVER_URL");
             remove_env("ZREMOTE_TOKEN");
+        }
+    }
+
+    #[test]
+    fn resume_agents_on_restart_defaults_true() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { remove_env("ZREMOTE_RESUME_AGENTS_ON_RESTART") };
+        assert!(super::resume_agents_on_restart());
+    }
+
+    #[test]
+    fn recreate_shell_on_restart_defaults_false() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { remove_env("ZREMOTE_RECREATE_SHELL_ON_RESTART") };
+        assert!(!super::recreate_shell_on_restart());
+    }
+
+    #[test]
+    fn resume_agents_on_restart_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { set_env("ZREMOTE_RESUME_AGENTS_ON_RESTART", "false") };
+        assert!(!super::resume_agents_on_restart());
+        unsafe { set_env("ZREMOTE_RESUME_AGENTS_ON_RESTART", "0") };
+        assert!(!super::resume_agents_on_restart());
+        unsafe { set_env("ZREMOTE_RESUME_AGENTS_ON_RESTART", "TRUE") };
+        assert!(super::resume_agents_on_restart());
+        unsafe { remove_env("ZREMOTE_RESUME_AGENTS_ON_RESTART") };
+    }
+
+    #[test]
+    fn recreate_shell_on_restart_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        unsafe { set_env("ZREMOTE_RECREATE_SHELL_ON_RESTART", "1") };
+        assert!(super::recreate_shell_on_restart());
+        unsafe { set_env("ZREMOTE_RECREATE_SHELL_ON_RESTART", "true") };
+        assert!(super::recreate_shell_on_restart());
+        unsafe { remove_env("ZREMOTE_RECREATE_SHELL_ON_RESTART") };
+    }
+
+    #[test]
+    fn bool_env_unparseable_falls_back_to_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test-only env var manipulation, serialized by ENV_LOCK
+        // Garbage value -> keep the documented default (true here, false there),
+        // never an invented value.
+        unsafe { set_env("ZREMOTE_RESUME_AGENTS_ON_RESTART", "maybe") };
+        assert!(super::resume_agents_on_restart());
+        unsafe { set_env("ZREMOTE_RECREATE_SHELL_ON_RESTART", "yes-please") };
+        assert!(!super::recreate_shell_on_restart());
+        unsafe {
+            remove_env("ZREMOTE_RESUME_AGENTS_ON_RESTART");
+            remove_env("ZREMOTE_RECREATE_SHELL_ON_RESTART");
         }
     }
 }

--- a/crates/zremote-agent/src/daemon/mod.rs
+++ b/crates/zremote-agent/src/daemon/mod.rs
@@ -129,6 +129,7 @@ pub async fn run_pty_daemon(
     extra_env: std::collections::HashMap<String, String>,
     shell_config: Option<ShellIntegrationConfig>,
     owner_id: Option<String>,
+    resume_argv: Option<Vec<String>>,
 ) {
     // 1. Ignore SIGHUP (safe, no unsafe block)
     let mut sighup = tokio::signal::unix::signal(SignalKind::hangup())
@@ -156,8 +157,19 @@ pub async fn run_pty_daemon(
         }
     };
 
-    // 3. Spawn shell
-    let mut cmd = CommandBuilder::new(&shell);
+    // 3. Spawn the session process.
+    // RFC-013 resume: when `resume_argv` is present, the PTY child IS the agent
+    // CLI (e.g. `claude --resume <id>`), spawned directly as program + args — no
+    // shell, no `-c`, no word-splitting, so the native id is never re-parsed.
+    // Otherwise spawn the shell as today.
+    let mut cmd = match resume_argv.as_deref() {
+        Some([program, rest @ ..]) => {
+            let mut c = CommandBuilder::new(program);
+            c.args(rest);
+            c
+        }
+        _ => CommandBuilder::new(&shell),
+    };
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     for (key, value) in &extra_env {
@@ -167,22 +179,42 @@ pub async fn run_pty_daemon(
         cmd.cwd(dir);
     }
 
-    // Apply shell integration (env vars, autosuggestion disabling, etc.)
-    // Parse session_id as UUID for the prepare function
-    let _integration_state = if let Some(ref config) = shell_config {
-        if let Ok(sid) = uuid::Uuid::parse_str(&session_id) {
-            match crate::pty::shell_integration::prepare(sid, &shell, config, &mut cmd) {
-                Ok(state) => state,
-                Err(e) => {
-                    tracing::warn!(error = %e, "shell integration failed, continuing without it");
-                    None
-                }
-            }
-        } else {
-            None
+    // Export ZREMOTE_SESSION_ID / ZREMOTE_TERMINAL unconditionally on the daemon
+    // backend, independent of shell integration config. RFC-012 native-session
+    // capture keys off ZREMOTE_SESSION_ID being present in the agent's env (it is
+    // forwarded as the X-ZRemote-Session-Id hook header); without it, capture
+    // silently fails for daemon-backed sessions. `prepare` may re-set the same
+    // values when export_env_vars is on; that is harmless (identical values).
+    match uuid::Uuid::parse_str(&session_id) {
+        Ok(sid) => crate::pty::shell_integration::set_session_env(sid, &mut cmd),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                session_id = %session_id,
+                "session_id is not a valid UUID; ZREMOTE_SESSION_ID not exported"
+            );
         }
-    } else {
-        None
+    }
+
+    // Apply shell integration (env vars, autosuggestion disabling, etc.).
+    // Skipped for a resume spawn: the process is the agent CLI, not a shell, so
+    // shell-rc integration does not apply.
+    // Parse session_id as UUID for the prepare function.
+    let _integration_state = match (shell_config.as_ref(), resume_argv.as_deref()) {
+        (Some(config), None) => {
+            if let Ok(sid) = uuid::Uuid::parse_str(&session_id) {
+                match crate::pty::shell_integration::prepare(sid, &shell, config, &mut cmd) {
+                    Ok(state) => state,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "shell integration failed, continuing without it");
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
     };
 
     let child = match pair.slave.spawn_command(cmd) {

--- a/crates/zremote-agent/src/daemon/session.rs
+++ b/crates/zremote-agent/src/daemon/session.rs
@@ -46,6 +46,7 @@ impl DaemonSession {
         shell_config: Option<&ShellIntegrationConfig>,
         sock_dir: &std::path::Path,
         owner_id: Option<&str>,
+        resume_argv: Option<&[String]>,
     ) -> Result<(Self, u32), Box<dyn std::error::Error + Send + Sync>> {
         // Use current_exe() for binary name detection, but /proc/PID/exe for
         // the actual spawn path on Linux. After recompilation, cargo replaces
@@ -116,6 +117,17 @@ impl DaemonSession {
         if let Some(id) = owner_id {
             args.push("--owner-id".to_string());
             args.push(id.to_string());
+        }
+
+        // RFC-013 resume: pass the agent resume command as ordered --init-arg
+        // tokens. The daemon subprocess spawns argv[0] with argv[1..] as the PTY
+        // child instead of `shell`. Each element is a separate argv token across
+        // the process boundary, so the native id is never word-split.
+        if let Some(argv) = resume_argv {
+            for arg in argv {
+                args.push("--init-arg".to_string());
+                args.push(arg.clone());
+            }
         }
 
         // Ensure socket directory exists before opening log file

--- a/crates/zremote-agent/src/hooks/channel.rs
+++ b/crates/zremote-agent/src/hooks/channel.rs
@@ -112,6 +112,7 @@ mod tests {
             mapper,
             outbound_tx,
             sent_cc_session_ids: Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            sent_agent_session_refs: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
         };
         (state, outbound_rx)
     }

--- a/crates/zremote-agent/src/hooks/handler.rs
+++ b/crates/zremote-agent/src/hooks/handler.rs
@@ -19,13 +19,14 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use zremote_protocol::claude::ClaudeAgentMessage;
 use zremote_protocol::{
-    AgentInputRequest, AgentInputRequestKind, AgentRuntimeStatus, AgenticLoopId, NodeStatus,
+    AgentInputRequest, AgentInputRequestKind, AgentKind, AgentRuntimeStatus, AgenticLoopId,
+    NodeStatus,
 };
 use zremote_protocol::{AgentMessage, AgenticAgentMessage, AgenticStatus, SessionId};
 
 use super::context::HookContextProvider;
 use super::mapper::SessionMapper;
-use super::transcript::extract_slug;
+use crate::agents::AgentIntegration;
 use crate::knowledge::context_delivery::DeliveryCoordinator;
 
 const INPUT_CAP_BYTES: usize = 1024;
@@ -131,6 +132,15 @@ pub struct HooksState {
     pub outbound_tx: mpsc::Sender<AgentMessage>,
     /// CC session IDs that have already been sent via `SessionIdCaptured` (dedup).
     pub sent_cc_session_ids: Arc<tokio::sync::RwLock<HashSet<String>>>,
+    /// `(zremote_session_id, agent, native_session_id)` tuples already emitted as
+    /// `AgentSessionRefCaptured`, for dedup of the RFC-012 generic capture path.
+    /// Generalizes [`Self::sent_cc_session_ids`], which is kept for the legacy
+    /// Claude-task `SessionIdCaptured` path during the transition.
+    ///
+    /// A `Mutex` (not `RwLock`) so the check-and-insert is a single critical
+    /// section — two concurrent hooks for the same key cannot both observe it
+    /// absent and double-send.
+    pub sent_agent_session_refs: Arc<tokio::sync::Mutex<HashSet<(SessionId, AgentKind, String)>>>,
     /// Builds `additionalContext` for hook responses.
     pub context_provider: HookContextProvider,
     /// Coordinates pending context nudges for delivery via hooks.
@@ -258,9 +268,19 @@ pub async fn handle_hook(
         .and_then(|v| v.to_str().ok())
         .filter(|v| !v.is_empty())
         .map(String::from);
+    // RFC-012: the forwarder script sets X-ZRemote-Session-Id to the originating
+    // PTY session's id (from $ZREMOTE_SESSION_ID). Validate it as a UUID here;
+    // it is the authoritative key for native-session capture and does not depend
+    // on the detector/loop mapping.
+    let zremote_session_id = parse_zremote_session_header(&headers);
+    // Select the per-agent integration from the X-ZRemote-Agent header (codex vs
+    // claude; absent => claude for back-compat). Drives both the captured agent
+    // kind and the transcript root / task-name extraction.
+    let integration = select_integration(&headers);
     tracing::debug!(
         hook_event = %payload.hook_event_name,
         cc_session = %payload.session_id,
+        agent = ?integration.agent_kind(),
         tool = ?payload.tool_name,
         "hook event received"
     );
@@ -278,10 +298,12 @@ pub async fn handle_hook(
     }
 
     let response = match payload.hook_event_name.as_str() {
-        "PreToolUse" => handle_pre_tool_use(&state, &payload).await,
-        "PostToolUse" => handle_post_tool_use(&state, &payload).await,
+        "PreToolUse" => {
+            handle_pre_tool_use(&state, integration, &payload, zremote_session_id).await
+        }
+        "PostToolUse" => handle_post_tool_use(&state, integration, &payload).await,
         "Stop" => {
-            handle_stop(&state, &payload).await;
+            handle_stop(&state, integration, &payload).await;
             HookResponse::default()
         }
         "Notification" => {
@@ -304,7 +326,7 @@ pub async fn handle_hook(
             HookResponse::default()
         }
         "UserPromptSubmit" => {
-            handle_user_prompt_submit(&state, &payload).await;
+            handle_user_prompt_submit(&state, integration, &payload, zremote_session_id).await;
             HookResponse::default()
         }
         "SessionStart" => {
@@ -313,6 +335,17 @@ pub async fn handle_hook(
                 source = ?payload.source,
                 "CC session started"
             );
+            // RFC-012: capture the native session id keyed by the ZRemote session
+            // id from the header, for the agent selected by X-ZRemote-Agent.
+            // Independent of the loop mapping and of whether this is a UI-started
+            // Claude task.
+            try_capture_agent_session_ref(
+                &state,
+                integration.agent_kind(),
+                zremote_session_id,
+                &payload.session_id,
+            )
+            .await;
             // Write session env vars to CLAUDE_ENV_FILE if provided.
             // These become available in all subsequent Bash tool calls.
             if let Some(ref path) = env_file {
@@ -376,7 +409,7 @@ pub async fn handle_hook(
                 cc_session = %payload.session_id,
                 "CC turn ended due to API error"
             );
-            handle_stop(&state, &payload).await;
+            handle_stop(&state, integration, &payload).await;
             HookResponse::default()
         }
         other => {
@@ -436,7 +469,116 @@ async fn try_capture_cc_session_id(
     }
 }
 
-async fn handle_pre_tool_use(state: &HooksState, payload: &HookPayload) -> HookResponse {
+/// Static Claude integration instance for per-request selection.
+static CLAUDE_INTEGRATION: crate::agents::ClaudeIntegration = crate::agents::ClaudeIntegration;
+/// Static Codex integration instance for per-request selection.
+static CODEX_INTEGRATION: crate::agents::CodexIntegration = crate::agents::CodexIntegration;
+
+/// Select the [`AgentIntegration`] for a hook request from its `X-ZRemote-Agent`
+/// header. `codex` -> Codex; anything else (including an absent header) ->
+/// Claude, preserving back-compat with the original claude-only forwarder that
+/// sent no agent header.
+fn select_integration(headers: &HeaderMap) -> &'static dyn AgentIntegration {
+    let raw = headers
+        .get("x-zremote-agent")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim);
+    match raw {
+        Some("codex") => &CODEX_INTEGRATION,
+        _ => &CLAUDE_INTEGRATION,
+    }
+}
+
+/// Parse and validate the `X-ZRemote-Session-Id` header as a ZRemote
+/// [`SessionId`] UUID. Returns `None` if the header is absent, non-UTF-8, empty,
+/// or not a valid UUID (callers then skip the generic capture path).
+fn parse_zremote_session_header(headers: &HeaderMap) -> Option<SessionId> {
+    let raw = headers
+        .get("x-zremote-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())?;
+    match SessionId::parse_str(raw) {
+        Ok(id) => Some(id),
+        Err(_) => {
+            tracing::warn!(
+                header = %raw,
+                "X-ZRemote-Session-Id is not a valid UUID, ignoring for capture"
+            );
+            None
+        }
+    }
+}
+
+/// RFC-012 generic native-session capture.
+///
+/// Emits [`AgenticAgentMessage::AgentSessionRefCaptured`] linking the ZRemote
+/// session id (from the validated `X-ZRemote-Session-Id` header) to the agent's
+/// native session id (`native_session_id`, i.e. the hook payload's
+/// `session_id`). The `agent` kind is selected per-request from the
+/// `X-ZRemote-Agent` header (see [`select_integration`]), so this path serves
+/// both Claude and Codex. Unlike [`try_capture_cc_session_id`], it does **not**
+/// consult `get_claude_task_id` — it captures for *every* session.
+///
+/// Deduplicated per `(zremote_session_id, agent, native_session_id)`. A missing
+/// or invalid header (`zremote_session_id == None`) is a no-op.
+async fn try_capture_agent_session_ref(
+    state: &HooksState,
+    agent: AgentKind,
+    zremote_session_id: Option<SessionId>,
+    native_session_id: &str,
+) {
+    /// Native session ids are short identifiers (UUIDs, rollout ids). Reject
+    /// anything implausibly long so a hostile/buggy payload can't grow the
+    /// dedup set without bound (CWE-400).
+    const MAX_NATIVE_ID_LEN: usize = 256;
+
+    let Some(session_id) = zremote_session_id else {
+        return;
+    };
+    if native_session_id.is_empty() {
+        return;
+    }
+    if native_session_id.len() > MAX_NATIVE_ID_LEN {
+        tracing::warn!(
+            len = native_session_id.len(),
+            "native_session_id exceeds {MAX_NATIVE_ID_LEN} bytes, ignoring for capture"
+        );
+        return;
+    }
+    let key = (session_id, agent, native_session_id.to_string());
+
+    // Check-and-insert under a single Mutex guard so two concurrent hooks for
+    // the same key cannot both observe it absent and double-send. Release the
+    // guard before the (synchronous) try_send.
+    {
+        let mut sent = state.sent_agent_session_refs.lock().await;
+        if sent.contains(&key) {
+            return;
+        }
+        sent.insert(key.clone());
+    }
+
+    let msg = AgenticAgentMessage::AgentSessionRefCaptured {
+        session_id,
+        agent,
+        native_session_id: native_session_id.to_string(),
+    };
+    if state.agentic_tx.try_send(msg).is_err() {
+        // The send failed, so this ref was never delivered. Roll back the dedup
+        // entry, otherwise the key stays forever and the session's native id is
+        // never re-captured — permanently breaking resume for that session.
+        state.sent_agent_session_refs.lock().await.remove(&key);
+        tracing::warn!("agentic channel full, AgentSessionRefCaptured dropped (will retry)");
+    }
+}
+
+async fn handle_pre_tool_use(
+    state: &HooksState,
+    integration: &dyn AgentIntegration,
+    payload: &HookPayload,
+    zremote_session_id: Option<SessionId>,
+) -> HookResponse {
     // Drop hook if tool_use_id is missing — we can't correlate without it.
     let Some(ref tool_use_id) = payload.tool_use_id else {
         tracing::warn!(
@@ -460,6 +602,15 @@ async fn handle_pre_tool_use(state: &HooksState, payload: &HookPayload) -> HookR
     };
 
     try_capture_cc_session_id(state, &payload.session_id, &mapped.session_id).await;
+    // RFC-012 fallback: agents may fire a tool before a SessionStart reaches us.
+    // Capture the native session id here too (dedup makes it first-only).
+    try_capture_agent_session_ref(
+        state,
+        integration.agent_kind(),
+        zremote_session_id,
+        &payload.session_id,
+    )
+    .await;
     state.mapper.mark_hook_activity(mapped.session_id);
     state.mapper.set_hook_mode(mapped.session_id);
 
@@ -520,7 +671,11 @@ async fn handle_pre_tool_use(state: &HooksState, payload: &HookPayload) -> HookR
     }
 }
 
-async fn handle_post_tool_use(state: &HooksState, payload: &HookPayload) -> HookResponse {
+async fn handle_post_tool_use(
+    state: &HooksState,
+    integration: &dyn AgentIntegration,
+    payload: &HookPayload,
+) -> HookResponse {
     let Some(ref tool_use_id) = payload.tool_use_id else {
         tracing::warn!(
             cc_session = %payload.session_id,
@@ -543,7 +698,7 @@ async fn handle_post_tool_use(state: &HooksState, payload: &HookPayload) -> Hook
     state.mapper.set_hook_mode(mapped.session_id);
 
     // Try to extract slug from transcript for task_name
-    let task_name = extract_task_name_from_transcript(payload, &mapped);
+    let task_name = extract_task_name_from_transcript(integration, payload, &mapped);
 
     let loop_state_msg = AgenticAgentMessage::LoopStateUpdate {
         loop_id: mapped.loop_id,
@@ -599,7 +754,11 @@ async fn handle_post_tool_use(state: &HooksState, payload: &HookPayload) -> Hook
     }
 }
 
-async fn handle_stop(state: &HooksState, payload: &HookPayload) {
+async fn handle_stop(
+    state: &HooksState,
+    integration: &dyn AgentIntegration,
+    payload: &HookPayload,
+) {
     let Some(mapped) = state
         .mapper
         .resolve_loop_id(&payload.session_id, payload.cwd.as_deref())
@@ -624,7 +783,7 @@ async fn handle_stop(state: &HooksState, payload: &HookPayload) {
     }
 
     // Extract task_name from transcript
-    let task_name = extract_task_name_from_transcript(payload, &mapped);
+    let task_name = extract_task_name_from_transcript(integration, payload, &mapped);
 
     emit_agent_state(
         state,
@@ -845,7 +1004,23 @@ async fn handle_elicitation(state: &HooksState, payload: &HookPayload) {
     .await;
 }
 
-async fn handle_user_prompt_submit(state: &HooksState, payload: &HookPayload) {
+async fn handle_user_prompt_submit(
+    state: &HooksState,
+    integration: &dyn AgentIntegration,
+    payload: &HookPayload,
+    zremote_session_id: Option<SessionId>,
+) {
+    // RFC-012 fallback: capture the native session id even before the loop
+    // mapping resolves (it keys off the header, not the mapping). Dedup makes
+    // this first-only across SessionStart / PreToolUse / UserPromptSubmit.
+    try_capture_agent_session_ref(
+        state,
+        integration.agent_kind(),
+        zremote_session_id,
+        &payload.session_id,
+    )
+    .await;
+
     let Some(mapped) = state
         .mapper
         .resolve_loop_id(&payload.session_id, payload.cwd.as_deref())
@@ -956,8 +1131,12 @@ fn sanitize_shell_value(value: &str) -> String {
     value.replace('\'', "'\\''")
 }
 
-/// Extract `task_name` from the transcript file slug, with path traversal validation.
+/// Extract `task_name` from the agent's transcript, with path-traversal
+/// validation. Agent-specific bits (transcript root + extraction format) are
+/// dispatched through `integration`; the HOME lookup, the prefix-validation
+/// structure, and the 100-char cap are agent-agnostic and stay here.
 fn extract_task_name_from_transcript(
+    integration: &dyn AgentIntegration,
     payload: &HookPayload,
     mapped: &super::mapper::MappedSession,
 ) -> Option<String> {
@@ -966,13 +1145,34 @@ fn extract_task_name_from_transcript(
         .as_ref()
         .or(mapped.transcript_path.as_ref())?;
 
-    // CWE-22: Validate transcript_path is within ~/.claude/projects/
+    // CWE-22: Validate transcript_path is within the agent's transcript root
+    // (for Claude: ~/.claude/projects/). We canonicalize both the candidate and
+    // the allowed root and compare with `Path::starts_with` (component-wise),
+    // not raw `str::starts_with` — the latter is bypassable with `..` segments
+    // (e.g. `~/.claude/projects/../../.ssh/id_rsa`). Canonicalizing resolves
+    // `..` and symlinks; it also requires the file to already exist, which is
+    // fine since we are about to open it.
     let Ok(home) = std::env::var("HOME") else {
         tracing::warn!("HOME not set, cannot validate transcript_path, skipping");
         return None;
     };
-    let allowed_prefix = format!("{home}/.claude/projects/");
-    if !transcript_path.starts_with(&allowed_prefix) {
+    let allowed_root = std::path::Path::new(&home).join(integration.transcript_root());
+    let Ok(canonical_root) = allowed_root.canonicalize() else {
+        // No transcript root on disk -> nothing valid to read.
+        tracing::debug!(
+            root = %allowed_root.display(),
+            "transcript root does not exist, skipping"
+        );
+        return None;
+    };
+    let Ok(canonical_path) = std::path::Path::new(transcript_path).canonicalize() else {
+        tracing::warn!(
+            path = %transcript_path,
+            "transcript_path could not be canonicalized (missing?), ignoring"
+        );
+        return None;
+    };
+    if !canonical_path.starts_with(&canonical_root) {
         tracing::warn!(
             path = %transcript_path,
             "transcript_path outside allowed directory, ignoring"
@@ -981,12 +1181,13 @@ fn extract_task_name_from_transcript(
     }
 
     let offset = mapped.transcript_offset;
-    match extract_slug(transcript_path, offset) {
+    match integration.extract_task_name(transcript_path, offset) {
         Ok((slug, _new_offset)) => {
-            // Cap task_name to 100 chars
+            // Cap task_name to 100 bytes at a valid UTF-8 boundary (a raw
+            // `s[..100]` panics if byte 100 splits a multibyte char).
             slug.map(|s| {
                 if s.len() > 100 {
-                    s[..100].to_string()
+                    s[..s.floor_char_boundary(100)].to_string()
                 } else {
                     s
                 }
@@ -1016,7 +1217,19 @@ mod tests {
         mpsc::Receiver<AgenticAgentMessage>,
         mpsc::Receiver<AgentMessage>,
     ) {
-        let (agentic_tx, agentic_rx) = mpsc::channel(64);
+        test_state_with_agentic_capacity(64)
+    }
+
+    /// Like [`test_state`] but with a custom agentic-channel capacity so tests
+    /// can force `try_send` to fail (channel-full) deterministically.
+    fn test_state_with_agentic_capacity(
+        cap: usize,
+    ) -> (
+        HooksState,
+        mpsc::Receiver<AgenticAgentMessage>,
+        mpsc::Receiver<AgentMessage>,
+    ) {
+        let (agentic_tx, agentic_rx) = mpsc::channel(cap);
         let (outbound_tx, outbound_rx) = mpsc::channel(64);
         let mapper = SessionMapper::new();
         let state = HooksState {
@@ -1026,6 +1239,7 @@ mod tests {
             mapper,
             outbound_tx,
             sent_cc_session_ids: Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            sent_agent_session_refs: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
         };
         (state, agentic_rx, outbound_rx)
     }
@@ -1071,7 +1285,7 @@ mod tests {
 
         let mut p = payload("PreToolUse", "cc-1");
         p.tool_use_id = Some("toolu_test1".to_string());
-        handle_pre_tool_use(&state, &p).await;
+        handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
 
         let msg = agentic_rx.try_recv().unwrap();
         match msg {
@@ -1095,7 +1309,7 @@ mod tests {
         // No loop registered -- resolve will fail after retries
         let mut p = payload("PreToolUse", "unknown-cc");
         p.tool_use_id = Some("toolu_unknown".to_string());
-        handle_pre_tool_use(&state, &p).await;
+        handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
         assert!(agentic_rx.try_recv().is_err());
     }
 
@@ -1108,7 +1322,7 @@ mod tests {
             let mut p = payload("PreToolUse", "cc-tools");
             p.tool_name = Some(tool.to_string());
             p.tool_use_id = Some(format!("toolu_{tool}"));
-            handle_pre_tool_use(&state, &p).await;
+            handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
 
             // All tool names should produce a Working status
             let msg = agentic_rx.try_recv().unwrap();
@@ -1136,7 +1350,7 @@ mod tests {
 
         let mut p = payload("PostToolUse", "cc-2");
         p.tool_use_id = Some("toolu_post1".to_string());
-        handle_post_tool_use(&state, &p).await;
+        handle_post_tool_use(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         let msg = agentic_rx.try_recv().unwrap();
         match msg {
@@ -1157,7 +1371,7 @@ mod tests {
         let (state, mut agentic_rx, _outbound_rx) = test_state();
         let mut p = payload("PostToolUse", "unknown-cc");
         p.tool_use_id = Some("toolu_unknown".to_string());
-        handle_post_tool_use(&state, &p).await;
+        handle_post_tool_use(&state, &crate::agents::ClaudeIntegration, &p).await;
         assert!(agentic_rx.try_recv().is_err());
     }
 
@@ -1192,7 +1406,7 @@ mod tests {
         let mut p = payload("PostToolUse", cc_id);
         p.transcript_path = Some(transcript_path.clone());
         p.tool_use_id = Some("toolu_slug_test".to_string());
-        handle_post_tool_use(&state, &p).await;
+        handle_post_tool_use(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         let msg = agentic_rx.try_recv().unwrap();
         match msg {
@@ -1217,7 +1431,7 @@ mod tests {
         let (_sid, loop_id) = setup_loop(&state).await;
 
         let p = payload("Stop", "cc-stop");
-        handle_stop(&state, &p).await;
+        handle_stop(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         // First message: SessionExecutionStopped
         let msg1 = agentic_rx.try_recv().unwrap();
@@ -1257,7 +1471,7 @@ mod tests {
     async fn stop_no_loop_mapping_is_noop() {
         let (state, mut agentic_rx, _outbound_rx) = test_state();
         let p = payload("Stop", "unknown-cc");
-        handle_stop(&state, &p).await;
+        handle_stop(&state, &crate::agents::ClaudeIntegration, &p).await;
         assert!(agentic_rx.try_recv().is_err());
     }
 
@@ -1286,7 +1500,7 @@ mod tests {
 
         let mut p = payload("Stop", cc_id);
         p.transcript_path = Some(transcript_path.clone());
-        handle_stop(&state, &p).await;
+        handle_stop(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         // First message: SessionExecutionStopped
         let msg1 = agentic_rx.try_recv().unwrap();
@@ -1431,7 +1645,7 @@ mod tests {
 
         let mut p = payload("UserPromptSubmit", "cc-prompt");
         p.prompt = Some("fix the bug".to_string());
-        handle_user_prompt_submit(&state, &p).await;
+        handle_user_prompt_submit(&state, &crate::agents::ClaudeIntegration, &p, None).await;
 
         let msg = agentic_rx.try_recv().unwrap();
         match msg {
@@ -1451,7 +1665,7 @@ mod tests {
     async fn user_prompt_submit_no_loop_mapping_is_noop() {
         let (state, mut agentic_rx, _outbound_rx) = test_state();
         let p = payload("UserPromptSubmit", "unknown-cc");
-        handle_user_prompt_submit(&state, &p).await;
+        handle_user_prompt_submit(&state, &crate::agents::ClaudeIntegration, &p, None).await;
         assert!(agentic_rx.try_recv().is_err());
     }
 
@@ -1591,6 +1805,326 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
+    // RFC-012: X-ZRemote-Session-Id parsing + AgentSessionRefCaptured
+    // ---------------------------------------------------------------
+
+    fn headers_with_session(value: &str) -> axum::http::HeaderMap {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            "x-zremote-session-id",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn parse_zremote_session_header_valid_uuid() {
+        let id = Uuid::new_v4();
+        let headers = headers_with_session(&id.to_string());
+        assert_eq!(parse_zremote_session_header(&headers), Some(id));
+    }
+
+    #[test]
+    fn parse_zremote_session_header_trims_whitespace() {
+        let id = Uuid::new_v4();
+        let headers = headers_with_session(&format!("  {id}  "));
+        assert_eq!(parse_zremote_session_header(&headers), Some(id));
+    }
+
+    #[test]
+    fn parse_zremote_session_header_absent_is_none() {
+        let headers = axum::http::HeaderMap::new();
+        assert_eq!(parse_zremote_session_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_zremote_session_header_empty_is_none() {
+        let headers = headers_with_session("");
+        assert_eq!(parse_zremote_session_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_zremote_session_header_invalid_uuid_is_none() {
+        let headers = headers_with_session("not-a-uuid");
+        assert_eq!(parse_zremote_session_header(&headers), None);
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_emits_for_non_claude_task_session() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        // Deliberately register NO claude task: the generic capture path must not
+        // depend on get_claude_task_id (unlike try_capture_cc_session_id).
+        let zremote_id = Uuid::new_v4();
+
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-native-123")
+            .await;
+
+        let msg = agentic_rx.try_recv().unwrap();
+        match msg {
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } => {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(agent, AgentKind::Claude);
+                assert_eq!(native_session_id, "cc-native-123");
+            }
+            other => panic!("expected AgentSessionRefCaptured, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_no_header_is_noop() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        try_capture_agent_session_ref(&state, AgentKind::Claude, None, "cc-native").await;
+        assert!(
+            agentic_rx.try_recv().is_err(),
+            "missing header must produce no capture message"
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_empty_native_id_is_noop() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(Uuid::new_v4()), "").await;
+        assert!(agentic_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_deduplicates() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let zremote_id = Uuid::new_v4();
+
+        // First call emits.
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-dedup")
+            .await;
+        assert!(agentic_rx.try_recv().is_ok());
+
+        // Same (session, agent, native) tuple is a no-op.
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-dedup")
+            .await;
+        assert!(agentic_rx.try_recv().is_err());
+
+        // A DIFFERENT native id for the same session still emits.
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-other")
+            .await;
+        assert!(agentic_rx.try_recv().is_ok());
+
+        // A DIFFERENT zremote session id also emits.
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(Uuid::new_v4()), "cc-dedup")
+            .await;
+        assert!(agentic_rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_rolls_back_dedup_on_send_failure() {
+        // If try_send fails (channel full), the dedup key must be rolled back so
+        // a later attempt re-captures — otherwise resume is permanently broken
+        // for that session.
+        let (state, mut agentic_rx, _outbound_rx) = test_state_with_agentic_capacity(1);
+        let zremote_id = Uuid::new_v4();
+
+        // Fill the size-1 channel so the capture's try_send will fail.
+        state
+            .agentic_tx
+            .try_send(AgenticAgentMessage::SessionExecutionStopped {
+                session_id: Uuid::new_v4(),
+            })
+            .unwrap();
+
+        // Capture attempt: send fails, key must be rolled back.
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-retry")
+            .await;
+        assert!(
+            state.sent_agent_session_refs.lock().await.is_empty(),
+            "dedup key must be removed after a failed send"
+        );
+
+        // Drain the channel, then retry: capture must now succeed (not deduped).
+        let _ = agentic_rx.try_recv();
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(zremote_id), "cc-retry")
+            .await;
+        match agentic_rx.try_recv() {
+            Ok(AgenticAgentMessage::AgentSessionRefCaptured {
+                native_session_id, ..
+            }) => assert_eq!(native_session_id, "cc-retry"),
+            other => panic!("expected re-captured AgentSessionRefCaptured, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_rejects_overlong_native_id() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let oversized = "x".repeat(257); // > MAX_NATIVE_ID_LEN (256)
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(Uuid::new_v4()), &oversized)
+            .await;
+        assert!(
+            agentic_rx.try_recv().is_err(),
+            "native_session_id > 256 bytes must be rejected"
+        );
+        assert!(
+            state.sent_agent_session_refs.lock().await.is_empty(),
+            "oversized id must not enter the dedup set"
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_agent_session_ref_accepts_max_length_native_id() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let at_max = "y".repeat(256); // exactly MAX_NATIVE_ID_LEN
+        try_capture_agent_session_ref(&state, AgentKind::Claude, Some(Uuid::new_v4()), &at_max)
+            .await;
+        assert!(
+            agentic_rx.try_recv().is_ok(),
+            "native_session_id of exactly 256 bytes must be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_captures_agent_session_ref_via_header() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let (_sid, _loop_id) = setup_loop(&state).await;
+        let zremote_id = Uuid::new_v4();
+
+        let mut p = payload("PreToolUse", "cc-native-abc");
+        p.tool_use_id = Some("toolu_x".to_string());
+        handle_pre_tool_use(
+            &state,
+            &crate::agents::ClaudeIntegration,
+            &p,
+            Some(zremote_id),
+        )
+        .await;
+
+        // Drain messages; one of them must be AgentSessionRefCaptured with the
+        // header session id and the payload's session_id as the native id.
+        let mut found = false;
+        while let Ok(msg) = agentic_rx.try_recv() {
+            if let AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } = msg
+            {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(agent, AgentKind::Claude);
+                assert_eq!(native_session_id, "cc-native-abc");
+                found = true;
+            }
+        }
+        assert!(
+            found,
+            "PreToolUse with a valid header must emit AgentSessionRefCaptured"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_captures_agent_session_ref_via_header() {
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let (_sid, _loop_id) = setup_loop(&state).await;
+        let zremote_id = Uuid::new_v4();
+
+        let p = payload("UserPromptSubmit", "cc-prompt-native");
+        handle_user_prompt_submit(
+            &state,
+            &crate::agents::ClaudeIntegration,
+            &p,
+            Some(zremote_id),
+        )
+        .await;
+
+        let mut found = false;
+        while let Ok(msg) = agentic_rx.try_recv() {
+            if let AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                native_session_id,
+                ..
+            } = msg
+            {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(native_session_id, "cc-prompt-native");
+                found = true;
+            }
+        }
+        assert!(found, "UserPromptSubmit with a valid header must capture");
+    }
+
+    // ---------------------------------------------------------------
+    // RFC-012 P4b: X-ZRemote-Agent routing -> integration selection
+    // ---------------------------------------------------------------
+
+    fn headers_with_agent(agent: &str) -> axum::http::HeaderMap {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            "x-zremote-agent",
+            axum::http::HeaderValue::from_str(agent).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn select_integration_codex_header() {
+        let h = headers_with_agent("codex");
+        assert_eq!(select_integration(&h).agent_kind(), AgentKind::Codex);
+    }
+
+    #[test]
+    fn select_integration_claude_header() {
+        let h = headers_with_agent("claude");
+        assert_eq!(select_integration(&h).agent_kind(), AgentKind::Claude);
+    }
+
+    #[test]
+    fn select_integration_absent_header_defaults_claude() {
+        let h = axum::http::HeaderMap::new();
+        assert_eq!(select_integration(&h).agent_kind(), AgentKind::Claude);
+    }
+
+    #[test]
+    fn select_integration_unknown_header_defaults_claude() {
+        let h = headers_with_agent("gemini");
+        assert_eq!(select_integration(&h).agent_kind(), AgentKind::Claude);
+    }
+
+    #[tokio::test]
+    async fn capture_via_codex_integration_uses_codex_agent_kind() {
+        // Routing a hook through CodexIntegration must capture AgentKind::Codex.
+        let (state, mut agentic_rx, _outbound_rx) = test_state();
+        let (_sid, _loop_id) = setup_loop(&state).await;
+        let zremote_id = Uuid::new_v4();
+
+        let mut p = payload("PreToolUse", "codex-native-xyz");
+        p.tool_use_id = Some("toolu_codex".to_string());
+        handle_pre_tool_use(
+            &state,
+            &crate::agents::CodexIntegration,
+            &p,
+            Some(zremote_id),
+        )
+        .await;
+
+        let mut found = false;
+        while let Ok(msg) = agentic_rx.try_recv() {
+            if let AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } = msg
+            {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(agent, AgentKind::Codex);
+                assert_eq!(native_session_id, "codex-native-xyz");
+                found = true;
+            }
+        }
+        assert!(
+            found,
+            "codex-routed PreToolUse must capture AgentKind::Codex"
+        );
+    }
+
+    // ---------------------------------------------------------------
     // extract_task_name_from_transcript
     // ---------------------------------------------------------------
 
@@ -1603,7 +2137,8 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         assert!(result.is_none());
     }
 
@@ -1626,7 +2161,8 @@ mod tests {
             transcript_path: Some(transcript_path),
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         assert_eq!(result.as_deref(), Some("fallback-slug"));
 
         std::fs::remove_dir_all(&transcript_dir).ok();
@@ -1654,7 +2190,8 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         assert_eq!(result.as_ref().map(|s| s.len()), Some(100));
 
         std::fs::remove_dir_all(&transcript_dir).ok();
@@ -1678,9 +2215,87 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         // Path traversal validation should reject this
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_task_name_rejects_dotdot_traversal_under_prefix() {
+        // A path that textually starts with the allowed prefix but escapes it via
+        // `..` must be rejected (the old str::starts_with guard was bypassable;
+        // the canonicalize + Path::starts_with guard is not).
+        let home = std::env::var("HOME").unwrap();
+        // Put a real file OUTSIDE the projects dir, then reference it through a
+        // `..`-laden path that begins with the allowed prefix string.
+        let outside_dir = format!("{home}/.claude/_test_handler_escape");
+        std::fs::create_dir_all(&outside_dir).ok();
+        let outside_file = format!("{outside_dir}/secret.jsonl");
+        std::fs::write(
+            &outside_file,
+            "{\"type\":\"result\",\"slug\":\"escaped\"}\n",
+        )
+        .unwrap();
+
+        // `~/.claude/projects/../_test_handler_escape/secret.jsonl` — starts with
+        // the allowed prefix as a raw string, but resolves outside it.
+        let traversal = format!("{home}/.claude/projects/../_test_handler_escape/secret.jsonl");
+        let mut p = payload("PostToolUse", "cc-1");
+        p.transcript_path = Some(traversal);
+        let mapped = super::super::mapper::MappedSession {
+            loop_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            transcript_path: None,
+            transcript_offset: 0,
+        };
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
+        assert!(
+            result.is_none(),
+            "`..` traversal escaping the transcript root must be rejected"
+        );
+
+        std::fs::remove_dir_all(&outside_dir).ok();
+    }
+
+    #[test]
+    fn extract_task_name_truncates_multibyte_slug_at_char_boundary() {
+        // A slug whose byte 100 falls inside a multibyte char must NOT panic
+        // (the old `s[..100]` did). Build a slug where a 3-byte char straddles
+        // byte 100: 99 ASCII bytes + a multibyte char.
+        let home = std::env::var("HOME").unwrap();
+        let transcript_dir = format!("{home}/.claude/projects/_test_handler_mb");
+        std::fs::create_dir_all(&transcript_dir).ok();
+        let transcript_path = format!("{transcript_dir}/transcript.jsonl");
+
+        let mut slug = "a".repeat(99); // bytes 0..99
+        slug.push('€'); // 3-byte char occupying bytes 99..102 (straddles 100)
+        slug.push_str(&"b".repeat(20)); // ensure len > 100
+        std::fs::write(
+            &transcript_path,
+            format!("{{\"type\":\"result\",\"slug\":\"{slug}\"}}\n"),
+        )
+        .unwrap();
+
+        let mut p = payload("PostToolUse", "cc-1");
+        p.transcript_path = Some(transcript_path);
+        let mapped = super::super::mapper::MappedSession {
+            loop_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            transcript_path: None,
+            transcript_offset: 0,
+        };
+        // Must not panic; result is capped to a valid char boundary <= 100 bytes.
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped)
+                .expect("slug should be extracted");
+        assert!(result.len() <= 100, "capped length must be <= 100 bytes");
+        // The '€' at byte 99 does not fit fully within 100 bytes, so the cap lands
+        // at byte 99 (the 99 'a's), never splitting the multibyte char.
+        assert_eq!(result, "a".repeat(99));
+
+        std::fs::remove_dir_all(&transcript_dir).ok();
     }
 
     #[test]
@@ -1697,7 +2312,8 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         assert!(result.is_none());
     }
 
@@ -1717,7 +2333,8 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         // Empty string slug is still returned (extract_slug returns it)
         assert_eq!(result.as_deref(), Some(""));
 
@@ -1744,7 +2361,8 @@ mod tests {
             transcript_path: None,
             transcript_offset: 0,
         };
-        let result = extract_task_name_from_transcript(&p, &mapped);
+        let result =
+            extract_task_name_from_transcript(&crate::agents::ClaudeIntegration, &p, &mapped);
         assert!(result.is_none());
 
         std::fs::remove_dir_all(&transcript_dir).ok();
@@ -2190,7 +2808,7 @@ mod tests {
         p.tool_name = Some("Bash".to_string());
         p.tool_use_id = Some("toolu_both".to_string());
         p.tool_input = Some(serde_json::json!({"command": "ls"}));
-        handle_pre_tool_use(&state, &p).await;
+        handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
 
         let msg1 = agentic_rx.try_recv().unwrap();
         match &msg1 {
@@ -2233,7 +2851,7 @@ mod tests {
         p.tool_name = Some("Bash".to_string());
         p.tool_use_id = Some("toolu_closed_test".to_string());
         p.tool_response = Some(serde_json::Value::String("output".to_string()));
-        handle_post_tool_use(&state, &p).await;
+        handle_post_tool_use(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         // First: LoopStateUpdate
         let _loop_msg = agentic_rx.try_recv().unwrap();
@@ -2264,7 +2882,7 @@ mod tests {
         let (sid, _loop_id) = setup_loop(&state).await;
 
         let p = payload("Stop", "cc-sesstopped");
-        handle_stop(&state, &p).await;
+        handle_stop(&state, &crate::agents::ClaudeIntegration, &p).await;
 
         let msg = agentic_rx.try_recv().unwrap();
         match msg {
@@ -2282,7 +2900,7 @@ mod tests {
         // No loop registered at all
         let mut p = payload("PreToolUse", "totally-unknown-session");
         p.tool_use_id = Some("toolu_unknown".to_string());
-        handle_pre_tool_use(&state, &p).await;
+        handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
         assert!(
             agentic_rx.try_recv().is_err(),
             "should produce no messages for unknown session"
@@ -2296,7 +2914,7 @@ mod tests {
         let _ = setup_loop(&state).await;
         // tool_use_id is None (default payload)
         let p = payload("PreToolUse", "cc-noid");
-        handle_pre_tool_use(&state, &p).await;
+        handle_pre_tool_use(&state, &crate::agents::ClaudeIntegration, &p, None).await;
         assert!(
             agentic_rx.try_recv().is_err(),
             "missing tool_use_id should produce no messages"

--- a/crates/zremote-agent/src/hooks/installer.rs
+++ b/crates/zremote-agent/src/hooks/installer.rs
@@ -1,5 +1,17 @@
 use std::path::Path;
 
+/// Version stamp for the generated hook script body.
+///
+/// Bump this whenever [`generate_hook_script`] changes. The installer embeds it
+/// as a `# ZREMOTE_HOOK_VERSION=<n>` comment in the script and
+/// [`is_already_installed`] treats a script missing the current version as
+/// out-of-date, forcing a re-install. Without this, idempotency was path-only:
+/// an existing (older) script would never be regenerated.
+const ZREMOTE_HOOK_VERSION: u32 = 2;
+
+/// Marker line embedded in the generated script for version detection.
+const HOOK_VERSION_MARKER_PREFIX: &str = "# ZREMOTE_HOOK_VERSION=";
+
 struct HookConfig {
     event: &'static str,
     matcher: &'static str,
@@ -51,8 +63,10 @@ async fn is_already_installed(home: &Path, script_path: &Path) -> bool {
         return false;
     }
 
-    // Check hook script exists
-    if !script_path.exists() {
+    // Check hook script exists AND is the current version. An older script body
+    // (missing the current `# ZREMOTE_HOOK_VERSION=<n>` marker) must trigger a
+    // re-install so script changes (e.g. new forwarded headers) actually land.
+    if !installed_script_is_current(script_path).await {
         return false;
     }
 
@@ -102,6 +116,18 @@ async fn is_already_installed(home: &Path, script_path: &Path) -> bool {
     true
 }
 
+/// Return `true` if the installed hook script exists and carries the current
+/// [`ZREMOTE_HOOK_VERSION`] marker. A missing file or an older/absent version
+/// marker returns `false`, signalling the installer to regenerate the script.
+async fn installed_script_is_current(script_path: &Path) -> bool {
+    let Ok(content) = tokio::fs::read_to_string(script_path).await else {
+        return false;
+    };
+    let expected = format!("{HOOK_VERSION_MARKER_PREFIX}{ZREMOTE_HOOK_VERSION}");
+    // Match the exact version line (so version 1 does not satisfy a check for 10).
+    content.lines().any(|line| line.trim() == expected)
+}
+
 /// Install hooks at a specific home directory path (testable).
 async fn install_hooks_at(home: &Path) -> Result<(), InstallError> {
     let script_path = home.join(".zremote").join("hooks").join("zremote-hook.sh");
@@ -139,37 +165,201 @@ async fn install_hooks_at(home: &Path) -> Result<(), InstallError> {
     // Update Claude Code settings
     update_claude_settings(home, &script_path).await?;
 
+    // Best-effort: also install the Codex forwarder. Codex may not be present;
+    // a failure here must NOT block the (succeeded) Claude install, so we log
+    // and continue rather than propagate.
+    if let Err(e) = install_codex_hooks_at(home).await {
+        tracing::debug!(error = %e, "codex hook install skipped/failed (non-fatal)");
+    }
+
     Ok(())
 }
 
+/// Resolve an agent's config directory, honoring its env override
+/// ([`AgentIntegration::config_dir_env`], e.g. `CODEX_HOME`/`CLAUDE_CONFIG_DIR`).
+/// When the override is set and non-empty it is used verbatim; otherwise
+/// `<home>/<config_dir>`.
+fn agent_config_dir(
+    home: &Path,
+    integration: &dyn crate::agents::AgentIntegration,
+) -> std::path::PathBuf {
+    if let Some(var) = integration.config_dir_env()
+        && let Ok(dir) = std::env::var(var)
+        && !dir.trim().is_empty()
+    {
+        return std::path::PathBuf::from(dir);
+    }
+    home.join(integration.config_dir())
+}
+
+/// Install the Codex forwarder hook into `<codex_home>/hooks.json`.
+///
+/// Writes the codex hook script (`~/.zremote/hooks/zremote-codex-hook.sh`,
+/// sending `X-ZRemote-Agent: codex`) and registers it for each event in
+/// [`crate::agents::CodexIntegration::hook_events`] inside `hooks.json`, merging
+/// with (and preserving) any existing user hooks. Default is a *normal* codex
+/// hook requiring one-time interactive trust (`/hooks` in the codex CLI); the
+/// managed `requirements.toml` zero-prompt path is intentionally left to an
+/// explicit opt-in and is not written here.
+async fn install_codex_hooks_at(home: &Path) -> Result<(), InstallError> {
+    use crate::agents::{AgentIntegration, CodexIntegration};
+
+    let integration = CodexIntegration;
+    let config_dir = agent_config_dir(home, &integration);
+
+    // Write the codex hook script (shared transport, codex agent header).
+    let script_path = home
+        .join(".zremote")
+        .join("hooks")
+        .join("zremote-codex-hook.sh");
+    let hooks_dir = home.join(".zremote").join("hooks");
+    tokio::fs::create_dir_all(&hooks_dir)
+        .await
+        .map_err(InstallError::Io)?;
+    tokio::fs::write(&script_path, generate_hook_script_for("codex"))
+        .await
+        .map_err(InstallError::Io)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .await
+            .map_err(InstallError::Io)?;
+    }
+
+    let hooks_json_path = config_dir.join("hooks.json");
+    let mut root: serde_json::Value = if hooks_json_path.exists() {
+        let content = tokio::fs::read_to_string(&hooks_json_path)
+            .await
+            .map_err(InstallError::Io)?;
+        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        tokio::fs::create_dir_all(&config_dir)
+            .await
+            .map_err(InstallError::Io)?;
+        serde_json::json!({})
+    };
+
+    let script = script_path.to_string_lossy().to_string();
+    merge_hook_events(&mut root, &script, integration.hook_events())?;
+
+    // Write atomically (tmp + rename) so codex never reads a half-written file.
+    let formatted =
+        serde_json::to_string_pretty(&root).map_err(|_| InstallError::InvalidSettings)?;
+    let tmp_path = hooks_json_path.with_extension("json.tmp");
+    tokio::fs::write(&tmp_path, &formatted)
+        .await
+        .map_err(InstallError::Io)?;
+    if let Err(e) = tokio::fs::rename(&tmp_path, &hooks_json_path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(InstallError::Io(e));
+    }
+
+    tracing::info!(path = %hooks_json_path.display(), "Codex hooks.json updated with zremote hooks");
+    Ok(())
+}
+
+/// Merge zremote hook entries for `events` into a codex/claude-shaped
+/// `{"hooks": {"<Event>": [...]}}` JSON object, preserving any existing user
+/// entries and not duplicating an already-present zremote entry (matched by the
+/// command string containing the script path).
+fn merge_hook_events(
+    root: &mut serde_json::Value,
+    script: &str,
+    events: &[crate::agents::HookEventSpec],
+) -> Result<(), InstallError> {
+    let hooks = root
+        .as_object_mut()
+        .ok_or(InstallError::InvalidSettings)?
+        .entry("hooks")
+        .or_insert(serde_json::json!({}));
+    let hooks_obj = hooks.as_object_mut().ok_or(InstallError::InvalidSettings)?;
+
+    for spec in events {
+        let event_hooks = hooks_obj.entry(spec.event).or_insert(serde_json::json!([]));
+        let Some(arr) = event_hooks.as_array_mut() else {
+            continue;
+        };
+        // Dedup against the ACTUAL script path we're about to install, not a
+        // hardcoded substring — otherwise a renamed/relocated script would slip
+        // past the check and silently double-insert on every install.
+        let already = arr.iter().any(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_some_and(|hs| {
+                    hs.iter().any(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|c| c == script)
+                    })
+                })
+        });
+        if already {
+            continue;
+        }
+        let mut entry = serde_json::json!({
+            "matcher": spec.matcher,
+            "hooks": [{ "type": "command", "command": script }]
+        });
+        if spec.async_hook {
+            entry["hooks"][0]["async"] = serde_json::json!(true);
+        }
+        arr.push(entry);
+    }
+    Ok(())
+}
+
+/// Claude's hook script (the default `agent_kind` is `claude`).
 fn generate_hook_script() -> String {
-    r#"#!/bin/sh
-# ZRemote hook script - forwards Claude Code hook events to the agent sidecar.
+    generate_hook_script_for("claude")
+}
+
+/// Generate the forwarder script for a given `agent_kind` (`"claude"` /
+/// `"codex"`). Both agents share the same transport: read the sidecar port,
+/// POST the hook JSON, forward `X-ZRemote-Session-Id` (from `$ZREMOTE_SESSION_ID`)
+/// and a fixed `X-ZRemote-Agent` header so the handler can pick the right
+/// `AgentIntegration`. The `CLAUDE_ENV_FILE` header is harmless for codex (the
+/// env var is simply never set there).
+///
+/// `agent_kind` is a fixed, trusted `&'static str` from the integration — never
+/// user input — and is embedded as the header value directly.
+fn generate_hook_script_for(agent_kind: &str) -> String {
+    // The leading `# ZREMOTE_HOOK_VERSION=<n>` comment lets `is_already_installed`
+    // detect an out-of-date script body and force a re-install (see the const docs).
+    // Optional headers are accumulated into the positional parameter list with
+    // `set --` so the native session id (and env-file path) are passed as separate
+    // argv elements to curl — never interpolated into the URL or body.
+    format!(
+        r#"#!/bin/sh
+{HOOK_VERSION_MARKER_PREFIX}{ZREMOTE_HOOK_VERSION}
+# ZRemote hook script - forwards {agent_kind} hook events to the agent sidecar.
 # Managed by zremote-agent. Do not edit manually.
 PORT=$(cat ~/.zremote/hooks-port 2>/dev/null) || exit 0
 INPUT=$(cat -)
 # Whitelist valid endpoints to prevent command injection via $1
-case "${1:-hooks}" in
-  hooks|hooks/notification/idle|hooks/notification/permission) ENDPOINT="${1:-hooks}" ;;
+case "${{1:-hooks}}" in
+  hooks|hooks/notification/idle|hooks/notification/permission) ENDPOINT="${{1:-hooks}}" ;;
   *) exit 1 ;;
 esac
+# Build optional headers as positional args (each value stays a separate argv element).
+set -- -s --max-time 60 -X POST "http://127.0.0.1:$PORT/$ENDPOINT" -H "Content-Type: application/json" -H "X-ZRemote-Agent: {agent_kind}"
 # Forward CLAUDE_ENV_FILE path (set by CC for SessionStart/CwdChanged/FileChanged)
 if [ -n "$CLAUDE_ENV_FILE" ]; then
-  RESPONSE=$(curl -s --max-time 60 -X POST "http://127.0.0.1:$PORT/$ENDPOINT" \
-    -H "Content-Type: application/json" \
-    -H "X-Claude-Env-File: $CLAUDE_ENV_FILE" \
-    -d "$INPUT" 2>/dev/null)
-else
-  RESPONSE=$(curl -s --max-time 60 -X POST "http://127.0.0.1:$PORT/$ENDPOINT" \
-    -H "Content-Type: application/json" \
-    -d "$INPUT" 2>/dev/null)
+  set -- "$@" -H "X-Claude-Env-File: $CLAUDE_ENV_FILE"
 fi
+# Forward the ZRemote session id so the agent can deterministically correlate
+# this hook event with the originating PTY session (RFC-012 capture path).
+if [ -n "$ZREMOTE_SESSION_ID" ]; then
+  set -- "$@" -H "X-ZRemote-Session-Id: $ZREMOTE_SESSION_ID"
+fi
+RESPONSE=$(curl "$@" -d "$INPUT" 2>/dev/null)
 if [ -n "$RESPONSE" ]; then
   echo "$RESPONSE"
 fi
 exit 0
 "#
-    .to_string()
+    )
 }
 
 async fn update_claude_settings(home: &Path, script_path: &Path) -> Result<(), InstallError> {
@@ -884,6 +1074,118 @@ mod tests {
         assert!(script.contains("exit 1"));
     }
 
+    #[test]
+    fn hook_script_embeds_current_version_marker() {
+        let script = generate_hook_script();
+        let expected = format!("{HOOK_VERSION_MARKER_PREFIX}{ZREMOTE_HOOK_VERSION}");
+        assert!(
+            script.lines().any(|l| l.trim() == expected),
+            "script must embed the current version marker line: {expected}"
+        );
+    }
+
+    #[test]
+    fn hook_script_forwards_zremote_session_id_header() {
+        let script = generate_hook_script();
+        // The session id is forwarded only when the env var is set, as a header
+        // whose value is the env var (kept a separate argv element, never in URL).
+        assert!(
+            script.contains(r#"if [ -n "$ZREMOTE_SESSION_ID" ]; then"#),
+            "script must gate the session-id header on the env var being set"
+        );
+        assert!(
+            script.contains(r#"-H "X-ZRemote-Session-Id: $ZREMOTE_SESSION_ID""#),
+            "script must forward the X-ZRemote-Session-Id header"
+        );
+    }
+
+    #[test]
+    fn claude_script_sends_claude_agent_header() {
+        let script = generate_hook_script();
+        assert!(
+            script.contains(r#"-H "X-ZRemote-Agent: claude""#),
+            "claude script must send the claude agent header"
+        );
+    }
+
+    #[test]
+    fn codex_script_sends_codex_agent_header() {
+        let script = generate_hook_script_for("codex");
+        assert!(
+            script.contains(r#"-H "X-ZRemote-Agent: codex""#),
+            "codex script must send the codex agent header"
+        );
+        // Shared transport: still forwards the session id and is version-stamped.
+        assert!(script.contains(r#"-H "X-ZRemote-Session-Id: $ZREMOTE_SESSION_ID""#));
+        let expected = format!("{HOOK_VERSION_MARKER_PREFIX}{ZREMOTE_HOOK_VERSION}");
+        assert!(script.lines().any(|l| l.trim() == expected));
+    }
+
+    #[test]
+    fn hook_script_still_forwards_env_file_header() {
+        // Regression: the CLAUDE_ENV_FILE forwarding must survive the rewrite.
+        let script = generate_hook_script();
+        assert!(script.contains(r#"if [ -n "$CLAUDE_ENV_FILE" ]; then"#));
+        assert!(script.contains(r#"-H "X-Claude-Env-File: $CLAUDE_ENV_FILE""#));
+    }
+
+    #[tokio::test]
+    async fn installed_script_is_current_detects_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = dir.path().join("zremote-hook.sh");
+
+        // Current script -> current
+        tokio::fs::write(&script_path, generate_hook_script())
+            .await
+            .unwrap();
+        assert!(installed_script_is_current(&script_path).await);
+
+        // Missing file -> not current
+        let missing = dir.path().join("does-not-exist.sh");
+        assert!(!installed_script_is_current(&missing).await);
+
+        // Old version marker -> not current
+        let old = "#!/bin/sh\n# ZREMOTE_HOOK_VERSION=0\necho hi\n";
+        tokio::fs::write(&script_path, old).await.unwrap();
+        assert!(!installed_script_is_current(&script_path).await);
+
+        // No marker at all -> not current
+        let no_marker = "#!/bin/sh\necho hi\n";
+        tokio::fs::write(&script_path, no_marker).await.unwrap();
+        assert!(!installed_script_is_current(&script_path).await);
+    }
+
+    #[tokio::test]
+    async fn install_reinstalls_when_script_version_is_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+
+        // Full install first (writes current-version script + settings).
+        install_hooks_at(home).await.unwrap();
+        let script_path = home.join(".zremote/hooks/zremote-hook.sh");
+        assert!(installed_script_is_current(&script_path).await);
+
+        // Simulate an older agent's script body: valid settings, but stale script.
+        let stale =
+            "#!/bin/sh\n# ZREMOTE_HOOK_VERSION=0\n# old body without session-id header\nexit 0\n";
+        tokio::fs::write(&script_path, stale).await.unwrap();
+
+        // is_already_installed must now report false due to the stale version...
+        assert!(
+            !is_already_installed(home, &script_path).await,
+            "stale script version should force a reinstall"
+        );
+
+        // ...and reinstalling regenerates the current script with the new header.
+        install_hooks_at(home).await.unwrap();
+        let content = tokio::fs::read_to_string(&script_path).await.unwrap();
+        assert!(installed_script_is_current(&script_path).await);
+        assert!(
+            content.contains("X-ZRemote-Session-Id"),
+            "regenerated script must include the session-id header"
+        );
+    }
+
     #[tokio::test]
     async fn install_creates_script_and_settings() {
         let dir = tempfile::tempdir().unwrap();
@@ -1322,6 +1624,152 @@ mod tests {
                     .any(|h| h["command"].as_str().unwrap().contains("myremote-hook"))
             }),
             "myremote hooks should be removed from Stop"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // RFC-012 P4b: Codex install
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn claude_integration_events_match_installer_config() {
+        // Guard against drift between the installer's claude hook_configs and the
+        // ClaudeIntegration trait's declared event set. The installer registers
+        // Notification twice (idle + permission) with the same event name, so we
+        // compare the *deduped, sorted* event-name sets.
+        use crate::agents::{AgentIntegration, ClaudeIntegration};
+        use std::collections::BTreeSet;
+
+        let installer_events: BTreeSet<&str> = [
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+            "Notification",
+            "Elicitation",
+            "UserPromptSubmit",
+            "SessionStart",
+            "SubagentStart",
+            "SubagentStop",
+            "StopFailure",
+            "FileChanged",
+            "CwdChanged",
+        ]
+        .into_iter()
+        .collect();
+
+        let trait_events: BTreeSet<&str> = ClaudeIntegration
+            .hook_events()
+            .iter()
+            .map(|e| e.event)
+            .collect();
+
+        assert_eq!(
+            trait_events, installer_events,
+            "ClaudeIntegration::hook_events drifted from the installer's claude config"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_codex_writes_script_and_hooks_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+
+        install_codex_hooks_at(home).await.unwrap();
+
+        // Codex hook script written + executable.
+        let script = home.join(".zremote/hooks/zremote-codex-hook.sh");
+        assert!(script.exists(), "codex hook script must be written");
+        let body = tokio::fs::read_to_string(&script).await.unwrap();
+        assert!(body.contains(r#"-H "X-ZRemote-Agent: codex""#));
+
+        // hooks.json written under ~/.codex with the codex event set.
+        let hooks_json = home.join(".codex/hooks.json");
+        assert!(hooks_json.exists(), "codex hooks.json must be written");
+        let content = tokio::fs::read_to_string(&hooks_json).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let hooks = value["hooks"].as_object().expect("hooks object");
+
+        use crate::agents::{AgentIntegration, CodexIntegration};
+        for spec in CodexIntegration.hook_events() {
+            let arr = hooks
+                .get(spec.event)
+                .and_then(|e| e.as_array())
+                .unwrap_or_else(|| panic!("missing codex event {}", spec.event));
+            assert!(
+                arr.iter().any(|entry| {
+                    entry["hooks"].as_array().is_some_and(|hs| {
+                        hs.iter().any(|h| {
+                            h["command"]
+                                .as_str()
+                                .is_some_and(|c| c.contains("zremote-codex-hook"))
+                        })
+                    })
+                }),
+                "codex event {} must reference the codex hook script",
+                spec.event
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn install_codex_is_idempotent_and_preserves_user_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+
+        // Pre-seed a user hook in ~/.codex/hooks.json.
+        let codex_dir = home.join(".codex");
+        tokio::fs::create_dir_all(&codex_dir).await.unwrap();
+        let existing = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/user-codex-hook.sh"}]}
+                ]
+            }
+        });
+        tokio::fs::write(
+            codex_dir.join("hooks.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Install twice.
+        install_codex_hooks_at(home).await.unwrap();
+        install_codex_hooks_at(home).await.unwrap();
+
+        let content = tokio::fs::read_to_string(codex_dir.join("hooks.json"))
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let pre_tool = value["hooks"]["PreToolUse"].as_array().unwrap();
+
+        // User hook preserved.
+        assert!(
+            pre_tool
+                .iter()
+                .any(|e| e["hooks"].as_array().unwrap().iter().any(|h| {
+                    h["command"]
+                        .as_str()
+                        .unwrap()
+                        .contains("user-codex-hook.sh")
+                })),
+            "user codex hook must be preserved"
+        );
+        // Exactly one zremote codex entry (no duplication on re-install).
+        let zremote_entries = pre_tool
+            .iter()
+            .filter(|e| {
+                e["hooks"].as_array().unwrap().iter().any(|h| {
+                    h["command"]
+                        .as_str()
+                        .unwrap()
+                        .contains("zremote-codex-hook")
+                })
+            })
+            .count();
+        assert_eq!(
+            zremote_entries, 1,
+            "re-install must not duplicate the zremote codex hook"
         );
     }
 }

--- a/crates/zremote-agent/src/hooks/server.rs
+++ b/crates/zremote-agent/src/hooks/server.rs
@@ -38,6 +38,13 @@ impl HooksServer {
                 mapper,
                 outbound_tx,
                 sent_cc_session_ids,
+                // Dedup set for the RFC-012 generic capture path. Owned by the
+                // server (not threaded through callers): the legacy
+                // `sent_cc_session_ids` set stays the per-connection dedup for
+                // `SessionIdCaptured`.
+                sent_agent_session_refs: Arc::new(tokio::sync::Mutex::new(
+                    std::collections::HashSet::new(),
+                )),
             },
         }
     }
@@ -194,6 +201,149 @@ mod tests {
         }
 
         // Shutdown
+        shutdown_tx.send(true).unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_captures_agent_session_ref_from_header() {
+        // RFC-012 end-to-end: a SessionStart hook carrying X-ZRemote-Session-Id
+        // emits AgentSessionRefCaptured on the agentic channel, keyed by the
+        // header session id, with the payload session_id as the native id —
+        // even with NO loop/claude-task registered.
+        let (agentic_tx, mut agentic_rx) = mpsc::channel(64);
+        let (outbound_tx, _outbound_rx) = mpsc::channel(64);
+        let mapper = SessionMapper::new();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        let server = HooksServer::new(
+            agentic_tx,
+            mapper,
+            outbound_tx,
+            Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            Arc::new(tokio::sync::Mutex::new(DeliveryCoordinator::new())),
+        );
+        let addr = server.start(shutdown_rx).await.unwrap();
+
+        let zremote_id = Uuid::new_v4();
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("http://{addr}/hooks"))
+            .header("X-ZRemote-Session-Id", zremote_id.to_string())
+            .json(&serde_json::json!({
+                "session_id": "claude-native-xyz",
+                "hook_event_name": "SessionStart",
+                "source": "startup"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let msg = agentic_rx.try_recv().expect("capture message expected");
+        match msg {
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } => {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(agent, zremote_protocol::AgentKind::Claude);
+                assert_eq!(native_session_id, "claude-native-xyz");
+            }
+            other => panic!("expected AgentSessionRefCaptured, got {other:?}"),
+        }
+
+        shutdown_tx.send(true).unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_routes_codex_agent_header_to_codex_capture() {
+        // RFC-012 P4b end-to-end: X-ZRemote-Agent: codex routes capture to
+        // AgentKind::Codex on the shared /hooks endpoint.
+        let (agentic_tx, mut agentic_rx) = mpsc::channel(64);
+        let (outbound_tx, _outbound_rx) = mpsc::channel(64);
+        let mapper = SessionMapper::new();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        let server = HooksServer::new(
+            agentic_tx,
+            mapper,
+            outbound_tx,
+            Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            Arc::new(tokio::sync::Mutex::new(DeliveryCoordinator::new())),
+        );
+        let addr = server.start(shutdown_rx).await.unwrap();
+
+        let zremote_id = Uuid::new_v4();
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("http://{addr}/hooks"))
+            .header("X-ZRemote-Session-Id", zremote_id.to_string())
+            .header("X-ZRemote-Agent", "codex")
+            .json(&serde_json::json!({
+                "session_id": "codex-native-001",
+                "hook_event_name": "SessionStart",
+                "source": "startup"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let msg = agentic_rx
+            .try_recv()
+            .expect("codex capture message expected");
+        match msg {
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } => {
+                assert_eq!(session_id, zremote_id);
+                assert_eq!(agent, zremote_protocol::AgentKind::Codex);
+                assert_eq!(native_session_id, "codex-native-001");
+            }
+            other => panic!("expected AgentSessionRefCaptured(Codex), got {other:?}"),
+        }
+
+        shutdown_tx.send(true).unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_no_capture_without_header() {
+        // Without the header, SessionStart must NOT emit a capture message.
+        let (agentic_tx, mut agentic_rx) = mpsc::channel(64);
+        let (outbound_tx, _outbound_rx) = mpsc::channel(64);
+        let mapper = SessionMapper::new();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        let server = HooksServer::new(
+            agentic_tx,
+            mapper,
+            outbound_tx,
+            Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            Arc::new(tokio::sync::Mutex::new(DeliveryCoordinator::new())),
+        );
+        let addr = server.start(shutdown_rx).await.unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("http://{addr}/hooks"))
+            .json(&serde_json::json!({
+                "session_id": "claude-native-nohdr",
+                "hook_event_name": "SessionStart",
+                "source": "startup"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        assert!(
+            agentic_rx.try_recv().is_err(),
+            "no header => no AgentSessionRefCaptured"
+        );
+
         shutdown_tx.send(true).unwrap();
     }
 

--- a/crates/zremote-agent/src/hooks/transcript.rs
+++ b/crates/zremote-agent/src/hooks/transcript.rs
@@ -1,37 +1,107 @@
 use std::io;
 
+/// Maximum bytes read for a single transcript line. JSONL records are small;
+/// cap the per-line read so a malformed/hostile transcript (a multi-GB line, or
+/// no newline at all) cannot OOM the parser (CWE-400). Over-long lines are
+/// skipped, not truncated-then-parsed (a partial JSON object would not parse).
+const MAX_LINE_BYTES: u64 = 1_048_576;
+
 /// Extract the `slug` field from a JSONL transcript file starting at `offset`.
 ///
 /// Reads lines from `offset`, looking for the first JSON object with a `"slug"` field.
 /// Returns `(slug, new_offset)` where `new_offset` is the end of the file.
+///
+/// Each line read is bounded to [`MAX_LINE_BYTES`]; a line longer than that is
+/// skipped (treated as not containing a parseable record).
 pub fn extract_slug(path: &str, offset: u64) -> Result<(Option<String>, u64), io::Error> {
-    use std::io::{BufRead, Seek, SeekFrom};
+    use std::io::{Seek, SeekFrom};
 
     let mut file = std::fs::File::open(path)?;
     let file_len = file.metadata()?.len();
     file.seek(SeekFrom::Start(offset))?;
 
-    let reader = io::BufReader::new(file);
+    let mut reader = io::BufReader::new(file);
     let mut slug = None;
 
-    for line in reader.lines() {
-        let line = line?;
-        if line.is_empty() {
-            continue;
-        }
-        // Quick check before full parse
-        if !line.contains("\"slug\"") {
-            continue;
-        }
-        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line)
-            && let Some(s) = obj.get("slug").and_then(|v| v.as_str())
-        {
-            slug = Some(s.to_string());
-            break;
+    loop {
+        let (line, hit_eof) = read_capped_line(&mut reader)?;
+        match line {
+            None if hit_eof => break, // clean EOF
+            None => continue,         // over-long line was skipped; keep going
+            Some(line) => {
+                let Ok(text) = std::str::from_utf8(&line) else {
+                    if hit_eof {
+                        break;
+                    }
+                    continue; // non-UTF-8 line, skip
+                };
+                let text = text.trim_end_matches(['\n', '\r']);
+                // Quick check before full parse
+                if !text.is_empty()
+                    && text.contains("\"slug\"")
+                    && let Ok(obj) = serde_json::from_str::<serde_json::Value>(text)
+                    && let Some(s) = obj.get("slug").and_then(|v| v.as_str())
+                {
+                    slug = Some(s.to_string());
+                    break;
+                }
+                if hit_eof {
+                    break;
+                }
+            }
         }
     }
 
     Ok((slug, file_len))
+}
+
+/// Read one line (up to and including its `\n`) capped at [`MAX_LINE_BYTES`].
+///
+/// Returns `(Some(line), hit_eof)` for a within-cap line. If a line exceeds the
+/// cap it is consumed up to its newline and `(None, false)` is returned so the
+/// caller skips it without OOM (a partial JSON object would not parse anyway).
+/// `(None, true)` signals clean EOF with no further data.
+fn read_capped_line<R: std::io::BufRead>(
+    reader: &mut R,
+) -> Result<(Option<Vec<u8>>, bool), io::Error> {
+    let mut line = Vec::new();
+    let mut over_cap = false;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            // EOF: return whatever we have (None if nothing/over-cap).
+            return Ok((
+                if over_cap || line.is_empty() {
+                    None
+                } else {
+                    Some(line)
+                },
+                true,
+            ));
+        }
+        match available.iter().position(|&b| b == b'\n') {
+            Some(idx) => {
+                // `idx + 1` bytes (including the newline) would be appended;
+                // clippy prefers the strict-`<` form of `len + idx + 1 <= MAX`.
+                if !over_cap && line.len() + idx < MAX_LINE_BYTES as usize {
+                    line.extend_from_slice(&available[..=idx]);
+                } else {
+                    over_cap = true;
+                }
+                reader.consume(idx + 1);
+                return Ok((if over_cap { None } else { Some(line) }, false));
+            }
+            None => {
+                let take = available.len();
+                if !over_cap && line.len() + take <= MAX_LINE_BYTES as usize {
+                    line.extend_from_slice(available);
+                } else {
+                    over_cap = true; // discard rest of this over-long line
+                }
+                reader.consume(take);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -224,5 +294,26 @@ mod tests {
         let file_len = std::fs::metadata(&path).unwrap().len();
         let (_, new_offset) = extract_slug(path.to_str().unwrap(), 0).unwrap();
         assert_eq!(new_offset, file_len);
+    }
+
+    #[test]
+    fn extract_slug_skips_overlong_line_then_finds_next() {
+        // An over-long line (> MAX_LINE_BYTES) must be skipped without OOM, and a
+        // valid slug on a following line must still be found (resync works).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("transcript.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        // A single line larger than the 1 MB cap (no embedded newline).
+        let huge = "x".repeat((MAX_LINE_BYTES as usize) + 1024);
+        writeln!(f, r#"{{"type":"junk","data":"{huge}"}}"#).unwrap();
+        // A normal slug line after it.
+        writeln!(f, r#"{{"type":"result","slug":"after-huge"}}"#).unwrap();
+
+        let (slug, _) = extract_slug(path.to_str().unwrap(), 0).unwrap();
+        assert_eq!(
+            slug.as_deref(),
+            Some("after-huge"),
+            "must skip the over-long line and find the next valid slug"
+        );
     }
 }

--- a/crates/zremote-agent/src/lib.rs
+++ b/crates/zremote-agent/src/lib.rs
@@ -144,6 +144,10 @@ pub enum Commands {
         /// Agent instance UUID that owns this daemon
         #[arg(long)]
         owner_id: Option<String>,
+        /// RFC-013 resume: spawn this argv as the PTY child instead of `shell`.
+        /// Repeated, ordered: first is the program, rest are its args.
+        #[arg(long = "init-arg")]
+        init_argv: Vec<String>,
     },
 }
 
@@ -186,6 +190,7 @@ pub fn run(command: Option<Commands>) {
         export_env_vars,
         force_sigwinch,
         owner_id,
+        init_argv,
     }) = command
     {
         // Validate session_id as UUID to prevent path traversal (e.g. "../")
@@ -245,6 +250,12 @@ pub fn run(command: Option<Commands>) {
             None
         };
 
+        let resume_argv = if init_argv.is_empty() {
+            None
+        } else {
+            Some(init_argv)
+        };
+
         rt.block_on(daemon::run_pty_daemon(
             session_id,
             socket,
@@ -256,6 +267,7 @@ pub fn run(command: Option<Commands>) {
             extra_env,
             shell_config,
             owner_id,
+            resume_argv,
         ));
         return;
     }

--- a/crates/zremote-agent/src/local/mod.rs
+++ b/crates/zremote-agent/src/local/mod.rs
@@ -32,6 +32,56 @@ fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// Classify suspended sessions whose daemon was NOT recovered after an agent
+/// restart/reboot (RFC-013, startup recovery step).
+///
+/// For each suspended session on this host that is not in `recovered_ids`:
+/// - if it has a persisted `agent_session_ref` (RFC-012) it backs an agent
+///   conversation we can re-open, so mark it **`resumable`** (stays listed,
+///   attach drives the resume engine) and reconcile any linked `claude_sessions`
+///   row so the sidebar reflects it instead of pointing at a dead session id;
+/// - otherwise mark it **`closed`** (current behavior). The plain-shell
+///   `recreate_shell_on_restart` path is a later phase, out of scope here.
+///
+/// Recovered sessions are skipped — they were already transitioned back to
+/// `active` by the caller.
+async fn classify_unrecovered_sessions(
+    pool: &sqlx::SqlitePool,
+    host_id: Uuid,
+    recovered_ids: &[String],
+    recovery_now: &str,
+) -> Result<(), zremote_core::error::AppError> {
+    let suspended_rows =
+        zremote_core::queries::sessions::list_suspended_sessions_with_optional_agent_ref(
+            pool,
+            &host_id.to_string(),
+        )
+        .await?;
+
+    for (session_id, agent_session_ref) in &suspended_rows {
+        if recovered_ids.contains(session_id) {
+            continue;
+        }
+        if agent_session_ref.is_some() {
+            zremote_core::queries::sessions::mark_session_resumable(pool, session_id).await?;
+            let reconciled = zremote_core::queries::sessions::reconcile_claude_session_resumable(
+                pool, session_id,
+            )
+            .await?;
+            tracing::info!(
+                %session_id,
+                claude_tasks_reconciled = reconciled,
+                "session backend not recovered; marked resumable (agent session ref present)"
+            );
+        } else {
+            zremote_core::queries::sessions::force_close_session_at(pool, session_id, recovery_now)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Start the local mode HTTP server.
 ///
 /// This runs an Axum server with SQLite database and all necessary
@@ -203,22 +253,10 @@ pub async fn run_local(
         sessions.insert(*session_id, session_state);
     }
 
-    // Close suspended sessions that weren't recovered (dead daemon sessions)
-    let suspended_rows: Vec<String> =
-        sqlx::query_scalar("SELECT id FROM sessions WHERE host_id = ? AND status = 'suspended'")
-            .bind(host_id.to_string())
-            .fetch_all(&pool)
-            .await?;
-
-    for row in &suspended_rows {
-        if !recovered_ids.contains(row) {
-            sqlx::query("UPDATE sessions SET status = 'closed', closed_at = ? WHERE id = ?")
-                .bind(&recovery_now)
-                .bind(row)
-                .execute(&pool)
-                .await?;
-        }
-    }
+    // Classify suspended sessions whose daemon wasn't recovered (dead backend):
+    // agent conversations -> `resumable`, plain shells -> `closed`. See
+    // `classify_unrecovered_sessions`.
+    classify_unrecovered_sessions(&pool, host_id, &recovered_ids, &recovery_now).await?;
 
     if !recovered.is_empty() {
         tracing::info!(
@@ -587,5 +625,382 @@ mod tests {
             .unwrap();
         let json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         assert!(json.is_empty());
+    }
+
+    // --- classify_unrecovered_sessions (RFC-013 startup recovery) ---
+
+    async fn setup_recovery_db(host_id: Uuid) -> sqlx::SqlitePool {
+        let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
+        upsert_local_host(&pool, &host_id, "test-host")
+            .await
+            .unwrap();
+        pool
+    }
+
+    async fn insert_suspended(
+        pool: &sqlx::SqlitePool,
+        host_id: Uuid,
+        id: &str,
+        agent_session_ref: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO sessions (id, host_id, status, agent_session_ref) \
+             VALUES (?, ?, 'suspended', ?)",
+        )
+        .bind(id)
+        .bind(host_id.to_string())
+        .bind(agent_session_ref)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn session_status(pool: &sqlx::SqlitePool, id: &str) -> String {
+        sqlx::query_scalar::<_, String>("SELECT status FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn classify_marks_agent_session_resumable() {
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        insert_suspended(&pool, host_id, "s_agent", Some("cc-123")).await;
+
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        assert_eq!(session_status(&pool, "s_agent").await, "resumable");
+    }
+
+    #[tokio::test]
+    async fn classify_closes_plain_session() {
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        insert_suspended(&pool, host_id, "s_plain", None).await;
+
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        assert_eq!(session_status(&pool, "s_plain").await, "closed");
+    }
+
+    #[tokio::test]
+    async fn classify_skips_recovered_session() {
+        // A recovered session must be left as-is even if it has an agent ref —
+        // the caller already transitioned it back to active.
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        insert_suspended(&pool, host_id, "s_recovered", Some("cc-123")).await;
+        // Simulate the caller having reactivated it.
+        sqlx::query("UPDATE sessions SET status = 'active' WHERE id = 's_recovered'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        classify_unrecovered_sessions(
+            &pool,
+            host_id,
+            &["s_recovered".to_string()],
+            "2026-06-04T09:00:00Z",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(session_status(&pool, "s_recovered").await, "active");
+    }
+
+    #[tokio::test]
+    async fn classify_reconciles_linked_claude_task() {
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        insert_suspended(&pool, host_id, "s_agent", Some("cc-123")).await;
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status) \
+             VALUES ('t1', 's_agent', ?, '/proj', 'active')",
+        )
+        .bind(host_id.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        assert_eq!(session_status(&pool, "s_agent").await, "resumable");
+        let (task_status, reason): (String, Option<String>) =
+            sqlx::query_as("SELECT status, disconnect_reason FROM claude_sessions WHERE id = 't1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(task_status, "suspended");
+        assert_eq!(reason.as_deref(), Some("agent_restarted"));
+    }
+
+    // --- RFC-013 question H: end-to-end runtime repro of the reboot scenario ---
+    //
+    // These exercise the full surface chain through the real local HTTP router:
+    // startup recovery (classify_unrecovered_sessions) -> which REST surface
+    // shows the session -> the resume path. They answer "which surface shows the
+    // resumable session" (the sessions list, NOT a closed/filtered row) and
+    // prove the resume argv is built from the persisted RFC-012 identity.
+
+    /// Build the full local router over `pool` with a known host id (so the
+    /// `/api/hosts/{host_id}/...` routes resolve).
+    fn router_over(state: std::sync::Arc<crate::local::state::LocalAppState>) -> axum::Router {
+        build_router(state).unwrap()
+    }
+
+    async fn get_json(router: &axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+        let resp = router
+            .clone()
+            .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = if body.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null)
+        };
+        (status, json)
+    }
+
+    /// Seed the post-reboot DB state for a Claude agent session: a `suspended`
+    /// row carrying `agent_kind`/`agent_session_ref` (RFC-012 capture survived),
+    /// whose daemon is gone, plus a linked `claude_sessions` row.
+    async fn seed_rebooted_claude_session(
+        pool: &sqlx::SqlitePool,
+        host_id: Uuid,
+        session_id: &str,
+        native_id: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO sessions \
+             (id, host_id, status, shell, working_dir, agent_kind, agent_session_ref, agent_session_updated_at) \
+             VALUES (?, ?, 'suspended', '/bin/sh', '/proj', 'claude', ?, '2026-06-04T08:00:00Z')",
+        )
+        .bind(session_id)
+        .bind(host_id.to_string())
+        .bind(native_id)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status) \
+             VALUES ('task-h', ?, ?, '/proj', 'active')",
+        )
+        .bind(session_id)
+        .bind(host_id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn repro_h_reboot_surfaces_session_as_resumable_in_sessions_list() {
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        let session_id = "11111111-1111-1111-1111-111111111111";
+        seed_rebooted_claude_session(&pool, host_id, session_id, "cc-reboot-001").await;
+
+        // Run startup recovery: daemon NOT recovered (recovered_ids empty).
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        let state = LocalAppState::new(
+            pool.clone(),
+            "test-host".to_string(),
+            host_id,
+            CancellationToken::new(),
+            crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
+            Uuid::new_v4(),
+        );
+        let router = router_over(state);
+
+        // SURFACE 1: GET /api/hosts/:id/sessions — the session is VISIBLE and
+        // marked `resumable` (not closed, not filtered out). This is the surface
+        // that shows it (answer to question H).
+        let (status, sessions) = get_json(&router, &format!("/api/hosts/{host_id}/sessions")).await;
+        assert_eq!(status, StatusCode::OK);
+        let arr = sessions.as_array().expect("sessions array");
+        let row = arr
+            .iter()
+            .find(|s| s["id"] == session_id)
+            .expect("rebooted session must still be listed (resumable, not closed)");
+        assert_eq!(
+            row["status"], "resumable",
+            "sessions list must surface the rebooted agent session as resumable"
+        );
+
+        // SURFACE 2: GET /api/claude-tasks — the linked task is reconciled to
+        // suspended + agent_restarted (so the sidebar reflects the dead session).
+        let (status, tasks) = get_json(&router, "/api/claude-tasks").await;
+        assert_eq!(status, StatusCode::OK);
+        let tasks_arr = tasks.as_array().expect("claude-tasks array");
+        let task = tasks_arr
+            .iter()
+            .find(|t| t["id"] == "task-h")
+            .expect("linked claude task must be listed");
+        assert_eq!(task["status"], "suspended");
+        assert_eq!(task["disconnect_reason"], "agent_restarted");
+    }
+
+    #[tokio::test]
+    async fn repro_h_resume_argv_built_from_persisted_identity() {
+        // The resume command is derived purely from the stored agent_kind +
+        // agent_session_ref (RFC-012), with the native id as a separate argv
+        // token (injection-safe). No real claude binary needed for this assert.
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        let session_id = "22222222-2222-2222-2222-222222222222";
+        seed_rebooted_claude_session(&pool, host_id, session_id, "cc-reboot-002").await;
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        let argv = crate::session::build_resume_argv_for_session(&pool, session_id)
+            .await
+            .unwrap()
+            .expect("resumable claude session must produce a resume argv");
+        assert_eq!(
+            argv,
+            vec![
+                "claude".to_string(),
+                "--resume".to_string(),
+                "cc-reboot-002".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn repro_h_resume_route_rejects_non_resumable_session() {
+        // The explicit resume route guards a non-resumable session: a clean
+        // rejection, not a panic / not a spurious spawn.
+        //
+        // RFC-013 review HIGH #1: the route now checks the DB status FIRST and
+        // rejects anything that is not `resumable` with 409 Conflict (so it can't
+        // corrupt timestamps / reactivate a closed row). A plain `suspended`
+        // session therefore returns Conflict, BEFORE the agent-ref check that
+        // would otherwise return BadRequest.
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        let session_id = "33333333-3333-3333-3333-333333333333";
+        // Plain suspended session (not resumable, no agent_session_ref).
+        insert_suspended(&pool, host_id, session_id, None).await;
+
+        let state = LocalAppState::new(
+            pool.clone(),
+            "test-host".to_string(),
+            host_id,
+            CancellationToken::new(),
+            crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
+            Uuid::new_v4(),
+        );
+        let router = router_over(state);
+
+        let resp = router
+            .oneshot(
+                Request::post(format!("/api/hosts/{host_id}/sessions/{session_id}/resume"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Non-resumable status -> Conflict (the status guard rejects it first).
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    /// Return `true` if an executable named `bin` is found on `$PATH`.
+    fn binary_on_path(bin: &str) -> bool {
+        let Some(path) = std::env::var_os("PATH") else {
+            return false;
+        };
+        std::env::split_paths(&path).any(|dir| {
+            let candidate = dir.join(bin);
+            // Exists + is a file. Execute-bit check is best-effort (good enough
+            // to decide whether the spawn can realistically succeed).
+            candidate.is_file()
+        })
+    }
+
+    #[tokio::test]
+    async fn repro_h_live_resume_spawns_claude_and_activates() {
+        // The one real-process proof closing the loop: resuming a `resumable`
+        // claude session actually spawns `claude --resume <id>` as the session's
+        // process and transitions the row resumable -> active.
+        //
+        // PATH-GATED: skipped when `claude` is not installed, so CI stays green.
+        if !binary_on_path("claude") {
+            eprintln!("skipping live-resume repro: `claude` not on PATH");
+            return;
+        }
+
+        let host_id = Uuid::new_v4();
+        let pool = setup_recovery_db(host_id).await;
+        let session_id = "44444444-4444-4444-4444-444444444444";
+        seed_rebooted_claude_session(&pool, host_id, session_id, "cc-live-001").await;
+        classify_unrecovered_sessions(&pool, host_id, &[], "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+        // Precondition: recovery marked it resumable.
+        assert_eq!(session_status(&pool, session_id).await, "resumable");
+
+        let state = LocalAppState::new(
+            pool.clone(),
+            "test-host".to_string(),
+            host_id,
+            CancellationToken::new(),
+            crate::config::PersistenceBackend::None,
+            std::path::PathBuf::from("/tmp/zremote-test"),
+            Uuid::new_v4(),
+        );
+        let router = router_over(state);
+
+        // Drive the explicit resume route.
+        let resp = router
+            .oneshot(
+                Request::post(format!("/api/hosts/{host_id}/sessions/{session_id}/resume"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "live resume of a claude session must succeed when claude is installed"
+        );
+
+        // The returned row + DB row are now `active` (reusing the SAME id), and a
+        // real PTY child was spawned (pid recorded).
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let row: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(row["id"], session_id);
+        assert_eq!(row["status"], "active");
+        assert_eq!(session_status(&pool, session_id).await, "active");
+        let pid: Option<i64> =
+            sqlx::query_scalar::<_, Option<i64>>("SELECT pid FROM sessions WHERE id = ?")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            pid.is_some_and(|p| p > 0),
+            "resume must record the spawned agent PID, got {pid:?}"
+        );
     }
 }

--- a/crates/zremote-agent/src/local/router.rs
+++ b/crates/zremote-agent/src/local/router.rs
@@ -61,6 +61,10 @@ pub(crate) fn build_router(
             post(routes::sessions::create_session).get(routes::sessions::list_sessions),
         )
         .route(
+            "/api/hosts/{host_id}/sessions/{session_id}/resume",
+            post(routes::sessions::resume_session),
+        )
+        .route(
             "/api/sessions/{session_id}",
             get(routes::sessions::get_session)
                 .patch(routes::sessions::update_session)

--- a/crates/zremote-agent/src/local/routes/claude_sessions.rs
+++ b/crates/zremote-agent/src/local/routes/claude_sessions.rs
@@ -250,43 +250,34 @@ pub async fn resume_claude_task(
 
     let host_id = state.host_id.to_string();
 
-    let new_session_id = Uuid::new_v4();
-    let new_session_id_str = new_session_id.to_string();
-    let new_task_id = Uuid::new_v4();
-    let new_task_id_str = new_task_id.to_string();
+    // RFC-013 (decisions D/E/F/4): resume IN PLACE — reuse the SAME terminal
+    // session id and the SAME claude_sessions row instead of minting new ones,
+    // so cost/tokens keep accumulating on one row and GUI handles stay stable.
+    let session_id: Uuid = original.session_id.parse().map_err(|_| {
+        AppError::Internal(format!(
+            "stored session_id is not a UUID: {}",
+            original.session_id
+        ))
+    })?;
+    let session_id_str = original.session_id.clone();
+    let task_id_str = original.id.clone();
 
     let initial_prompt = resume_req.initial_prompt;
 
-    q::insert_session_for_task(
+    // In-place update of the existing row (status -> starting, clear terminal
+    // stamps, refresh prompt/options). Replaces the old new-row insert.
+    let updated = q::resume_claude_task_in_place(
         &state.db,
-        &new_session_id_str,
-        &host_id,
-        &original.project_path,
-        original.project_id.as_deref(),
-    )
-    .await?;
-
-    q::insert_resumed_claude_task(
-        &state.db,
-        &new_task_id_str,
-        &new_session_id_str,
-        &host_id,
-        &original.project_path,
-        original.project_id.as_deref(),
+        &task_id_str,
         original.model.as_deref(),
         initial_prompt.as_deref(),
-        cc_session_id.as_deref(),
-        &original.id,
         original.options_json.as_deref(),
     )
     .await?;
-
-    {
-        let mut sessions = state.sessions.write().await;
-        sessions.insert(
-            new_session_id,
-            SessionState::new(new_session_id, state.host_id),
-        );
+    if updated == 0 {
+        return Err(AppError::NotFound(format!(
+            "claude task {task_id_str} not found"
+        )));
     }
 
     let (
@@ -297,7 +288,12 @@ pub async fn resume_claude_task(
         development_channels,
         print_mode,
     ) = if let Some(ref opts_str) = original.options_json {
-        let opts: serde_json::Value = serde_json::from_str(opts_str).unwrap_or_default();
+        // Do NOT silently drop options on corrupt JSON: skip_permissions /
+        // allowed_tools are security-relevant, so resuming with defaults would
+        // be a silent behavior change. Propagate the parse error instead.
+        let opts: serde_json::Value = serde_json::from_str(opts_str).map_err(|e| {
+            AppError::Internal(format!("corrupt options_json for task {task_id_str}: {e}"))
+        })?;
         let tools = opts["allowed_tools"]
             .as_array()
             .map(|arr| {
@@ -356,56 +352,79 @@ pub async fn resume_claude_task(
     let cmd = CommandBuilder::build(&cmd_opts)
         .map_err(|e| AppError::BadRequest(format!("invalid command options: {e}")))?;
 
-    // Spawn PTY session
+    // RFC-013 (decision D): relaunch via the shared argv-direct engine. The
+    // claude command needs a shell (it uses `cd`, env prefixes, and
+    // `"$(cat <promptfile>)"` for large prompts), so the session's program is
+    // `<shell> -c '<cmd>; exec <shell>'` — run AS the session command. No 300ms
+    // sleep, no write-into-a-live-shell, so there is no prompt-readiness race.
+    // Every field inside `cmd` is already shell-quoted by CommandBuilder.
+    //
+    // The trailing `; exec <shell>` keeps a live interactive shell after `claude`
+    // exits, matching the claude-task START behavior (which spawns a persistent
+    // shell and types the command into it) — so the session does not die when
+    // the agent finishes.
     let shell = default_shell();
+    let script = format!("{}; exec {}", cmd.trim_end_matches('\n'), shell);
+    let resume_argv = vec![shell.to_string(), "-c".to_string(), script];
     let ai_config = crate::pty::shell_integration::ShellIntegrationConfig::for_ai_session();
+
     let pid = {
         let mut mgr = state.session_manager.lock().await;
-        mgr.create(
-            new_session_id,
+        mgr.resume_session(
+            session_id,
             shell,
             120,
             40,
             Some(&original.project_path),
             None,
             Some(&ai_config),
+            &resume_argv,
         )
         .await
-        .map_err(|e| AppError::Internal(format!("failed to spawn PTY: {e}")))?
+        .map_err(|e| AppError::Internal(format!("failed to spawn resume PTY: {e}")))?
     };
 
-    // Update session status in DB
-    sqlx::query("UPDATE sessions SET status = 'active', shell = ?, pid = ? WHERE id = ?")
-        .bind(shell)
-        .bind(i64::from(pid))
-        .bind(&new_session_id_str)
-        .execute(&state.db)
-        .await
-        .map_err(AppError::Database)?;
-
-    // Brief delay to let the shell initialize before writing the command
-    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-
-    // Write the claude command into the PTY
-    {
+    // Transition the reused terminal row resumable/closed -> active. If the DB
+    // update fails AFTER the spawn, tear down the spawned backend so we don't
+    // orphan a PTY (and don't insert in-memory state for a row that's not active).
+    let db_result = async {
+        zremote_core::queries::sessions::mark_session_active(&state.db, &session_id_str).await?;
+        sqlx::query("UPDATE sessions SET shell = ?, pid = ? WHERE id = ?")
+            .bind(shell)
+            .bind(i64::from(pid))
+            .bind(&session_id_str)
+            .execute(&state.db)
+            .await
+            .map_err(AppError::Database)?;
+        Ok::<(), AppError>(())
+    }
+    .await;
+    if let Err(e) = db_result {
         let mut mgr = state.session_manager.lock().await;
-        mgr.write_to(&new_session_id, cmd.as_bytes())
-            .map_err(|e| AppError::Internal(format!("failed to write command to PTY: {e}")))?;
+        let _ = mgr.close(&session_id);
+        return Err(e);
+    }
+
+    // Re-create in-memory state under the SAME terminal id, only after the spawn
+    // and DB update both succeeded.
+    {
+        let mut sessions = state.sessions.write().await;
+        sessions.insert(session_id, SessionState::new(session_id, state.host_id));
     }
 
     // Register channel dialog auto-approval detector + channel bridge discovery.
-    crate::claude::register_channel_auto_approve(new_session_id, &development_channels, &state)
-        .await;
+    crate::claude::register_channel_auto_approve(session_id, &development_channels, &state).await;
 
     let _ = state.events.send(ServerEvent::ClaudeTaskStarted {
-        task_id: new_task_id_str.clone(),
-        session_id: new_session_id_str.clone(),
+        task_id: task_id_str.clone(),
+        session_id: session_id_str.clone(),
         host_id: host_id.clone(),
         project_path: original.project_path.clone(),
     });
 
-    let task = q::get_claude_task(&state.db, &new_task_id_str).await?;
-    Ok((StatusCode::CREATED, Json(task)))
+    // In-place: return the SAME (updated) task row.
+    let task = q::get_claude_task(&state.db, &task_id_str).await?;
+    Ok((StatusCode::OK, Json(task)))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1692,9 +1711,13 @@ mod tests {
         // PTY spawn will fail in test env but it exercises the DB insertion and option parsing paths
         // Status will be 500 (Internal Server Error) because PTY spawn fails, or 201 if it succeeds
         let status = response.status();
+        // RFC-013 in-place resume returns 200 OK with the SAME task row on
+        // success (no longer 201 + a new row). The spawned program is
+        // `sh -c '<claude cmd>'`; `sh` spawns fine in tests, so success is 200.
+        // A spawn failure still surfaces as 500.
         assert!(
-            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::CREATED,
-            "expected 500 or 201, got {status}"
+            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::OK,
+            "expected 500 or 200, got {status}"
         );
     }
 
@@ -1755,9 +1778,13 @@ mod tests {
 
         // Will fail at PTY spawn but exercises the options parsing path
         let status = response.status();
+        // RFC-013 in-place resume returns 200 OK with the SAME task row on
+        // success (no longer 201 + a new row). The spawned program is
+        // `sh -c '<claude cmd>'`; `sh` spawns fine in tests, so success is 200.
+        // A spawn failure still surfaces as 500.
         assert!(
-            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::CREATED,
-            "expected 500 or 201, got {status}"
+            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::OK,
+            "expected 500 or 200, got {status}"
         );
     }
 
@@ -1983,9 +2010,154 @@ mod tests {
 
         let status = response.status();
         // Exercises the None options_json branch (defaults: empty tools, no skip, no format, no flags)
+        // RFC-013 in-place resume returns 200 OK with the SAME task row on
+        // success (no longer 201 + a new row). The spawned program is
+        // `sh -c '<claude cmd>'`; `sh` spawns fine in tests, so success is 200.
+        // A spawn failure still surfaces as 500.
         assert!(
-            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::CREATED,
-            "expected 500 or 201, got {status}"
+            status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::OK,
+            "expected 500 or 200, got {status}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_claude_task_is_in_place_same_id_no_new_row() {
+        // RFC-013 decisions E/4: resume reuses the SAME claude_sessions row and
+        // terminal session id — no new task row is created.
+        let state = test_state().await;
+        let host_id = state.host_id.to_string();
+        let session_id = Uuid::new_v4().to_string();
+        let task_id = Uuid::new_v4().to_string();
+
+        zremote_core::queries::claude_sessions::insert_session_for_task(
+            &state.db,
+            &session_id,
+            &host_id,
+            "/tmp/project",
+            None,
+        )
+        .await
+        .unwrap();
+        zremote_core::queries::claude_sessions::insert_claude_task(
+            &state.db,
+            &task_id,
+            &session_id,
+            &host_id,
+            "/tmp/project",
+            None,
+            Some("opus"),
+            Some("original"),
+            None,
+        )
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE claude_sessions SET status = 'completed', claude_session_id = 'cc-1' WHERE id = ?",
+        )
+        .bind(&task_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        let count_before: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM claude_sessions")
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+
+        let app = build_test_router(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resume"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"initial_prompt":"keep going"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        // `sh -c` spawns fine in tests -> 200; a spawn failure -> 500. Either way
+        // the in-place invariants below must hold (the in-place DB update runs
+        // before the spawn).
+        assert!(
+            status == StatusCode::OK || status == StatusCode::INTERNAL_SERVER_ERROR,
+            "got {status}"
+        );
+
+        // No NEW row was created.
+        let count_after: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM claude_sessions")
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        assert_eq!(
+            count_after.0, count_before.0,
+            "resume must not insert a new task row"
+        );
+
+        // The SAME row was updated in place: prompt refreshed, still same session_id.
+        let task = zremote_core::queries::claude_sessions::get_claude_task(&state.db, &task_id)
+            .await
+            .unwrap();
+        assert_eq!(task.session_id, session_id);
+        assert_eq!(task.initial_prompt, Some("keep going".to_string()));
+        assert_eq!(task.model, Some("opus".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resume_claude_task_rejects_corrupt_options_json() {
+        // MEDIUM #4: corrupt options_json must NOT silently drop security-relevant
+        // options (skip_permissions/allowed_tools). Resume returns 500, not 2xx.
+        let state = test_state().await;
+        let host_id = state.host_id.to_string();
+        let session_id = Uuid::new_v4().to_string();
+        let task_id = Uuid::new_v4().to_string();
+
+        zremote_core::queries::claude_sessions::insert_session_for_task(
+            &state.db,
+            &session_id,
+            &host_id,
+            "/tmp/project",
+            None,
+        )
+        .await
+        .unwrap();
+        zremote_core::queries::claude_sessions::insert_claude_task(
+            &state.db,
+            &task_id,
+            &session_id,
+            &host_id,
+            "/tmp/project",
+            None,
+            None,
+            None,
+            Some("{not valid json"),
+        )
+        .await
+        .unwrap();
+        sqlx::query("UPDATE claude_sessions SET status = 'completed' WHERE id = ?")
+            .bind(&task_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let app = build_test_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/claude-tasks/{task_id}/resume"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "corrupt options_json must surface an error, not resume with dropped options"
         );
     }
 }

--- a/crates/zremote-agent/src/local/routes/sessions.rs
+++ b/crates/zremote-agent/src/local/routes/sessions.rs
@@ -212,6 +212,29 @@ pub async fn get_session(
     Ok(Json(session))
 }
 
+/// `POST /api/hosts/:host_id/sessions/:session_id/resume` - explicitly resume a
+/// `resumable` agent session (RFC-013). Re-spawns the agent for the SAME session
+/// id via the shared resume engine, transitions the row to `active`, and returns
+/// the re-created session.
+pub async fn resume_session(
+    State(state): State<Arc<LocalAppState>>,
+    Path((host_id, session_id)): Path<(String, String)>,
+) -> Result<Json<q::SessionRow>, AppError> {
+    let parsed_host_id: Uuid = host_id
+        .parse()
+        .map_err(|_| AppError::BadRequest(format!("invalid host ID: {host_id}")))?;
+    if parsed_host_id != state.host_id {
+        return Err(AppError::NotFound(format!("host {host_id} not found")));
+    }
+    let parsed_session_id: Uuid = session_id
+        .parse()
+        .map_err(|_| AppError::BadRequest(format!("invalid session ID: {session_id}")))?;
+
+    super::terminal::resume_session_by_id(&state, &parsed_session_id).await?;
+    let session = q::get_session(&state.db, &session_id).await?;
+    Ok(Json(session))
+}
+
 /// Request body for updating a session.
 #[derive(Debug, Deserialize)]
 pub struct UpdateSessionRequest {
@@ -356,6 +379,14 @@ pub(crate) async fn close_sessions_for_project(
         if row.status == "closed" {
             continue;
         }
+        // RFC-013: never let a bulk/cascade close (project/worktree cleanup)
+        // silently destroy a `resumable` session — that would permanently lose
+        // the ability to resume the agent conversation. A resumable session has
+        // no live PTY holding the working dir, so skipping it does not block
+        // teardown. It is only closed by an explicit action on that session.
+        if row.status == "resumable" {
+            continue;
+        }
         if !seen.insert(row.id.clone()) {
             continue;
         }
@@ -369,6 +400,9 @@ pub(crate) async fn close_sessions_for_project(
     if let Some(path) = path_scope {
         let by_path = q::list_active_sessions_under_path(&state.db, host_id, path).await?;
         for row in by_path {
+            if row.status == "resumable" {
+                continue;
+            }
             if !seen.insert(row.id.clone()) {
                 continue;
             }
@@ -2090,5 +2124,59 @@ mod tests {
             assert!(!node.working_dir.is_empty());
             assert!(node.duration_ms >= 0);
         }
+    }
+
+    #[tokio::test]
+    async fn close_sessions_for_project_skips_resumable() {
+        // HIGH #2: a bulk/cascade close (project/worktree cleanup) must NOT
+        // destroy a resumable session — only an active one is closed.
+        let state = test_state().await;
+        let host_id = state.host_id.to_string();
+        let project_id = Uuid::new_v4().to_string();
+        zremote_core::queries::projects::insert_project(
+            &state.db,
+            &project_id,
+            &host_id,
+            "/tmp/proj",
+            "proj",
+        )
+        .await
+        .unwrap();
+
+        let active_id = Uuid::new_v4().to_string();
+        let resumable_id = Uuid::new_v4().to_string();
+        for (id, status) in [(&active_id, "active"), (&resumable_id, "resumable")] {
+            sqlx::query(
+                "INSERT INTO sessions (id, host_id, status, project_id, working_dir) \
+                 VALUES (?, ?, ?, ?, '/tmp/proj')",
+            )
+            .bind(id)
+            .bind(&host_id)
+            .bind(status)
+            .bind(&project_id)
+            .execute(&state.db)
+            .await
+            .unwrap();
+        }
+
+        // Cascade close (no live PTYs in test — close still updates the DB rows).
+        let _ = close_sessions_for_project(&state, &host_id, &project_id, Some("/tmp/proj")).await;
+
+        let active_status: String = sqlx::query_scalar("SELECT status FROM sessions WHERE id = ?")
+            .bind(&active_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        let resumable_status: String =
+            sqlx::query_scalar("SELECT status FROM sessions WHERE id = ?")
+                .bind(&resumable_id)
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(active_status, "closed", "active session should be closed");
+        assert_eq!(
+            resumable_status, "resumable",
+            "resumable session must be PRESERVED by cascade close"
+        );
     }
 }

--- a/crates/zremote-agent/src/local/routes/terminal.rs
+++ b/crates/zremote-agent/src/local/routes/terminal.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 use zremote_core::error::AppError;
-use zremote_core::state::BrowserMessage;
+use zremote_core::state::{BrowserMessage, ServerEvent, SessionState};
 use zremote_core::terminal_ws::{
     BROWSER_CHANNEL_SIZE, RegistrationResult, SessionError, TerminalBackend,
     handle_terminal_websocket,
@@ -17,6 +17,7 @@ use zremote_core::terminal_ws::{
 use zremote_protocol::status::SessionStatus;
 
 use crate::local::state::LocalAppState;
+use crate::pty::shell_integration::ShellIntegrationConfig;
 
 /// Local-mode terminal backend that writes directly to PTY.
 struct LocalTerminalBackend {
@@ -35,24 +36,36 @@ impl TerminalBackend for LocalTerminalBackend {
         };
 
         if !session_exists {
-            let error_message =
-                match sqlx::query_as::<_, (String,)>("SELECT status FROM sessions WHERE id = ?")
+            let db_status =
+                sqlx::query_as::<_, (String,)>("SELECT status FROM sessions WHERE id = ?")
                     .bind(session_id.to_string())
                     .fetch_optional(&self.state.db)
-                    .await
-                {
+                    .await;
+
+            // RFC-013: a `resumable` session has no live backend yet. With
+            // auto-resume on, relaunch the agent now (so the happy path below
+            // finds it active); with it off, return a typed resumable signal so
+            // the GUI offers an explicit "Continue" instead of a dead terminal.
+            if matches!(&db_status, Ok(Some((s,))) if s == "resumable") {
+                if crate::config::resume_agents_on_restart() {
+                    self.resume_resumable_session(session_id).await?;
+                    // Fall through: the session is now in memory and active.
+                } else {
+                    return Err(SessionError::resumable(
+                        "session is resumable — click to continue".to_string(),
+                    ));
+                }
+            } else {
+                let error_message = match db_status {
                     Ok(Some((status,))) if status == "active" || status == "creating" => {
                         "session is stale (server restarted)".to_string()
                     }
-                    Ok(Some((status,))) => {
-                        format!("session is {status}")
-                    }
+                    Ok(Some((status,))) => format!("session is {status}"),
                     Ok(None) => "session not found".to_string(),
                     Err(_) => "session not found or not active".to_string(),
                 };
-            return Err(SessionError {
-                message: error_message,
-            });
+                return Err(SessionError::new(error_message));
+            }
         }
 
         // Phase 2: Take write lock for the happy path
@@ -63,18 +76,14 @@ impl TerminalBackend for LocalTerminalBackend {
         {
             let mut sessions = self.state.sessions.write().await;
             let Some(session) = sessions.get_mut(session_id) else {
-                return Err(SessionError {
-                    message: "session was closed while connecting".to_string(),
-                });
+                return Err(SessionError::new("session was closed while connecting"));
             };
 
             if session.status != SessionStatus::Active
                 && session.status != SessionStatus::Creating
                 && session.status != SessionStatus::Suspended
             {
-                return Err(SessionError {
-                    message: format!("session is {}", session.status),
-                });
+                return Err(SessionError::new(format!("session is {}", session.status)));
             }
 
             scrollback_data = session.scrollback.iter().cloned().collect::<Vec<_>>();
@@ -126,6 +135,123 @@ impl TerminalBackend for LocalTerminalBackend {
             tracing::warn!(error = %e, "image paste failed");
         }
     }
+}
+
+impl LocalTerminalBackend {
+    /// Resume-on-attach (RFC-013): re-spawn the agent for a `resumable` session
+    /// during `register_browser`, mapping engine errors to a `SessionError` so
+    /// the WS handler reports a clean failure (and the row stays `resumable`).
+    async fn resume_resumable_session(&self, session_id: &Uuid) -> Result<(), SessionError> {
+        resume_session_by_id(&self.state, session_id)
+            .await
+            .map_err(|e| SessionError::new(format!("failed to resume session: {e}")))?;
+        Ok(())
+    }
+}
+
+/// Shared resume engine for the local agent (RFC-013), used by both
+/// resume-on-attach (`register_browser`) and the explicit
+/// `POST /api/hosts/:host_id/sessions/:id/resume` endpoint.
+///
+/// Re-spawns the agent for an existing `resumable` session using the argv-direct
+/// engine (`SessionManager::resume_session`), reusing the SAME `sessions.id`,
+/// then transitions the row `resumable` -> `active` and re-creates the in-memory
+/// `SessionState`. Returns an error (leaving the row `resumable`) if the session
+/// has no resumable agent ref or the agent CLI cannot be spawned.
+pub async fn resume_session_by_id(
+    state: &Arc<LocalAppState>,
+    session_id: &Uuid,
+) -> Result<(), AppError> {
+    let session_id_str = session_id.to_string();
+
+    // Load status + shell + working_dir in one read.
+    let row: Option<(String, Option<String>, Option<String>)> =
+        sqlx::query_as("SELECT status, shell, working_dir FROM sessions WHERE id = ?")
+            .bind(&session_id_str)
+            .fetch_optional(&state.db)
+            .await?;
+    let (status, shell_opt, working_dir) =
+        row.ok_or_else(|| AppError::NotFound(format!("session {session_id_str} not found")))?;
+
+    // Guard: only a `resumable` session may be resumed. Without this an
+    // explicit resume (REST) on an active/closed session would corrupt
+    // timestamps or reactivate a closed row.
+    if status != "resumable" {
+        return Err(AppError::Conflict(format!(
+            "session {session_id_str} is not resumable (status: {status})"
+        )));
+    }
+
+    // Build the resume argv from the persisted agent identity (RFC-012).
+    let Some(resume_argv) =
+        crate::session::build_resume_argv_for_session(&state.db, &session_id_str).await?
+    else {
+        return Err(AppError::BadRequest(format!(
+            "session {session_id_str} is not a resumable agent session"
+        )));
+    };
+
+    let shell = crate::shell::resolve_shell(shell_opt.as_deref());
+    let ai_config = ShellIntegrationConfig::for_ai_session();
+
+    // Spawn the agent as the session's process (argv-direct, no shell race).
+    let pid = {
+        let mut mgr = state.session_manager.lock().await;
+        mgr.resume_session(
+            *session_id,
+            &shell,
+            120,
+            40,
+            working_dir.as_deref(),
+            None,
+            Some(&ai_config),
+            &resume_argv,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("failed to spawn resume PTY: {e}")))?
+    };
+
+    // resumable -> active (reuses the same id; clears suspended/closed stamps).
+    // If the DB update fails AFTER the spawn, tear the spawned backend down so we
+    // don't leave an orphan PTY with the row still `resumable`.
+    if let Err(e) = mark_session_active_and_pid(state, &session_id_str, &shell, pid).await {
+        let mut mgr = state.session_manager.lock().await;
+        let _ = mgr.close(session_id);
+        return Err(e);
+    }
+
+    // Re-create in-memory state only after spawn AND DB update both succeed, so
+    // a failed resume never leaves a dangling SessionState without a backend.
+    {
+        let mut sessions = state.sessions.write().await;
+        let mut session_state = SessionState::new(*session_id, state.host_id);
+        session_state.status = SessionStatus::Active;
+        sessions.insert(*session_id, session_state);
+    }
+
+    let _ = state.events.send(ServerEvent::SessionUpdated {
+        session_id: session_id_str,
+    });
+
+    Ok(())
+}
+
+/// Transition a resumed session row to `active` and record the new shell/pid.
+/// Split out so the caller can roll back the spawned PTY if this fails.
+async fn mark_session_active_and_pid(
+    state: &Arc<LocalAppState>,
+    session_id_str: &str,
+    shell: &str,
+    pid: u32,
+) -> Result<(), AppError> {
+    zremote_core::queries::sessions::mark_session_active(&state.db, session_id_str).await?;
+    sqlx::query("UPDATE sessions SET shell = ?, pid = ? WHERE id = ?")
+        .bind(shell)
+        .bind(i64::from(pid))
+        .bind(session_id_str)
+        .execute(&state.db)
+        .await?;
+    Ok(())
 }
 
 /// Request body for terminal input.
@@ -387,5 +513,170 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // --- RFC-013 resume-on-attach + REST resume ---
+
+    // tokio Mutex so the guard can be held across `.await` (env mutation must be
+    // serialized for the whole async test body, including DB setup).
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn insert_resumable_agent_session(
+        state: &Arc<LocalAppState>,
+        id: &str,
+        agent_kind: Option<&str>,
+        agent_ref: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO sessions (id, host_id, status, shell, working_dir, agent_kind, agent_session_ref) \
+             VALUES (?, ?, 'resumable', '/bin/sh', '/tmp', ?, ?)",
+        )
+        .bind(id)
+        .bind(state.host_id.to_string())
+        .bind(agent_kind)
+        .bind(agent_ref)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_session_by_id_rejects_non_resumable_session() {
+        // A session with no agent_session_ref cannot be resumed (BadRequest).
+        let state = test_state().await;
+        let id = Uuid::new_v4();
+        insert_resumable_agent_session(&state, &id.to_string(), None, None).await;
+
+        let err = resume_session_by_id(&state, &id).await.unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)), "got {err:?}");
+        // Row stays resumable (not mutated to active on failure).
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM sessions WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        assert_eq!(status, "resumable");
+    }
+
+    #[tokio::test]
+    async fn resume_session_by_id_rejects_non_resumable_status() {
+        // HIGH #1: resume must be rejected (Conflict) for active/closed sessions
+        // so it can't corrupt timestamps or reactivate a closed row.
+        for status in ["active", "closed"] {
+            let state = test_state().await;
+            let id = Uuid::new_v4();
+            // Insert with an agent ref but the wrong status.
+            sqlx::query(
+                "INSERT INTO sessions (id, host_id, status, agent_kind, agent_session_ref) \
+                 VALUES (?, ?, ?, 'claude', 'cc-xyz')",
+            )
+            .bind(id.to_string())
+            .bind(state.host_id.to_string())
+            .bind(status)
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+            let err = resume_session_by_id(&state, &id).await.unwrap_err();
+            assert!(
+                matches!(err, AppError::Conflict(_)),
+                "status {status} should be rejected with Conflict, got {err:?}"
+            );
+            // Status unchanged (no mark_session_active side effect).
+            let (got,): (String,) = sqlx::query_as("SELECT status FROM sessions WHERE id = ?")
+                .bind(id.to_string())
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+            assert_eq!(got, status, "status must be untouched on rejected resume");
+        }
+    }
+
+    #[tokio::test]
+    async fn resume_session_by_id_transitions_resumable_to_active() {
+        // Claude agent session -> resume_argv = ["claude","--resume",..]. The
+        // `claude` binary likely isn't on PATH in CI, so the spawn may fail; in
+        // that case the row must STAY resumable (no false 'active'). When the
+        // spawn does succeed, the row must be 'active' and tracked in memory.
+        let state = test_state().await;
+        let id = Uuid::new_v4();
+        insert_resumable_agent_session(&state, &id.to_string(), Some("claude"), Some("cc-xyz"))
+            .await;
+
+        let result = resume_session_by_id(&state, &id).await;
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM sessions WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        if result.is_ok() {
+            assert_eq!(status, "active");
+            assert!(state.sessions.read().await.contains_key(&id));
+        } else {
+            // Spawn failed (no `claude` on PATH): row must remain resumable.
+            assert_eq!(status, "resumable");
+        }
+    }
+
+    #[tokio::test]
+    async fn register_browser_returns_resumable_when_autoresume_off() {
+        let _guard = ENV_LOCK.lock().await;
+        // SAFETY: serialized by ENV_LOCK; restored at end.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("ZREMOTE_RESUME_AGENTS_ON_RESTART", "false");
+        }
+
+        let state = test_state().await;
+        let id = Uuid::new_v4();
+        insert_resumable_agent_session(&state, &id.to_string(), Some("claude"), Some("cc-xyz"))
+            .await;
+
+        let backend = LocalTerminalBackend {
+            state: state.clone(),
+        };
+        let Err(err) = backend.register_browser(&id).await else {
+            panic!("expected a resumable error, got Ok");
+        };
+        assert!(
+            err.resumable,
+            "expected typed resumable signal, got: {}",
+            err.message
+        );
+        // Row untouched (no resume attempted when the flag is off).
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM sessions WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        assert_eq!(status, "resumable");
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("ZREMOTE_RESUME_AGENTS_ON_RESTART");
+        }
+    }
+
+    #[tokio::test]
+    async fn register_browser_hard_error_for_closed_session() {
+        // A non-resumable, non-live session still yields a hard (non-resumable)
+        // error so the GUI shows the stale/closed message.
+        let state = test_state().await;
+        let id = Uuid::new_v4();
+        sqlx::query("INSERT INTO sessions (id, host_id, status) VALUES (?, ?, 'closed')")
+            .bind(id.to_string())
+            .bind(state.host_id.to_string())
+            .execute(&state.db)
+            .await
+            .unwrap();
+
+        let backend = LocalTerminalBackend {
+            state: state.clone(),
+        };
+        let Err(err) = backend.register_browser(&id).await else {
+            panic!("expected a hard error, got Ok");
+        };
+        assert!(!err.resumable);
+        assert!(err.message.contains("closed"), "got: {}", err.message);
     }
 }

--- a/crates/zremote-agent/src/pty/mod.rs
+++ b/crates/zremote-agent/src/pty/mod.rs
@@ -36,6 +36,7 @@ impl PtySession {
         env: Option<&std::collections::HashMap<String, String>>,
         output_tx: mpsc::Sender<PtyOutput>,
         shell_config: Option<&ShellIntegrationConfig>,
+        resume_argv: Option<&[String]>,
     ) -> Result<(Self, u32, Option<ShellIntegrationState>), Box<dyn std::error::Error + Send + Sync>>
     {
         let pty_system = native_pty_system();
@@ -48,7 +49,18 @@ impl PtySession {
 
         let pair = pty_system.openpty(size)?;
 
-        let mut cmd = CommandBuilder::new(shell);
+        // RFC-013 resume: when `resume_argv` is present, the session's process IS
+        // the agent CLI (e.g. `claude --resume <id>`), spawned directly as
+        // program + args — no shell, no `-c`, no word-splitting, so the native id
+        // is never re-parsed (injection-safe). Otherwise spawn the shell as today.
+        let mut cmd = match resume_argv {
+            Some(argv) if !argv.is_empty() => {
+                let mut c = CommandBuilder::new(&argv[0]);
+                c.args(&argv[1..]);
+                c
+            }
+            _ => CommandBuilder::new(shell),
+        };
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
         if let Some(dir) = working_dir {
@@ -60,11 +72,23 @@ impl PtySession {
             }
         }
 
-        // Apply shell integration (env vars, autosuggestion disabling, etc.)
-        let mut integration_state = if let Some(config) = shell_config {
-            shell_integration::prepare(session_id, shell, config, &mut cmd)?
-        } else {
-            None
+        // Export ZREMOTE_SESSION_ID / ZREMOTE_TERMINAL unconditionally, before
+        // (and independent of) shell integration. RFC-012 native-session capture
+        // requires these on every spawned session — even when shell_config is
+        // None or integration is disabled. `prepare` may re-set the same values
+        // when `export_env_vars` is on; that is harmless (identical values).
+        // For a resume spawn this exports ZREMOTE_SESSION_ID to the agent process
+        // so it re-reports its (possibly new) native id via the hook.
+        shell_integration::set_session_env(session_id, &mut cmd);
+
+        // Apply shell integration (env vars, autosuggestion disabling, etc.).
+        // Skipped for a resume spawn: the process is the agent CLI, not a shell,
+        // so shell-rc integration does not apply.
+        let mut integration_state = match (shell_config, resume_argv) {
+            (Some(config), None) => {
+                shell_integration::prepare(session_id, shell, config, &mut cmd)?
+            }
+            _ => None,
         };
 
         let child = pair.slave.spawn_command(cmd)?;
@@ -205,7 +229,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(64);
         let session_id = uuid::Uuid::new_v4();
         let (session, pid, _) =
-            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None).unwrap();
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
 
         assert!(pid > 0);
         assert_eq!(session.pid(), pid);
@@ -230,6 +254,7 @@ mod tests {
             None,
             tx,
             None,
+            None,
         )
         .unwrap();
 
@@ -242,7 +267,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(256);
         let session_id = uuid::Uuid::new_v4();
         let (mut session, _pid, _) =
-            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None).unwrap();
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
 
         // Write a command to the PTY
         session.write(b"echo hello_from_pty\n").unwrap();
@@ -268,11 +293,162 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn spawn_exports_zremote_session_id_without_shell_config() {
+        // RFC-012: ZREMOTE_SESSION_ID must be exported on EVERY spawn, even when
+        // shell_config is None (no shell integration at all). Prove it end-to-end
+        // by reading the var back from the child shell.
+        let (tx, mut rx) = mpsc::channel(256);
+        let session_id = uuid::Uuid::new_v4();
+        let (mut session, _pid, integration_state) =
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
+
+        // No shell_config -> no integration state returned, but env still set.
+        assert!(
+            integration_state.is_none(),
+            "shell_config None should yield no integration state"
+        );
+
+        session
+            .write(b"printf 'SID=%s\\n' \"$ZREMOTE_SESSION_ID\"\n")
+            .unwrap();
+
+        let expected = format!("SID={session_id}");
+        let mut found = false;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        let mut acc = String::new();
+        while tokio::time::Instant::now() < deadline {
+            if let Ok(Some(output)) =
+                tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await
+            {
+                acc.push_str(&String::from_utf8_lossy(&output.data));
+                if acc.contains(&expected) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found,
+            "child shell should see ZREMOTE_SESSION_ID; got output: {acc:?}"
+        );
+
+        drop(session);
+    }
+
+    async fn read_until(
+        rx: &mut mpsc::Receiver<PtyOutput>,
+        needle: &str,
+        secs: u64,
+    ) -> (bool, String) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(secs);
+        let mut acc = String::new();
+        while tokio::time::Instant::now() < deadline {
+            if let Ok(Some(output)) =
+                tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await
+            {
+                acc.push_str(&String::from_utf8_lossy(&output.data));
+                if acc.contains(needle) {
+                    return (true, acc);
+                }
+            }
+        }
+        (false, acc)
+    }
+
+    #[tokio::test]
+    async fn spawn_with_resume_argv_runs_that_program() {
+        // RFC-013: when resume_argv is present, the PTY child IS that program,
+        // run directly (no shell, no typing into a live shell). Prove it by
+        // having the program print a unique marker on start.
+        let (tx, mut rx) = mpsc::channel(256);
+        let session_id = uuid::Uuid::new_v4();
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf 'RESUMED=%s\\n' ok".to_string(),
+        ];
+        let (session, _pid, integration_state) = PtySession::spawn(
+            session_id,
+            "/bin/zsh",
+            80,
+            24,
+            None,
+            None,
+            tx,
+            None,
+            Some(&argv),
+        )
+        .unwrap();
+
+        // Resume spawn skips shell integration even if a config is passed; here
+        // shell_config is None anyway, so no integration state.
+        assert!(integration_state.is_none());
+
+        let (found, acc) = read_until(&mut rx, "RESUMED=ok", 3).await;
+        assert!(
+            found,
+            "resume_argv program should have run and printed marker; got: {acc:?}"
+        );
+
+        drop(session);
+    }
+
+    #[tokio::test]
+    async fn spawn_with_resume_argv_passes_metachars_as_single_token() {
+        // Injection safety: a native id full of shell metacharacters must be
+        // delivered to the program as ONE literal argv element — no word-split,
+        // no command substitution at the spawn boundary.
+        //
+        // We run `/bin/sh -c 'printf "<<%s>>" "$1"' sh <evil>`: <evil> arrives as
+        // positional $1 and is printed verbatim. If the spawn had shell-parsed it
+        // (word-split / command-substituted), $1 would not equal the literal.
+        // `/bin/sh` is used as the program (NixOS lacks /bin/echo).
+        let (tx, mut rx) = mpsc::channel(256);
+        let session_id = uuid::Uuid::new_v4();
+        let evil = "$(touch /tmp/zremote_pwned); rm -rf / && echo `whoami`";
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf '<<%s>>' \"$1\"".to_string(),
+            "sh".to_string(),
+            evil.to_string(),
+        ];
+        let (session, _pid, _) = PtySession::spawn(
+            session_id,
+            "/bin/sh",
+            80,
+            24,
+            None,
+            None,
+            tx,
+            None,
+            Some(&argv),
+        )
+        .unwrap();
+
+        // The literal string (with all metachars intact) must appear, wrapped in
+        // the markers so we know it came through as the single $1 token.
+        let expected = format!("<<{evil}>>");
+        let (found, acc) = read_until(&mut rx, &expected, 3).await;
+        assert!(
+            found,
+            "metacharacter-laden arg must pass as one literal token (no shell expansion); got: {acc:?}"
+        );
+        // The marker file must NOT have been created by command substitution.
+        assert!(
+            !std::path::Path::new("/tmp/zremote_pwned").exists(),
+            "command substitution must not have executed"
+        );
+
+        drop(session);
+    }
+
+    #[tokio::test]
     async fn resize_session() {
         let (tx, _rx) = mpsc::channel(64);
         let session_id = uuid::Uuid::new_v4();
         let (session, _pid, _) =
-            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None).unwrap();
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
 
         // Resize should succeed
         let result = session.resize(120, 40);
@@ -286,7 +462,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(64);
         let session_id = uuid::Uuid::new_v4();
         let (mut session, _pid, _) =
-            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None).unwrap();
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
 
         session.kill();
 
@@ -306,7 +482,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(64);
         let session_id = uuid::Uuid::new_v4();
         let (session, pid, _) =
-            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None).unwrap();
+            PtySession::spawn(session_id, "/bin/sh", 80, 24, None, None, tx, None, None).unwrap();
 
         assert!(pid > 0);
 

--- a/crates/zremote-agent/src/pty/shell_integration.rs
+++ b/crates/zremote-agent/src/pty/shell_integration.rs
@@ -128,7 +128,7 @@ pub fn prepare(
     let shell_type = ShellType::detect(shell_cmd);
 
     if config.export_env_vars {
-        apply_env_vars(session_id, cmd);
+        set_session_env(session_id, cmd);
     }
 
     let temp_dir = match &shell_type {
@@ -145,7 +145,19 @@ pub fn prepare(
     }))
 }
 
-fn apply_env_vars(session_id: SessionId, cmd: &mut CommandBuilder) {
+/// Set the session-identity env vars (`ZREMOTE_TERMINAL`, `ZREMOTE_SESSION_ID`)
+/// on a spawn command, unconditionally.
+///
+/// Unlike [`prepare`], this is **not** gated on any [`ShellIntegrationConfig`]
+/// flag or on the shell type, and must be called at every PTY spawn site (both
+/// the in-process [`crate::pty::PtySession`] backend and the [`crate::daemon`]
+/// backend). RFC-012's native-session capture path keys off `ZREMOTE_SESSION_ID`
+/// being present in the agent's environment (forwarded as the
+/// `X-ZRemote-Session-Id` hook header); if it is missing, capture silently
+/// fails for that session. Keeping this separate from `prepare` guarantees the
+/// vars are exported even when shell integration is fully disabled or no
+/// `ShellIntegrationConfig` is supplied.
+pub fn set_session_env(session_id: SessionId, cmd: &mut CommandBuilder) {
     cmd.env("ZREMOTE_TERMINAL", "1");
     cmd.env("ZREMOTE_SESSION_ID", session_id.to_string());
 }
@@ -380,6 +392,22 @@ mod tests {
 
         let result = prepare(session_id, "/bin/zsh", &config, &mut cmd).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn set_session_env_sets_both_vars() {
+        let session_id = uuid::Uuid::new_v4();
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        set_session_env(session_id, &mut cmd);
+
+        assert_eq!(
+            cmd.get_env("ZREMOTE_TERMINAL").and_then(|v| v.to_str()),
+            Some("1")
+        );
+        assert_eq!(
+            cmd.get_env("ZREMOTE_SESSION_ID").and_then(|v| v.to_str()),
+            Some(session_id.to_string().as_str())
+        );
     }
 
     #[test]

--- a/crates/zremote-agent/src/session.rs
+++ b/crates/zremote-agent/src/session.rs
@@ -73,6 +73,34 @@ impl SessionManager {
         env: Option<&std::collections::HashMap<String, String>>,
         shell_config: Option<&ShellIntegrationConfig>,
     ) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
+        self.create_inner(
+            session_id,
+            shell,
+            cols,
+            rows,
+            working_dir,
+            env,
+            shell_config,
+            None,
+        )
+        .await
+    }
+
+    /// Shared spawn path for `create` and `resume_session`. When `resume_argv`
+    /// is `Some`, the spawned session's process is that argv directly (RFC-013
+    /// resume) instead of a bare shell; otherwise it spawns the shell as usual.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_inner(
+        &mut self,
+        session_id: SessionId,
+        shell: &str,
+        cols: u16,
+        rows: u16,
+        working_dir: Option<&str>,
+        env: Option<&std::collections::HashMap<String, String>>,
+        shell_config: Option<&ShellIntegrationConfig>,
+        resume_argv: Option<&[String]>,
+    ) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
         // Extract short shell name (e.g., "/bin/zsh" → "zsh") and cache it.
         // This avoids re-deriving via sysinfo on reconnect (which can degrade to "shell").
         let shell_name = std::path::Path::new(shell)
@@ -92,6 +120,7 @@ impl SessionManager {
                     shell_config,
                     &self.socket_dir,
                     Some(&self.agent_instance_id.to_string()),
+                    resume_argv,
                 )
                 .await?;
                 self.sessions
@@ -109,6 +138,7 @@ impl SessionManager {
                     env,
                     self.output_tx.clone(),
                     shell_config,
+                    resume_argv,
                 )?;
                 self.sessions
                     .insert(session_id, SessionBackend::Pty(session));
@@ -119,6 +149,77 @@ impl SessionManager {
                 Ok(pid)
             }
         }
+    }
+
+    /// Resume a stopped agent session (RFC-013) by re-spawning a backend for the
+    /// **same** `session_id` with `resume_argv` (e.g. `claude --resume <id>`) as
+    /// the session's process. Deterministic — the agent IS the session command,
+    /// so there is no shell-readiness race and no "type into a live shell".
+    ///
+    /// Double-launch guard: if a live daemon for this id already exists, this is
+    /// a no-op attach (returns the existing pid) and the resume command is NOT
+    /// run a second time. Stale daemon state files are cleaned up first.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resume_session(
+        &mut self,
+        session_id: SessionId,
+        shell: &str,
+        cols: u16,
+        rows: u16,
+        working_dir: Option<&str>,
+        env: Option<&std::collections::HashMap<String, String>>,
+        shell_config: Option<&ShellIntegrationConfig>,
+        resume_argv: &[String],
+    ) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
+        if resume_argv.is_empty() {
+            return Err("resume_argv must not be empty".into());
+        }
+
+        // Defensive: a stale state file may linger after a reboot. Recreation
+        // overwrites it, but clear known-dead entries first so discovery doesn't
+        // re-adopt a corpse.
+        if self.backend != PersistenceBackend::None {
+            crate::daemon::discovery::cleanup_stale_daemons(&self.socket_dir);
+        }
+
+        // Double-launch guard: if ANY backend for this id is already tracked,
+        // attach instead of relaunching so the resume command runs exactly once.
+        // Guard on `has_session` (covers BOTH Daemon and Pty backends) rather
+        // than `is_daemon_alive` (Daemon-only): with PersistenceBackend::None the
+        // backend is a Pty, so a daemon-only guard would never fire and two
+        // concurrent resume callers (REST + attach) could spawn duplicate agents.
+        //
+        // Atomicity: callers hold the `SessionManager` lock for the whole
+        // `resume_session` call, so this guard check and the `create_inner` spawn
+        // below happen under ONE continuous lock hold — a concurrent REST+WS
+        // resume cannot both pass the guard and double-spawn. Callers must NOT do
+        // a separate has_session/is_daemon_alive pre-check outside the lock.
+        if self.has_session(&session_id) {
+            // Sentinel for "tracked but pid unknown" — `u32::MAX`, never `0`
+            // (POSIX pid 0 means the caller's process group; misleading even
+            // though this value is never passed to kill()).
+            let pid = self
+                .session_pids()
+                .find_map(|(id, pid)| (id == session_id).then_some(pid))
+                .unwrap_or(u32::MAX);
+            tracing::info!(
+                %session_id,
+                "resume requested but a backend for this id already exists; attaching instead of relaunching"
+            );
+            return Ok(pid);
+        }
+
+        self.create_inner(
+            session_id,
+            shell,
+            cols,
+            rows,
+            working_dir,
+            env,
+            shell_config,
+            Some(resume_argv),
+        )
+        .await
     }
 
     /// Write data to a session's stdin.
@@ -378,6 +479,39 @@ fn get_process_name(pid: u32) -> String {
         .unwrap_or_else(|| "shell".to_string())
 }
 
+/// Map a persisted `sessions.agent_kind` string back to an [`AgentKind`].
+/// Mirrors the `snake_case` serde representation (see RFC-012 capture).
+fn agent_kind_from_db(kind: &str) -> zremote_protocol::AgentKind {
+    match kind {
+        "claude" => zremote_protocol::AgentKind::Claude,
+        "codex" => zremote_protocol::AgentKind::Codex,
+        _ => zremote_protocol::AgentKind::Unknown,
+    }
+}
+
+/// Build the resume argv for a session from its persisted agent identity
+/// (RFC-013). Reads `agent_kind` + `agent_session_ref` (RFC-012) and turns them
+/// into the agent's native resume command via [`crate::agents::resume_argv`].
+///
+/// Returns `Ok(None)` when the session has no resumable agent ref or the agent
+/// kind has no known resume command (e.g. `Unknown`). The resulting argv is then
+/// passed to [`SessionManager::resume_session`], which spawns it directly as the
+/// session's process — the native id stays a single argv token (injection-safe).
+pub async fn build_resume_argv_for_session(
+    pool: &sqlx::SqlitePool,
+    session_id: &str,
+) -> Result<Option<Vec<String>>, zremote_core::error::AppError> {
+    let Some((kind, native_id)) =
+        zremote_core::queries::sessions::get_agent_session_ref(pool, session_id).await?
+    else {
+        return Ok(None);
+    };
+    Ok(crate::agents::resume_argv(
+        agent_kind_from_db(&kind),
+        &native_id,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,6 +735,152 @@ mod tests {
         }
         // If create failed (no PTY available), closing nonexistent is fine
         assert!(mgr.close(&session_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn resume_session_rejects_empty_argv() {
+        let mut mgr = make_manager();
+        let session_id = Uuid::new_v4();
+        let result = mgr
+            .resume_session(session_id, "/bin/sh", 80, 24, None, None, None, &[])
+            .await;
+        assert!(result.is_err(), "empty resume_argv must be rejected");
+        assert!(!mgr.has_session(&session_id));
+    }
+
+    #[tokio::test]
+    async fn resume_session_spawns_session_for_same_id() {
+        // None backend (PTY). resume_session re-creates a backend for the given
+        // id with the resume argv as the process. Reuses the same session id.
+        let mut mgr = make_manager();
+        let session_id = Uuid::new_v4();
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "sleep 1".to_string(),
+        ];
+        if mgr
+            .resume_session(session_id, "/bin/sh", 80, 24, None, None, None, &argv)
+            .await
+            .is_ok()
+        {
+            assert!(
+                mgr.has_session(&session_id),
+                "resumed session must be tracked under the same id"
+            );
+            let _ = mgr.close(&session_id);
+            assert!(!mgr.has_session(&session_id));
+        }
+    }
+
+    #[tokio::test]
+    async fn resume_session_does_not_double_spawn_on_pty_backend() {
+        // Regression (review finding): the double-launch guard must cover the
+        // None/Pty backend, not just Daemon. A second resume_session for an
+        // already-tracked id must NOT create a second backend — it attaches.
+        let mut mgr = make_manager(); // None backend -> Pty
+        let session_id = Uuid::new_v4();
+        let argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "sleep 5".to_string(),
+        ];
+
+        // First resume spawns the backend. If the env can't spawn a PTY at all,
+        // skip (nothing to guard against).
+        if mgr
+            .resume_session(session_id, "/bin/sh", 80, 24, None, None, None, &argv)
+            .await
+            .is_err()
+        {
+            return;
+        }
+        assert!(mgr.has_session(&session_id));
+        assert_eq!(mgr.count(), 1);
+
+        // Second resume for the SAME id must be a no-op attach: still exactly one
+        // backend, no duplicate process.
+        mgr.resume_session(session_id, "/bin/sh", 80, 24, None, None, None, &argv)
+            .await
+            .expect("second resume should attach, not error");
+        assert_eq!(
+            mgr.count(),
+            1,
+            "second resume must not spawn a second backend for the same id"
+        );
+
+        let _ = mgr.close(&session_id);
+    }
+
+    async fn db_with_session(
+        session_id: &str,
+        kind: Option<&str>,
+        native: Option<&str>,
+    ) -> sqlx::SqlitePool {
+        let pool = zremote_core::db::init_db("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "INSERT INTO hosts (id, name, hostname, auth_token_hash, status) \
+             VALUES ('h1', 'h1', 'h1', 'hash', 'online')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO sessions (id, host_id, status, agent_kind, agent_session_ref) VALUES (?, 'h1', 'resumable', ?, ?)")
+            .bind(session_id)
+            .bind(kind)
+            .bind(native)
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn build_resume_argv_claude_session() {
+        let pool = db_with_session("s1", Some("claude"), Some("cc-abc")).await;
+        let argv = build_resume_argv_for_session(&pool, "s1").await.unwrap();
+        // resume_argv(Claude, "cc-abc") = ["claude", "--resume", "cc-abc"]
+        let argv = argv.expect("claude session should yield resume argv");
+        assert_eq!(argv.first().map(String::as_str), Some("claude"));
+        assert!(argv.iter().any(|a| a == "cc-abc"));
+        // Native id is its own token (not concatenated into another arg).
+        assert!(argv.contains(&"cc-abc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn build_resume_argv_none_without_ref() {
+        // Session with no agent_session_ref -> no resume argv.
+        let pool = db_with_session("s1", None, None).await;
+        assert_eq!(
+            build_resume_argv_for_session(&pool, "s1").await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn build_resume_argv_none_for_unknown_kind() {
+        // Unknown agent kind has no known resume command.
+        let pool = db_with_session("s1", Some("future_agent"), Some("xyz")).await;
+        assert_eq!(
+            build_resume_argv_for_session(&pool, "s1").await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn build_resume_argv_native_id_stays_single_token() {
+        // Injection safety at the argv-building layer: a metachar-laden native id
+        // must remain exactly one argv element.
+        let evil = "$(touch pwned); rm -rf /";
+        let pool = db_with_session("s1", Some("claude"), Some(evil)).await;
+        let argv = build_resume_argv_for_session(&pool, "s1")
+            .await
+            .unwrap()
+            .expect("claude yields argv");
+        assert!(
+            argv.iter().any(|a| a == evil),
+            "native id must be a single un-split argv token; got {argv:?}"
+        );
     }
 
     #[test]

--- a/crates/zremote-client/src/client.rs
+++ b/crates/zremote-client/src/client.rs
@@ -329,6 +329,28 @@ impl ApiClient {
         Ok(resp.json().await?)
     }
 
+    /// Resume a `resumable` agent session (RFC-013). Re-spawns the agent for the
+    /// SAME session id and returns the re-created (active) session.
+    #[must_use = "session resume returns the re-created session"]
+    pub async fn resume_session(
+        &self,
+        host_id: &str,
+        session_id: &str,
+    ) -> Result<Session, ApiError> {
+        let resp = self
+            .client
+            .post(format!(
+                "{}/api/hosts/{}/sessions/{}/resume",
+                self.base_url,
+                encode_path(host_id),
+                encode_path(session_id)
+            ))
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     /// Update a session.
     #[must_use = "session update returns the updated session"]
     pub async fn update_session(

--- a/crates/zremote-client/src/terminal.rs
+++ b/crates/zremote-client/src/terminal.rs
@@ -345,6 +345,9 @@ async fn run_terminal_ws(
                             Ok(TerminalServerMessage::SessionResumed) => {
                                 let _ = output_tx.send(TerminalEvent::SessionResumed);
                             }
+                            Ok(TerminalServerMessage::SessionResumable) => {
+                                let _ = output_tx.send(TerminalEvent::SessionResumable);
+                            }
                             Ok(TerminalServerMessage::PaneAdded { pane_id, index }) => {
                                 let _ = output_tx
                                     .send(TerminalEvent::PaneAdded { pane_id, index });

--- a/crates/zremote-client/src/types.rs
+++ b/crates/zremote-client/src/types.rs
@@ -239,6 +239,8 @@ pub(crate) enum TerminalServerMessage {
     SessionSuspended,
     #[serde(rename = "session_resumed")]
     SessionResumed,
+    #[serde(rename = "session_resumable")]
+    SessionResumable,
     #[serde(rename = "pane_added")]
     PaneAdded { pane_id: String, index: u16 },
     #[serde(rename = "pane_removed")]
@@ -291,6 +293,9 @@ pub enum TerminalEvent {
     SessionSuspended,
     /// Session was resumed (agent reconnected).
     SessionResumed,
+    /// RFC-013: the session is `resumable` but auto-resume is off — the GUI
+    /// should render a "Continue" affordance that triggers an explicit resume.
+    SessionResumable,
     /// Server-side error (session not found, stale, etc.)
     Error { message: String },
     /// WebSocket connection lost (session may still be alive on the server).

--- a/crates/zremote-core/migrations/029_agent_session_ref.sql
+++ b/crates/zremote-core/migrations/029_agent_session_ref.sql
@@ -1,0 +1,6 @@
+-- Durable record of an agent's native session id for a managed session.
+-- Populated when AgentSessionRefCaptured is processed. RFC-013 reads this row
+-- to build the resume command for a stopped agent.
+ALTER TABLE sessions ADD COLUMN agent_kind TEXT;               -- 'claude' | 'codex' | NULL
+ALTER TABLE sessions ADD COLUMN agent_session_ref TEXT;        -- native session id (opaque)
+ALTER TABLE sessions ADD COLUMN agent_session_updated_at TEXT; -- ISO 8601 (RFC 3339)

--- a/crates/zremote-core/src/processing/agentic.rs
+++ b/crates/zremote-core/src/processing/agentic.rs
@@ -216,7 +216,51 @@ impl AgenticProcessor {
             AgenticAgentMessage::SessionExecutionStopped { session_id } => {
                 self.handle_session_execution_stopped(session_id).await?;
             }
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent,
+                native_session_id,
+            } => {
+                self.handle_agent_session_ref_captured(session_id, agent, native_session_id)
+                    .await?;
+            }
         }
+        Ok(())
+    }
+
+    /// Persist an agent's native session id (Claude `cc_session_id`, Codex
+    /// rollout id, ...) for a managed session. This is the durable record
+    /// RFC-013 reads to resume a stopped agent. Persistence-only: no broadcast
+    /// event is emitted in this phase.
+    ///
+    /// `native_session_id` is opaque — it is only bound as a SQL parameter,
+    /// never interpreted as shell text.
+    async fn handle_agent_session_ref_captured(
+        &self,
+        session_id: zremote_protocol::SessionId,
+        agent: zremote_protocol::AgentKind,
+        native_session_id: String,
+    ) -> Result<(), AppError> {
+        let session_id_str = session_id.to_string();
+        let agent_kind = agent.as_str();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        crate::queries::sessions::set_agent_session_ref(
+            &self.db,
+            &session_id_str,
+            agent_kind,
+            &native_session_id,
+            &now,
+        )
+        .await?;
+
+        tracing::info!(
+            host_id = %self.host_id,
+            session_id = %session_id,
+            agent = %agent_kind,
+            "captured agent native session ref"
+        );
+
         Ok(())
     }
 
@@ -2024,5 +2068,95 @@ mod tests {
             created_count, 1,
             "exactly one ExecutionNodeCreated event must fire even on duplicate PreToolUse"
         );
+    }
+
+    #[tokio::test]
+    async fn handle_agent_session_ref_captured_persists_to_session_row() {
+        let db = test_db().await;
+        let proc = make_processor(db.clone());
+        let host_id_str = proc.host_id.to_string();
+        insert_host(&db, &host_id_str).await;
+
+        let session_id = Uuid::new_v4();
+        insert_session(&db, &session_id.to_string(), &host_id_str).await;
+
+        proc.handle_message(AgenticAgentMessage::AgentSessionRefCaptured {
+            session_id,
+            agent: zremote_protocol::AgentKind::Claude,
+            native_session_id: "cc-native-123".to_string(),
+        })
+        .await
+        .unwrap();
+
+        let (agent_kind, agent_ref, updated_at): (Option<String>, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT agent_kind, agent_session_ref, agent_session_updated_at \
+                 FROM sessions WHERE id = ?",
+            )
+            .bind(session_id.to_string())
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(agent_kind.as_deref(), Some("claude"));
+        assert_eq!(agent_ref.as_deref(), Some("cc-native-123"));
+        assert!(
+            updated_at.is_some(),
+            "agent_session_updated_at should be set"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_agent_session_ref_captured_stores_codex_kind() {
+        let db = test_db().await;
+        let proc = make_processor(db.clone());
+        let host_id_str = proc.host_id.to_string();
+        insert_host(&db, &host_id_str).await;
+
+        let session_id = Uuid::new_v4();
+        insert_session(&db, &session_id.to_string(), &host_id_str).await;
+
+        proc.handle_message(AgenticAgentMessage::AgentSessionRefCaptured {
+            session_id,
+            agent: zremote_protocol::AgentKind::Codex,
+            native_session_id: "rollout-abc".to_string(),
+        })
+        .await
+        .unwrap();
+
+        let (agent_kind, agent_ref): (Option<String>, Option<String>) =
+            sqlx::query_as("SELECT agent_kind, agent_session_ref FROM sessions WHERE id = ?")
+                .bind(session_id.to_string())
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(agent_kind.as_deref(), Some("codex"));
+        assert_eq!(agent_ref.as_deref(), Some("rollout-abc"));
+    }
+
+    #[tokio::test]
+    async fn handle_agent_session_ref_captured_unknown_agent_stores_unknown() {
+        let db = test_db().await;
+        let proc = make_processor(db.clone());
+        let host_id_str = proc.host_id.to_string();
+        insert_host(&db, &host_id_str).await;
+
+        let session_id = Uuid::new_v4();
+        insert_session(&db, &session_id.to_string(), &host_id_str).await;
+
+        proc.handle_message(AgenticAgentMessage::AgentSessionRefCaptured {
+            session_id,
+            agent: zremote_protocol::AgentKind::Unknown,
+            native_session_id: "ref".to_string(),
+        })
+        .await
+        .unwrap();
+
+        let (agent_kind,): (Option<String>,) =
+            sqlx::query_as("SELECT agent_kind FROM sessions WHERE id = ?")
+                .bind(session_id.to_string())
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(agent_kind.as_deref(), Some("unknown"));
     }
 }

--- a/crates/zremote-core/src/queries/claude_sessions.rs
+++ b/crates/zremote-core/src/queries/claude_sessions.rs
@@ -153,6 +153,13 @@ pub async fn insert_claude_task(
     Ok(())
 }
 
+/// Insert a NEW `claude_sessions` row for a resumed task (server mode only).
+///
+/// RFC-013: LOCAL mode no longer creates a new row on resume — it updates the
+/// existing row in place via [`resume_claude_task_in_place`] (decisions E/4),
+/// reusing the same terminal session id. Server mode still uses this new-row
+/// path (`zremote-server/src/routes/claude_sessions.rs`), so this function and
+/// its `_creates_entry` test are intentionally kept.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_resumed_claude_task(
     pool: &SqlitePool,
@@ -185,6 +192,39 @@ pub async fn insert_resumed_claude_task(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+/// Resume a Claude task IN PLACE (RFC-013, decisions E/F/4).
+///
+/// Unlike [`insert_resumed_claude_task`] (which created a NEW row per resume),
+/// this reuses the existing `claude_sessions` row and its terminal `session_id`,
+/// so total cost/tokens keep accumulating on the single row. Sets the row back
+/// to a running state (`starting`), clears the terminal timestamps
+/// (`ended_at`, `disconnect_reason`), and refreshes `model`/`initial_prompt`/
+/// `options_json` from the resume request (last-wins). Returns the number of
+/// rows updated (0 if the task id no longer exists).
+pub async fn resume_claude_task_in_place(
+    pool: &SqlitePool,
+    task_id: &str,
+    model: Option<&str>,
+    initial_prompt: Option<&str>,
+    options_json: Option<&str>,
+) -> Result<u64, AppError> {
+    let result = sqlx::query(
+        "UPDATE claude_sessions \
+         SET status = 'starting', ended_at = NULL, disconnect_reason = NULL, summary = NULL, \
+             model = COALESCE(?, model), \
+             initial_prompt = ?, \
+             options_json = COALESCE(?, options_json) \
+         WHERE id = ?",
+    )
+    .bind(model)
+    .bind(initial_prompt)
+    .bind(options_json)
+    .bind(task_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
 }
 
 /// Update real-time metrics for a Claude session from status line data.
@@ -654,6 +694,75 @@ mod tests {
         assert_eq!(task.claude_session_id, Some("cc-session-123".to_string()));
         assert_eq!(task.status, "starting");
         assert_eq!(task.initial_prompt, Some("continue".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resume_claude_task_in_place_updates_existing_row() {
+        // RFC-013: in-place resume reuses the SAME task row (no new row), so the
+        // task id and session_id are unchanged; status returns to running and the
+        // prompt/options are refreshed.
+        let pool = test_db().await;
+        let host_id = "host-1";
+        insert_host(&pool, host_id).await;
+        insert_session(&pool, "sess-orig", host_id).await;
+
+        insert_claude_task(
+            &pool,
+            "task-1",
+            "sess-orig",
+            host_id,
+            "/proj",
+            None,
+            Some("sonnet"),
+            Some("first prompt"),
+            Some(r#"{"skip_permissions":true}"#),
+        )
+        .await
+        .unwrap();
+        // Simulate the task having finished.
+        sqlx::query(
+            "UPDATE claude_sessions SET status = 'completed', ended_at = '2026-06-04T09:00:00Z' WHERE id = 'task-1'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let updated = resume_claude_task_in_place(
+            &pool,
+            "task-1",
+            None,                  // keep existing model (COALESCE)
+            Some("second prompt"), // new follow-up prompt
+            None,                  // keep existing options (COALESCE)
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated, 1);
+
+        let task = get_claude_task(&pool, "task-1").await.unwrap();
+        // Same row: id + session_id unchanged.
+        assert_eq!(task.id, "task-1");
+        assert_eq!(task.session_id, "sess-orig");
+        // Back to running, terminal stamps cleared, prompt refreshed.
+        assert_eq!(task.status, "starting");
+        assert_eq!(task.ended_at, None);
+        assert_eq!(task.initial_prompt, Some("second prompt".to_string()));
+        // COALESCE preserved model + options.
+        assert_eq!(task.model, Some("sonnet".to_string()));
+        assert_eq!(
+            task.options_json,
+            Some(r#"{"skip_permissions":true}"#.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_claude_task_in_place_noop_for_missing_task() {
+        let pool = test_db().await;
+        let host_id = "host-1";
+        insert_host(&pool, host_id).await;
+        let updated = resume_claude_task_in_place(&pool, "nonexistent", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(updated, 0);
     }
 
     #[tokio::test]

--- a/crates/zremote-core/src/queries/sessions.rs
+++ b/crates/zremote-core/src/queries/sessions.rs
@@ -164,12 +164,82 @@ pub async fn list_suspended_session_ids(
 
 pub async fn force_close_session(pool: &SqlitePool, session_id: &str) -> Result<(), AppError> {
     let now = chrono::Utc::now().to_rfc3339();
+    force_close_session_at(pool, session_id, &now).await
+}
+
+/// Like [`force_close_session`] but with a caller-supplied `closed_at`
+/// timestamp, so a batch (e.g. startup recovery) can stamp every closed row with
+/// the same instant.
+pub async fn force_close_session_at(
+    pool: &SqlitePool,
+    session_id: &str,
+    closed_at: &str,
+) -> Result<(), AppError> {
     sqlx::query("UPDATE sessions SET status = 'closed', closed_at = ? WHERE id = ?")
-        .bind(&now)
+        .bind(closed_at)
         .bind(session_id)
         .execute(pool)
         .await?;
     Ok(())
+}
+
+/// List ALL suspended sessions for a host, each paired with its (possibly null)
+/// `agent_session_ref` (RFC-012). The query does NOT filter by a non-null ref —
+/// the caller inspects the `Option` to decide. Named for the column it returns,
+/// not a filter, to avoid implying only agent sessions come back.
+///
+/// Used by startup recovery to classify a session whose daemon did not survive
+/// the restart: `Some(ref)` means the row backs an agent conversation we can
+/// re-open (-> `resumable`); `None` is a plain session (-> `closed`).
+pub async fn list_suspended_sessions_with_optional_agent_ref(
+    pool: &SqlitePool,
+    host_id: &str,
+) -> Result<Vec<(String, Option<String>)>, AppError> {
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+        "SELECT id, agent_session_ref FROM sessions \
+         WHERE host_id = ? AND status = 'suspended'",
+    )
+    .bind(host_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Mark a session as `resumable` (RFC-013): its backend did not survive an
+/// agent restart, but it can be re-opened. The row stays listed
+/// (`list_sessions` includes everything `!= 'closed'`) and attach drives the
+/// resume engine. `suspended_at` is preserved as the time the backend went away.
+pub async fn mark_session_resumable(pool: &SqlitePool, session_id: &str) -> Result<(), AppError> {
+    sqlx::query("UPDATE sessions SET status = 'resumable' WHERE id = ?")
+        .bind(session_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Reconcile a Claude task whose backing terminal session just became
+/// `resumable` on startup (RFC-013 "Claude-task reconciliation").
+///
+/// Without this, the `claude_sessions` row stays `active`/`starting` and the
+/// sidebar shows a task that maps to a now-dead `session_id` — the "shows but
+/// cannot continue" symptom. We move it to `suspended` with a `disconnect_reason`,
+/// mirroring the existing agent-disconnect reconciliation (a suspended Claude
+/// task is the established "alive but not running, can be resumed" state). Only
+/// rows in a live state (`starting`/`active`) are touched, so terminal tasks
+/// (`completed`/`error`) are left intact. Returns the number of rows updated.
+pub async fn reconcile_claude_session_resumable(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> Result<u64, AppError> {
+    let result = sqlx::query(
+        "UPDATE claude_sessions \
+         SET status = 'suspended', disconnect_reason = 'agent_restarted' \
+         WHERE session_id = ? AND status IN ('starting', 'active')",
+    )
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
 }
 
 pub async fn list_sessions_by_project(
@@ -216,6 +286,72 @@ pub async fn list_active_sessions_under_path(
     .fetch_all(pool)
     .await?;
     Ok(sessions)
+}
+
+/// Persist an agent's native session id for a managed session.
+///
+/// Records which agent CLI (`agent_kind`, e.g. `claude` / `codex`) produced
+/// `native_session_id` and when it was last observed (`now`, ISO 8601). This
+/// row is the durable record RFC-013 reads to build the resume command. The
+/// caller supplies `now` so the timestamp source is explicit (mirrors how
+/// `mark_session_error`/`force_close_session` mint their own `rfc3339`).
+///
+/// The `native_session_id` is treated as opaque data — it is only ever bound
+/// as a parameter, never interpolated into SQL or shell text.
+pub async fn set_agent_session_ref(
+    pool: &SqlitePool,
+    session_id: &str,
+    agent_kind: &str,
+    native_session_id: &str,
+    now: &str,
+) -> Result<(), AppError> {
+    sqlx::query(
+        "UPDATE sessions \
+         SET agent_kind = ?, agent_session_ref = ?, agent_session_updated_at = ? \
+         WHERE id = ?",
+    )
+    .bind(agent_kind)
+    .bind(native_session_id)
+    .bind(now)
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Read the persisted agent identity for a session (RFC-012/013).
+///
+/// Returns `Some((agent_kind, agent_session_ref))` only when BOTH columns are
+/// non-null — i.e. the session backs an agent conversation that can be resumed.
+/// Returns `None` for a plain session or one that never captured a native id.
+/// The resume engine maps `agent_kind` back to an `AgentKind` and builds the
+/// resume argv from `agent_session_ref`.
+pub async fn get_agent_session_ref(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> Result<Option<(String, String)>, AppError> {
+    let row: Option<(Option<String>, Option<String>)> =
+        sqlx::query_as("SELECT agent_kind, agent_session_ref FROM sessions WHERE id = ?")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(kind, native)| Some((kind?, native?))))
+}
+
+/// Transition a session to `active` after a successful resume (RFC-013).
+///
+/// Clears `suspended_at` and `closed_at` so a previously `resumable` row looks
+/// like a normal live session again. The same `sessions.id` is reused, so GUI
+/// handles and any `claude_sessions` linkage stay stable.
+pub async fn mark_session_active(pool: &SqlitePool, session_id: &str) -> Result<(), AppError> {
+    sqlx::query(
+        "UPDATE sessions SET status = 'active', suspended_at = NULL, closed_at = NULL \
+         WHERE id = ?",
+    )
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(())
 }
 
 /// Mark a session row as errored.
@@ -343,5 +479,298 @@ mod tests {
         // StartFailed handler can tolerate agent-side rejections that
         // happened before the server committed the session row.
         mark_session_error(&pool, "nonexistent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn migration_029_adds_agent_session_ref_columns() {
+        // Guard that migration 029 applied and the three new columns exist on
+        // `sessions`. A bare SELECT of the columns errors if any is missing.
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+        let row: (Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT agent_kind, agent_session_ref, agent_session_updated_at \
+             FROM sessions WHERE id = 's1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // Newly inserted session has no agent ref yet.
+        assert_eq!(row, (None, None, None));
+    }
+
+    #[tokio::test]
+    async fn set_agent_session_ref_persists_values() {
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+
+        set_agent_session_ref(
+            &pool,
+            "s1",
+            "claude",
+            "cc-native-abc",
+            "2026-06-04T10:00:00Z",
+        )
+        .await
+        .unwrap();
+
+        let row: (Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT agent_kind, agent_session_ref, agent_session_updated_at \
+             FROM sessions WHERE id = 's1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some("claude"));
+        assert_eq!(row.1.as_deref(), Some("cc-native-abc"));
+        assert_eq!(row.2.as_deref(), Some("2026-06-04T10:00:00Z"));
+    }
+
+    #[tokio::test]
+    async fn set_agent_session_ref_overwrites_previous_values() {
+        // A later capture (e.g. agent reconnect) must replace the stored ref.
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+
+        set_agent_session_ref(&pool, "s1", "claude", "first", "2026-06-04T10:00:00Z")
+            .await
+            .unwrap();
+        set_agent_session_ref(&pool, "s1", "codex", "second", "2026-06-04T11:00:00Z")
+            .await
+            .unwrap();
+
+        let row: (Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT agent_kind, agent_session_ref, agent_session_updated_at \
+             FROM sessions WHERE id = 's1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some("codex"));
+        assert_eq!(row.1.as_deref(), Some("second"));
+        assert_eq!(row.2.as_deref(), Some("2026-06-04T11:00:00Z"));
+    }
+
+    #[tokio::test]
+    async fn set_agent_session_ref_is_noop_for_missing_row() {
+        // UPDATE affecting 0 rows returns Ok so the processing path can tolerate
+        // a capture for a session that was purged/closed concurrently.
+        let pool = setup().await;
+        set_agent_session_ref(&pool, "nonexistent", "claude", "x", "2026-06-04T10:00:00Z")
+            .await
+            .unwrap();
+    }
+
+    async fn insert_suspended_session(
+        pool: &SqlitePool,
+        id: &str,
+        agent_session_ref: Option<&str>,
+    ) {
+        insert_session(pool, id, "h1", None, None, None)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE sessions SET status = 'suspended', agent_session_ref = ? WHERE id = ?")
+            .bind(agent_session_ref)
+            .bind(id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_suspended_sessions_with_optional_agent_ref_returns_only_suspended() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s_agent", Some("cc-123")).await;
+        insert_suspended_session(&pool, "s_plain", None).await;
+        // An active session must NOT appear.
+        insert_session(&pool, "s_active", "h1", None, None, None)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE sessions SET status = 'active' WHERE id = 's_active'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut rows = list_suspended_sessions_with_optional_agent_ref(&pool, "h1")
+            .await
+            .unwrap();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "s_agent");
+        assert_eq!(rows[0].1.as_deref(), Some("cc-123"));
+        assert_eq!(rows[1].0, "s_plain");
+        assert_eq!(rows[1].1, None);
+    }
+
+    #[tokio::test]
+    async fn mark_session_resumable_sets_status() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", Some("cc-123")).await;
+
+        mark_session_resumable(&pool, "s1").await.unwrap();
+
+        let row = get_session(&pool, "s1").await.unwrap();
+        assert_eq!(row.status, "resumable");
+        // A resumable session is NOT closed, so it stays in list_sessions.
+        let listed = list_sessions(&pool, "h1").await.unwrap();
+        assert!(listed.iter().any(|s| s.id == "s1"));
+    }
+
+    #[tokio::test]
+    async fn force_close_session_at_uses_supplied_timestamp() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", None).await;
+
+        force_close_session_at(&pool, "s1", "2026-06-04T09:00:00Z")
+            .await
+            .unwrap();
+
+        let row = get_session(&pool, "s1").await.unwrap();
+        assert_eq!(row.status, "closed");
+        assert_eq!(row.closed_at.as_deref(), Some("2026-06-04T09:00:00Z"));
+    }
+
+    async fn insert_claude_task(pool: &SqlitePool, id: &str, session_id: &str, status: &str) {
+        sqlx::query(
+            "INSERT INTO claude_sessions (id, session_id, host_id, project_path, status) \
+             VALUES (?, ?, 'h1', '/proj', ?)",
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_session_resumable_suspends_live_task() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", Some("cc-123")).await;
+        insert_claude_task(&pool, "t1", "s1", "active").await;
+
+        let updated = reconcile_claude_session_resumable(&pool, "s1")
+            .await
+            .unwrap();
+        assert_eq!(updated, 1);
+
+        let (status, reason): (String, Option<String>) =
+            sqlx::query_as("SELECT status, disconnect_reason FROM claude_sessions WHERE id = 't1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "suspended");
+        assert_eq!(reason.as_deref(), Some("agent_restarted"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_session_resumable_reconciles_starting_task() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", Some("cc-123")).await;
+        insert_claude_task(&pool, "t1", "s1", "starting").await;
+
+        let updated = reconcile_claude_session_resumable(&pool, "s1")
+            .await
+            .unwrap();
+        assert_eq!(updated, 1);
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM claude_sessions WHERE id = 't1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "suspended");
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_session_resumable_leaves_terminal_task_untouched() {
+        // A completed/error Claude task must not be revived into 'suspended'.
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", Some("cc-123")).await;
+        insert_claude_task(&pool, "t1", "s1", "completed").await;
+
+        let updated = reconcile_claude_session_resumable(&pool, "s1")
+            .await
+            .unwrap();
+        assert_eq!(updated, 0);
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM claude_sessions WHERE id = 't1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "completed");
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_session_resumable_noop_without_linked_task() {
+        let pool = setup().await;
+        insert_suspended_session(&pool, "s1", Some("cc-123")).await;
+
+        let updated = reconcile_claude_session_resumable(&pool, "s1")
+            .await
+            .unwrap();
+        assert_eq!(updated, 0);
+    }
+
+    #[tokio::test]
+    async fn get_agent_session_ref_returns_pair_when_both_set() {
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+        set_agent_session_ref(&pool, "s1", "claude", "cc-123", "2026-06-04T10:00:00Z")
+            .await
+            .unwrap();
+
+        let got = get_agent_session_ref(&pool, "s1").await.unwrap();
+        assert_eq!(got, Some(("claude".to_string(), "cc-123".to_string())));
+    }
+
+    #[tokio::test]
+    async fn get_agent_session_ref_none_when_unset() {
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+        // Never captured -> both columns null -> None.
+        assert_eq!(get_agent_session_ref(&pool, "s1").await.unwrap(), None);
+        // Missing row -> None.
+        assert_eq!(
+            get_agent_session_ref(&pool, "nonexistent").await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_session_active_transitions_resumable_and_clears_timestamps() {
+        let pool = setup().await;
+        insert_session(&pool, "s1", "h1", None, None, None)
+            .await
+            .unwrap();
+        // Put it in resumable with stale suspended/closed timestamps.
+        sqlx::query(
+            "UPDATE sessions SET status = 'resumable', suspended_at = '2026-06-04T08:00:00Z', \
+             closed_at = '2026-06-04T08:30:00Z' WHERE id = 's1'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        mark_session_active(&pool, "s1").await.unwrap();
+
+        let (status, suspended_at, closed_at): (String, Option<String>, Option<String>) =
+            sqlx::query_as("SELECT status, suspended_at, closed_at FROM sessions WHERE id = 's1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "active");
+        assert_eq!(suspended_at, None);
+        assert_eq!(closed_at, None);
     }
 }

--- a/crates/zremote-core/src/state.rs
+++ b/crates/zremote-core/src/state.rs
@@ -146,6 +146,11 @@ pub enum BrowserMessage {
     SessionSuspended,
     #[serde(rename = "session_resumed")]
     SessionResumed,
+    /// RFC-013: the session is `resumable` but auto-resume is off, so the agent
+    /// did NOT relaunch. The GUI renders a "Continue" affordance that triggers an
+    /// explicit resume instead of showing a dead terminal.
+    #[serde(rename = "session_resumable")]
+    SessionResumable,
     #[serde(rename = "error")]
     Error { message: String },
     #[serde(rename = "scrollback_start")]

--- a/crates/zremote-core/src/terminal_ws.rs
+++ b/crates/zremote-core/src/terminal_ws.rs
@@ -52,6 +52,30 @@ pub struct RegistrationResult {
 /// Error message returned when a session cannot be connected.
 pub struct SessionError {
     pub message: String,
+    /// RFC-013: set when the session is `resumable` but auto-resume is off.
+    /// The WS handler then sends a typed `session_resumable` message instead of
+    /// a hard `error`, so the GUI can offer an explicit "Continue" action.
+    pub resumable: bool,
+}
+
+impl SessionError {
+    /// A hard, non-resumable error (session missing/closed/stale).
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            resumable: false,
+        }
+    }
+
+    /// A non-fatal "session is resumable, click to continue" signal (RFC-013).
+    #[must_use]
+    pub fn resumable(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            resumable: true,
+        }
+    }
 }
 
 /// Abstracts the differences between server and local terminal backends.
@@ -99,13 +123,15 @@ pub async fn handle_terminal_websocket<B: TerminalBackend>(
     let registration = match backend.register_browser(&session_id).await {
         Ok(r) => r,
         Err(e) => {
-            let error_msg = serde_json::json!({
-                "type": "error",
-                "message": e.message
-            });
-            let _ = socket
-                .send(Message::Text(error_msg.to_string().into()))
-                .await;
+            // RFC-013: a resumable session (auto-resume off) is not a hard error;
+            // send a typed `session_resumable` so the GUI offers "Continue".
+            let payload = if e.resumable {
+                serde_json::to_string(&BrowserMessage::SessionResumable)
+                    .unwrap_or_else(|_| r#"{"type":"session_resumable"}"#.to_string())
+            } else {
+                serde_json::json!({ "type": "error", "message": e.message }).to_string()
+            };
+            let _ = socket.send(Message::Text(payload.into())).await;
             let _ = socket.send(Message::Close(None)).await;
             return;
         }

--- a/crates/zremote-gui/assets/icons/play.svg
+++ b/crates/zremote-gui/assets/icons/play.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polygon points="6 3 20 12 6 21 6 3" />
+</svg>

--- a/crates/zremote-gui/src/icons.rs
+++ b/crates/zremote-gui/src/icons.rs
@@ -36,6 +36,7 @@ pub enum Icon {
     RefreshCw,
     CircleSlash,
     AlertCircle,
+    Play,
 }
 
 impl Icon {
@@ -75,6 +76,7 @@ impl Icon {
             Self::RefreshCw => "icons/refresh-cw.svg",
             Self::CircleSlash => "icons/circle-slash.svg",
             Self::AlertCircle => "icons/alert-circle.svg",
+            Self::Play => "icons/play.svg",
         }
     }
 }

--- a/crates/zremote-gui/src/views/main_view.rs
+++ b/crates/zremote-gui/src/views/main_view.rs
@@ -1446,6 +1446,49 @@ impl MainView {
                     cx.notify();
                 });
             }
+            TerminalPanelEvent::ResumeRequested { session_id } => {
+                // RFC-013 click-to-continue: POST the resume endpoint, then
+                // reconnect the terminal on success. On failure, surface a
+                // recoverable inline error on the panel (row stays resumable).
+                let api = self.app_state.api.clone();
+                let handle = self.app_state.tokio_handle.clone();
+                let host_id = self.current_host_id.clone().unwrap_or_default();
+                let sid = session_id.clone();
+                let terminal = terminal.clone();
+                let app_state = self.app_state.clone();
+                cx.spawn(async move |_this: WeakEntity<Self>, cx: &mut AsyncApp| {
+                    let host_for_call = host_id.clone();
+                    let sid_for_call = sid.clone();
+                    let result = handle
+                        .spawn(
+                            async move { api.resume_session(&host_for_call, &sid_for_call).await },
+                        )
+                        .await;
+                    let _ = terminal.update(cx, |panel, cx| match result {
+                        Ok(Ok(_session)) => {
+                            if let Some(new_handle) =
+                                connect_terminal(&app_state, &sid, &host_id, false)
+                            {
+                                panel.reconnect(new_handle, &app_state.tokio_handle, cx);
+                            } else {
+                                panel.set_resume_error(
+                                    "could not open terminal connection".to_string(),
+                                    cx,
+                                );
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(error = %e, "session resume failed");
+                            panel.set_resume_error(e.to_string(), cx);
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "session resume task join failed");
+                            panel.set_resume_error("resume task failed".to_string(), cx);
+                        }
+                    });
+                })
+                .detach();
+            }
         }
     }
 
@@ -2849,6 +2892,47 @@ impl SessionWindow {
                         "failed to duplicate session window"
                     );
                 });
+            }
+            TerminalPanelEvent::ResumeRequested { session_id } => {
+                // RFC-013 click-to-continue in a popped-out session window.
+                let api = self.app_state.api.clone();
+                let handle = self.app_state.tokio_handle.clone();
+                let host_id = self.host_id.clone();
+                let sid = session_id.clone();
+                let terminal = terminal.clone();
+                let app_state = self.app_state.clone();
+                cx.spawn(async move |_this: WeakEntity<Self>, cx: &mut AsyncApp| {
+                    let host_for_call = host_id.clone();
+                    let sid_for_call = sid.clone();
+                    let result = handle
+                        .spawn(
+                            async move { api.resume_session(&host_for_call, &sid_for_call).await },
+                        )
+                        .await;
+                    let _ = terminal.update(cx, |panel, cx| match result {
+                        Ok(Ok(_session)) => {
+                            if let Some(new_handle) =
+                                connect_terminal(&app_state, &sid, &host_id, false)
+                            {
+                                panel.reconnect(new_handle, &app_state.tokio_handle, cx);
+                            } else {
+                                panel.set_resume_error(
+                                    "could not open terminal connection".to_string(),
+                                    cx,
+                                );
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(error = %e, "session resume failed (window)");
+                            panel.set_resume_error(e.to_string(), cx);
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "session resume task join failed (window)");
+                            panel.set_resume_error("resume task failed".to_string(), cx);
+                        }
+                    });
+                })
+                .detach();
             }
             TerminalPanelEvent::OpenCommandPalette { .. }
             | TerminalPanelEvent::OpenSessionSwitcher

--- a/crates/zremote-gui/src/views/session_switcher.rs
+++ b/crates/zremote-gui/src/views/session_switcher.rs
@@ -537,10 +537,12 @@ fn build_entries(
         .map(|r| (r.session_id.as_str(), r.timestamp))
         .collect();
 
-    // Filter to active sessions only
+    // Filter to live + resumable sessions. RFC-013: a `resumable` session
+    // (agent backend died on reboot) must remain visible and clickable so the
+    // user can continue it — hiding it would be a dead end.
     let mut active: Vec<&Session> = sessions
         .iter()
-        .filter(|s| s.status == SessionStatus::Active)
+        .filter(|s| s.status == SessionStatus::Active || s.status == SessionStatus::Resumable)
         .collect();
 
     // Sort: waiting_for_input first, then working, then MRU order
@@ -692,5 +694,85 @@ mod tests {
         };
 
         assert!(parse_preview_color(&span).is_none());
+    }
+
+    use super::build_entries;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+    use zremote_client::{Host, HostStatus, Session, SessionStatus};
+
+    fn test_session(id: &str, status: SessionStatus) -> Session {
+        Session {
+            id: id.to_string(),
+            host_id: "h1".to_string(),
+            name: Some(id.to_string()),
+            shell: None,
+            status,
+            working_dir: None,
+            project_id: None,
+            pid: None,
+            exit_code: None,
+            created_at: "2026-06-04T00:00:00Z".to_string(),
+            closed_at: None,
+        }
+    }
+
+    fn test_host() -> Host {
+        Host {
+            id: "h1".to_string(),
+            name: "h1".to_string(),
+            hostname: "host-1".to_string(),
+            status: HostStatus::Online,
+            last_seen_at: None,
+            agent_version: None,
+            os: None,
+            arch: None,
+            created_at: "2026-06-04T00:00:00Z".to_string(),
+            updated_at: "2026-06-04T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_entries_includes_active_and_resumable_excludes_closed_suspended() {
+        // RFC-013: a resumable session must remain visible in the switcher
+        // alongside active ones; closed/suspended must not appear.
+        let sessions = Rc::new(vec![
+            test_session("s_active", SessionStatus::Active),
+            test_session("s_resumable", SessionStatus::Resumable),
+            test_session("s_closed", SessionStatus::Closed),
+            test_session("s_suspended", SessionStatus::Suspended),
+        ]);
+        let hosts = Rc::new(vec![test_host()]);
+        let projects = Rc::new(Vec::new());
+        let cc_states = HashMap::new();
+        let cc_metrics = HashMap::new();
+        let previews = HashMap::new();
+
+        let entries = build_entries(
+            &sessions,
+            &hosts,
+            &projects,
+            &[],
+            None,
+            "local",
+            &cc_states,
+            &cc_metrics,
+            &previews,
+        );
+
+        let ids: Vec<&str> = entries.iter().map(|e| e.session_id.as_str()).collect();
+        assert!(ids.contains(&"s_active"), "active must appear: {ids:?}");
+        assert!(
+            ids.contains(&"s_resumable"),
+            "resumable must appear: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"s_closed"),
+            "closed must NOT appear: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"s_suspended"),
+            "suspended must NOT appear: {ids:?}"
+        );
     }
 }

--- a/crates/zremote-gui/src/views/sidebar.rs
+++ b/crates/zremote-gui/src/views/sidebar.rs
@@ -286,7 +286,10 @@ impl SidebarView {
             s.project_id
                 .as_deref()
                 .is_some_and(|pid| worktree_ids.contains(pid))
+                // RFC-013: a resumable session keeps the project visible so the
+                // user can reach + continue it.
                 && (s.status == SessionStatus::Active
+                    || s.status == SessionStatus::Resumable
                     || self.cc_states.get(&s.id).is_some_and(|cc| {
                         matches!(
                             cc.status,
@@ -481,7 +484,11 @@ impl SidebarView {
                         all_sessions.extend(sessions.unwrap_or_default());
                         all_projects.extend(projects.unwrap_or_default());
                     }
-                    // Fetch active + starting Claude tasks
+                    // Fetch active + starting + suspended Claude tasks.
+                    // RFC-013: a task whose terminal session became `resumable`
+                    // after a reboot is reconciled to `suspended`
+                    // (disconnect_reason='agent_restarted'); include it so the
+                    // sidebar can surface it as resumable instead of dropping it.
                     let active_filter = ListClaudeTasksFilter {
                         status: Some("active".to_string()),
                         ..ListClaudeTasksFilter::default()
@@ -490,12 +497,18 @@ impl SidebarView {
                         status: Some("starting".to_string()),
                         ..ListClaudeTasksFilter::default()
                     };
-                    let (active, starting) = tokio::join!(
+                    let suspended_filter = ListClaudeTasksFilter {
+                        status: Some("suspended".to_string()),
+                        ..ListClaudeTasksFilter::default()
+                    };
+                    let (active, starting, suspended) = tokio::join!(
                         api.list_claude_tasks(&active_filter),
                         api.list_claude_tasks(&starting_filter),
+                        api.list_claude_tasks(&suspended_filter),
                     );
                     let mut tasks = active.unwrap_or_default();
                     tasks.extend(starting.unwrap_or_default());
+                    tasks.extend(suspended.unwrap_or_default());
                     // Fetch agent profiles and supported kinds.
                     let (profiles, kinds) =
                         tokio::join!(api.list_agent_profiles(None), api.list_agent_kinds());
@@ -2277,6 +2290,8 @@ impl SidebarView {
         let status_color = match session.status {
             SessionStatus::Active => theme::success(),
             SessionStatus::Suspended => theme::warning(),
+            // RFC-013: resumable reads as "paused, can continue".
+            SessionStatus::Resumable => theme::accent(),
             _ => theme::text_tertiary(),
         };
 
@@ -2402,6 +2417,27 @@ impl SidebarView {
                 name_div = name_div.flex_shrink_0();
 
                 row1 = row1.child(name_div.child(display_name));
+
+                // RFC-013 resumable badge: a session whose agent backend died on
+                // reboot but can be re-opened. Click the row to continue (attach
+                // auto-resumes when configured, else the terminal offers Continue).
+                if session.status == SessionStatus::Resumable {
+                    row1 = row1.child(
+                        div()
+                            .flex_shrink_0()
+                            .flex()
+                            .items_center()
+                            .gap(px(3.0))
+                            .px(px(4.0))
+                            .py(px(1.0))
+                            .rounded(px(3.0))
+                            .bg(theme::warning_bg())
+                            .text_color(theme::accent())
+                            .text_size(px(10.0))
+                            .child(icon(Icon::Play).size(px(9.0)).text_color(theme::accent()))
+                            .child("Resumable"),
+                    );
+                }
 
                 // Permission mode badge
                 if let Some(cc) = cc_state
@@ -2680,6 +2716,7 @@ fn build_session_tooltip(
         SessionStatus::Closed => "closed",
         SessionStatus::Creating => "creating",
         SessionStatus::Error => "error",
+        SessionStatus::Resumable => "resumable",
         SessionStatus::Unknown => "unknown",
     };
     lines.push(format!("Status: {status_label}"));

--- a/crates/zremote-gui/src/views/terminal_panel.rs
+++ b/crates/zremote-gui/src/views/terminal_panel.rs
@@ -256,6 +256,10 @@ pub struct TerminalPanel {
     /// Whether the terminal WebSocket connection has been lost
     /// (session may still be alive on server, waiting for reconnect).
     disconnected: bool,
+    /// RFC-013: the session is `resumable` and auto-resume is off, so attach
+    /// returned a typed resumable signal instead of connecting. The panel shows
+    /// a "Resumable — click to continue" affordance. Cleared once resumed.
+    resumable: bool,
     /// Terminal title set by OSC escape sequences (e.g. `\e]0;title\a`).
     terminal_title: Option<String>,
     /// Claude Code session metrics for the current session.
@@ -367,6 +371,7 @@ impl TerminalPanel {
             last_focus_reported: false,
             mode,
             disconnected: false,
+            resumable: false,
             terminal_title: None,
             cc_metrics: None,
             cc_status: None,
@@ -479,6 +484,15 @@ impl TerminalPanel {
         self.cc_task_name = None;
     }
 
+    /// RFC-013: record a recoverable resume failure (e.g. agent CLI not on
+    /// PATH). Keeps the panel `resumable` so the overlay shows the error inline
+    /// with a Retry button — never a toast-only dead end.
+    pub fn set_resume_error(&mut self, message: String, cx: &mut Context<Self>) {
+        self.error_message = Some(message);
+        self.resumable = true;
+        cx.notify();
+    }
+
     /// Reconnect with a new terminal handle after session resume.
     /// Resets disconnect state, replaces the handle, restarts the reader,
     /// and sets up a new resize debounce pipeline.
@@ -490,6 +504,7 @@ impl TerminalPanel {
     ) {
         self.disconnected = false;
         self.closed = false;
+        self.resumable = false; // RFC-013: cleared once the session reconnects
         self.error_message = None;
         self.terminal_title = None;
         self.reader_started = false; // Allow start_output_reader to run again
@@ -747,6 +762,16 @@ impl TerminalPanel {
                         Ok(GuiSignal::Event(TerminalEvent::Disconnected)) => {
                             let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
                                 this.disconnected = true;
+                                cx.notify();
+                            });
+                            break;
+                        }
+                        Ok(GuiSignal::Event(TerminalEvent::SessionResumable)) => {
+                            // RFC-013: agent backend died on reboot and auto-resume
+                            // is off. Show the click-to-continue affordance; the
+                            // server closed this WS, so stop reading.
+                            let _ = this.update(cx, |this: &mut Self, cx: &mut Context<Self>| {
+                                this.resumable = true;
                                 cx.notify();
                             });
                             break;
@@ -1095,6 +1120,11 @@ pub enum TerminalPanelEvent {
     TitleChanged {
         session_id: String,
         title: Option<String>,
+    },
+    /// RFC-013: the user clicked "Continue" on a resumable session. The parent
+    /// (which holds the API client) POSTs the resume endpoint for this session.
+    ResumeRequested {
+        session_id: String,
     },
 }
 
@@ -1510,6 +1540,96 @@ impl TerminalPanel {
         } else {
             None
         }
+    }
+
+    /// RFC-013: centered "Resumable — click to continue" affordance shown when
+    /// auto-resume is off (or a prior resume failed). Clicking emits
+    /// `ResumeRequested` so the parent POSTs the resume endpoint. A failed resume
+    /// surfaces inline (the row stays resumable) with the same button as retry —
+    /// recoverable, never a toast-only dead end.
+    fn render_resumable_overlay(&self, cx: &mut Context<Self>) -> AnyElement {
+        let session_id = self.session_id.clone();
+        let button_label = if self.error_message.is_some() {
+            "Retry"
+        } else {
+            "Continue"
+        };
+        let mut col = div()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap(px(10.0))
+            .child(icon(Icon::Play).size(px(28.0)).text_color(theme::accent()))
+            .child(
+                div()
+                    .text_color(theme::text_primary())
+                    .text_size(px(14.0))
+                    .child("Resumable session"),
+            )
+            .child(
+                div()
+                    .text_color(theme::text_secondary())
+                    .text_size(px(12.0))
+                    .child(
+                        "The agent stopped after a restart. Continue to re-open the conversation.",
+                    ),
+            );
+
+        // Inline recoverable error (e.g. agent CLI not on PATH).
+        if let Some(ref msg) = self.error_message {
+            col = col.child(
+                div()
+                    .max_w(px(360.0))
+                    .text_color(theme::error())
+                    .text_size(px(11.0))
+                    .child(format!("Resume failed: {msg}")),
+            );
+        }
+
+        col = col.child(
+            div()
+                .id("resume-continue-button")
+                .flex()
+                .items_center()
+                .gap(px(6.0))
+                .px(px(12.0))
+                .py(px(6.0))
+                .rounded(px(6.0))
+                .bg(theme::accent())
+                .text_color(theme::bg_primary())
+                .text_size(px(12.0))
+                .cursor_pointer()
+                .hover(|s| s.opacity(0.9))
+                .tooltip(|_window, cx| {
+                    cx.new(|_| ConnectionTooltip("Re-open this agent session".to_string()))
+                        .into()
+                })
+                .child(
+                    icon(Icon::Play)
+                        .size(px(12.0))
+                        .text_color(theme::bg_primary()),
+                )
+                .child(button_label)
+                .on_click(cx.listener(move |this, _event: &ClickEvent, _window, cx| {
+                    // Optimistic: clear the prior error and let the parent drive
+                    // the POST; the WS will reconnect once the row is active.
+                    this.error_message = None;
+                    cx.emit(TerminalPanelEvent::ResumeRequested {
+                        session_id: session_id.clone(),
+                    });
+                    cx.notify();
+                })),
+        );
+
+        div()
+            .absolute()
+            .inset_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(theme::bg_primary())
+            .child(col)
+            .into_any_element()
     }
 
     fn render_connection_badge(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -2247,6 +2367,12 @@ impl Render for TerminalPanel {
         }
 
         content = content.child(self.render_connection_badge(cx));
+
+        // RFC-013: resumable affordance overlays the (clean) terminal — no
+        // scrollback restore (decision C). Rendered last so it sits on top.
+        if self.resumable {
+            content = content.child(self.render_resumable_overlay(cx));
+        }
 
         let mut wrapper = div().flex().flex_col().size_full();
         if let Some(overlay) = &self.search_overlay {

--- a/crates/zremote-protocol/src/agentic.rs
+++ b/crates/zremote-protocol/src/agentic.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{AgenticLoopId, NodeStatus, SessionId};
+use crate::{AgentKind, AgenticLoopId, NodeStatus, SessionId};
 
 /// Status of an agentic loop.
 ///
@@ -127,6 +127,23 @@ pub enum AgenticAgentMessage {
 
     /// Stop / `StopFailure` hook: close every running node for this session.
     SessionExecutionStopped { session_id: SessionId },
+
+    /// Kind-agnostic native session id capture.
+    ///
+    /// Emitted when an agent's native session identifier (Claude `cc_session_id`,
+    /// Codex rollout id, ...) is observed for a managed session. Generalizes the
+    /// Claude-task-specific [`crate::claude::ClaudeAgentMessage::SessionIdCaptured`],
+    /// which is kept during the transition and emitted alongside this message for
+    /// Claude-task sessions only.
+    AgentSessionRefCaptured {
+        /// Managed session id (authoritative key, from `ZREMOTE_SESSION_ID`).
+        session_id: SessionId,
+        /// Which agent CLI produced `native_session_id`.
+        agent: AgentKind,
+        /// Native session id from the agent (claude/codex). Treated as opaque
+        /// data, never interpreted as shell text.
+        native_session_id: String,
+    },
 }
 
 #[cfg(test)]
@@ -267,6 +284,67 @@ mod tests {
         roundtrip_agent(&AgenticAgentMessage::SessionExecutionStopped {
             session_id: Uuid::new_v4(),
         });
+    }
+
+    #[test]
+    fn agent_session_ref_captured_roundtrip() {
+        for agent in [AgentKind::Claude, AgentKind::Codex] {
+            let msg = AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id: Uuid::new_v4(),
+                agent,
+                native_session_id: "cc-01HZX9".to_string(),
+            };
+            roundtrip_agent(&msg);
+            // Assert the fields survived the roundtrip, not just that it parsed.
+            let json = serde_json::to_string(&msg).expect("serialize");
+            let parsed: AgenticAgentMessage = serde_json::from_str(&json).expect("deserialize");
+            match parsed {
+                AgenticAgentMessage::AgentSessionRefCaptured {
+                    agent: parsed_agent,
+                    native_session_id,
+                    ..
+                } => {
+                    assert_eq!(parsed_agent, agent);
+                    assert_eq!(native_session_id, "cc-01HZX9");
+                }
+                other => panic!("expected AgentSessionRefCaptured, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn agent_session_ref_captured_agent_serialization() {
+        let session_id = Uuid::new_v4();
+        let json = serde_json::to_string(&AgenticAgentMessage::AgentSessionRefCaptured {
+            session_id,
+            agent: AgentKind::Claude,
+            native_session_id: "abc".to_string(),
+        })
+        .expect("serialize");
+        // The agent kind is tagged snake_case inside the message payload.
+        assert!(json.contains(r#""agent":"claude""#), "json was: {json}");
+    }
+
+    #[test]
+    fn agent_session_ref_captured_unknown_agent_deserializes() {
+        // An unknown agent kind from a newer peer must fall back to Unknown
+        // rather than failing deserialization (forward compatibility).
+        let session_id = Uuid::new_v4();
+        let json = format!(
+            r#"{{"type":"AgentSessionRefCaptured","payload":{{"session_id":"{session_id}","agent":"gemini","native_session_id":"xyz"}}}}"#
+        );
+        let parsed: AgenticAgentMessage = serde_json::from_str(&json).expect("deserialize");
+        match parsed {
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                agent,
+                native_session_id,
+                ..
+            } => {
+                assert_eq!(agent, AgentKind::Unknown);
+                assert_eq!(native_session_id, "xyz");
+            }
+            other => panic!("expected AgentSessionRefCaptured, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/zremote-protocol/src/agents.rs
+++ b/crates/zremote-protocol/src/agents.rs
@@ -14,6 +14,42 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+/// Kind-agnostic identifier for an agent CLI.
+///
+/// Serialized as `snake_case` strings (`"claude"`, `"codex"`). Unknown kinds
+/// from newer peers deserialize to [`AgentKind::Unknown`] via `#[serde(other)]`
+/// so the protocol stays forward-compatible. This mirrors the string `kind`
+/// values listed in [`SUPPORTED_KINDS`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentKind {
+    Claude,
+    Codex,
+    #[serde(other)]
+    Unknown,
+}
+
+impl AgentKind {
+    /// Stable lowercase wire/DB string for this kind (`"claude"`, `"codex"`,
+    /// `"unknown"`). Matches the `#[serde(rename_all = "snake_case")]`
+    /// serialization and the `agent_kind` column values persisted on `sessions`.
+    /// Use this instead of re-deriving the string at each call site.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Server -> agent messages for the generic launcher flow.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "payload")]
@@ -248,5 +284,70 @@ mod tests {
         assert!(kinds.contains(&"claude"));
         assert!(kinds.contains(&"codex"));
         assert_eq!(SUPPORTED_KINDS.len(), kinds.len());
+    }
+
+    #[test]
+    fn agent_kind_serialization() {
+        assert_eq!(
+            serde_json::to_string(&AgentKind::Claude).unwrap(),
+            r#""claude""#
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentKind::Codex).unwrap(),
+            r#""codex""#
+        );
+    }
+
+    #[test]
+    fn agent_kind_roundtrip() {
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Unknown] {
+            let json = serde_json::to_string(&kind).expect("serialize");
+            let back: AgentKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, kind);
+        }
+    }
+
+    #[test]
+    fn agent_kind_unknown_deserialization() {
+        // Any unrecognized kind string falls back to Unknown.
+        let parsed: AgentKind = serde_json::from_str(r#""gemini""#).expect("deserialize");
+        assert_eq!(parsed, AgentKind::Unknown);
+    }
+
+    #[test]
+    fn agent_kind_as_str_values() {
+        assert_eq!(AgentKind::Claude.as_str(), "claude");
+        assert_eq!(AgentKind::Codex.as_str(), "codex");
+        assert_eq!(AgentKind::Unknown.as_str(), "unknown");
+    }
+
+    #[test]
+    fn agent_kind_as_str_matches_serde() {
+        // `as_str` must equal the serde snake_case representation so the DB
+        // string (written via as_str) round-trips through deserialization.
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Unknown] {
+            let serde_str = serde_json::to_string(&kind).expect("serialize");
+            assert_eq!(format!("\"{}\"", kind.as_str()), serde_str);
+        }
+    }
+
+    #[test]
+    fn agent_kind_as_str_roundtrips_through_from_db() {
+        // Simulate reading back the stored `sessions.agent_kind` string: parsing
+        // `as_str()` must recover the original variant. Claude/Codex round-trip
+        // exactly; the catch-all "unknown" also deserializes back to Unknown.
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Unknown] {
+            let db_value = kind.as_str();
+            let json = format!("\"{db_value}\"");
+            let back: AgentKind = serde_json::from_str(&json).expect("deserialize from db value");
+            assert_eq!(back, kind, "agent_kind {db_value} must round-trip");
+        }
+    }
+
+    #[test]
+    fn agent_kind_display_matches_as_str() {
+        assert_eq!(AgentKind::Claude.to_string(), "claude");
+        assert_eq!(AgentKind::Codex.to_string(), "codex");
+        assert_eq!(AgentKind::Unknown.to_string(), "unknown");
     }
 }

--- a/crates/zremote-protocol/src/lib.rs
+++ b/crates/zremote-protocol/src/lib.rs
@@ -14,8 +14,8 @@ pub use agentic::{
     AgenticStatus,
 };
 pub use agents::{
-    AgentCapabilityInfo, AgentLifecycleMessage, AgentProfileData, AgentServerMessage, KindInfo,
-    SUPPORTED_KINDS, supported_kinds,
+    AgentCapabilityInfo, AgentKind, AgentLifecycleMessage, AgentProfileData, AgentServerMessage,
+    KindInfo, SUPPORTED_KINDS, supported_kinds,
 };
 pub use claude::*;
 pub use events::{HostInfo, LoopInfo, NodeStatus, ServerEvent, SessionInfo};

--- a/crates/zremote-protocol/src/status.rs
+++ b/crates/zremote-protocol/src/status.rs
@@ -12,6 +12,12 @@ pub enum SessionStatus {
     Suspended,
     Closed,
     Error,
+    /// The session's backend (daemon) did not survive an agent restart/reboot,
+    /// but it can be re-opened: either it backs an agent conversation with a
+    /// persisted `agent_session_ref` (RFC-012), or it is a plain shell the agent
+    /// is configured to re-create. Listed and attachable (attach drives the
+    /// resume engine) but NOT treated as a live/active session. See RFC-013.
+    Resumable,
     /// Forward-compatibility: unknown status values from newer servers.
     #[serde(other)]
     Unknown,
@@ -25,6 +31,7 @@ impl fmt::Display for SessionStatus {
             Self::Suspended => write!(f, "suspended"),
             Self::Closed => write!(f, "closed"),
             Self::Error => write!(f, "error"),
+            Self::Resumable => write!(f, "resumable"),
             Self::Unknown => write!(f, "unknown"),
         }
     }
@@ -41,6 +48,7 @@ impl SessionStatus {
             "suspended" => Self::Suspended,
             "closed" => Self::Closed,
             "error" => Self::Error,
+            "resumable" => Self::Resumable,
             _ => Self::Unknown,
         }
     }
@@ -201,11 +209,29 @@ mod tests {
             SessionStatus::Active,
             SessionStatus::Suspended,
             SessionStatus::Closed,
+            SessionStatus::Resumable,
         ] {
             let json = serde_json::to_string(&status).unwrap();
             let parsed: SessionStatus = serde_json::from_str(&json).unwrap();
             assert_eq!(status, parsed);
         }
+    }
+
+    #[test]
+    fn session_status_resumable_serde_display_parse() {
+        // Serializes/deserializes as "resumable" and is distinct from Unknown
+        // so old peers that don't know the variant fall back via #[serde(other)].
+        assert_eq!(
+            serde_json::to_string(&SessionStatus::Resumable).unwrap(),
+            r#""resumable""#
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionStatus>(r#""resumable""#).unwrap(),
+            SessionStatus::Resumable
+        );
+        assert_eq!(SessionStatus::Resumable.to_string(), "resumable");
+        assert_eq!(SessionStatus::parse("resumable"), SessionStatus::Resumable);
+        assert_ne!(SessionStatus::Resumable, SessionStatus::Unknown);
     }
 
     // --- HostStatus tests ---

--- a/crates/zremote-server/src/routes/agents/dispatch.rs
+++ b/crates/zremote-server/src/routes/agents/dispatch.rs
@@ -1963,6 +1963,40 @@ pub(super) async fn handle_agentic_message(
                 });
             }
         }
+        AgenticAgentMessage::AgentSessionRefCaptured {
+            session_id,
+            agent,
+            native_session_id,
+        } => {
+            // Server-mode persistence of an agent's native session id. Mirrors
+            // the local-mode path in zremote_core's AgenticProcessor; both write
+            // the same `sessions` columns via the shared core query. This is the
+            // durable record RFC-013 reads to resume a stopped agent.
+            // Persistence-only: no broadcast event in this phase.
+            let session_id_str = session_id.to_string();
+            let now = Utc::now().to_rfc3339();
+            if let Err(e) = zremote_core::queries::sessions::set_agent_session_ref(
+                &state.db,
+                &session_id_str,
+                agent.as_str(),
+                &native_session_id,
+                &now,
+            )
+            .await
+            {
+                // Best-effort persistence: a failure only means RFC-013 resume is
+                // disabled for THIS session (the row keeps its prior ref/none).
+                // Do NOT escalate this into dropping the WS connection — the
+                // agent's other messages (state, execution nodes) must keep
+                // flowing; the native id will be re-captured on the next hook.
+                tracing::warn!(
+                    %host_id,
+                    %session_id,
+                    error = %e,
+                    "failed to persist agent native session ref (resume disabled for this session)"
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -4160,5 +4194,51 @@ mod tests {
         .unwrap();
         assert_eq!(row.0.as_deref(), Some("v2"));
         assert_eq!(row.1.as_deref(), Some("h2"));
+    }
+
+    // ── handle_agentic_message: AgentSessionRefCaptured ──
+
+    #[tokio::test]
+    async fn handle_agentic_session_ref_captured_persists_to_session_row() {
+        let state = test_state().await;
+        let host_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+
+        insert_test_host(&state, &host_id.to_string(), "test-host").await;
+        insert_test_session(
+            &state,
+            &session_id.to_string(),
+            &host_id.to_string(),
+            "active",
+        )
+        .await;
+
+        handle_agentic_message(
+            &state,
+            host_id,
+            AgenticAgentMessage::AgentSessionRefCaptured {
+                session_id,
+                agent: zremote_protocol::AgentKind::Codex,
+                native_session_id: "rollout-xyz".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (agent_kind, agent_ref, updated_at): (Option<String>, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT agent_kind, agent_session_ref, agent_session_updated_at \
+                 FROM sessions WHERE id = ?",
+            )
+            .bind(session_id.to_string())
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+        assert_eq!(agent_kind.as_deref(), Some("codex"));
+        assert_eq!(agent_ref.as_deref(), Some("rollout-xyz"));
+        assert!(
+            updated_at.is_some(),
+            "agent_session_updated_at should be set"
+        );
     }
 }

--- a/crates/zremote-server/src/routes/terminal.rs
+++ b/crates/zremote-server/src/routes/terminal.rs
@@ -47,9 +47,7 @@ impl TerminalBackend for ServerTerminalBackend {
                     Ok(None) => "session not found".to_string(),
                     Err(_) => "session not found or not active".to_string(),
                 };
-            return Err(SessionError {
-                message: error_message,
-            });
+            return Err(SessionError::new(error_message));
         }
 
         // Phase 2: Take write lock for the happy path
@@ -60,18 +58,14 @@ impl TerminalBackend for ServerTerminalBackend {
         {
             let mut sessions = self.state.sessions.write().await;
             let Some(session) = sessions.get_mut(session_id) else {
-                return Err(SessionError {
-                    message: "session was closed while connecting".to_string(),
-                });
+                return Err(SessionError::new("session was closed while connecting"));
             };
 
             if session.status != SessionStatus::Active
                 && session.status != SessionStatus::Creating
                 && session.status != SessionStatus::Suspended
             {
-                return Err(SessionError {
-                    message: format!("session is {}", session.status),
-                });
+                return Err(SessionError::new(format!("session is {}", session.status)));
             }
 
             scrollback_data = session.scrollback.iter().cloned().collect::<Vec<_>>();

--- a/docs/rfc/rfc-012-agent-hooks-native-session-capture.md
+++ b/docs/rfc/rfc-012-agent-hooks-native-session-capture.md
@@ -1,0 +1,430 @@
+# RFC-012: Agent Integration Hooks — Hardening & Universal Native Session Capture
+
+## Status: Draft
+
+## Date: 2026-06-04
+
+## Problem Statement
+
+ZRemote installs Claude Code hooks to learn what an agent is doing. Today those
+hooks serve agent-state detection (RFC-011) well, but they do **not** reliably
+record the one fact required to *resume* an agent later: the agent's own native
+session id (Claude's `session_id` UUID, Codex's rollout/session id).
+
+Three concrete gaps:
+
+1. **Capture is tied to the Claude-task feature.** The native session id is only
+   forwarded when the PTY session was registered as a Claude task
+   (`mapper.get_claude_task_id(&session_id)` returns `Some`). A user who simply
+   opens a ZRemote terminal and types `claude` never gets their session id
+   captured, and it is only ever stored in `claude_sessions`, never on the
+   generic `sessions` row.
+2. **Codex has no hook integration at all.** Codex is already a first-class
+   *detected* agent (`agentic/detector.rs:13`), but the installer writes nothing
+   for it and there is no Codex resume command builder.
+3. **Correlation is fragile.** Hooks are mapped to a ZRemote session through the
+   process-detector + loop-mapping retry loop (`hooks/mapper.rs`), even though
+   every spawned shell already exports a deterministic
+   `ZREMOTE_SESSION_ID` (`pty/shell_integration.rs:149-150`) that the hook could
+   simply echo back.
+
+This RFC makes hooks capture the native agent session id for **every** terminal
+session running a supported agent, keyed deterministically by
+`ZREMOTE_SESSION_ID`, persists it on the `sessions` table, and adds Codex hook
+support. It is the producer half; **RFC-013** consumes the persisted reference to
+relaunch sessions after a restart/reboot.
+
+## Goals
+
+1. Capture the native agent session id (Claude, Codex) for **every** ZRemote
+   terminal session that runs a supported agent — not only Claude-task sessions.
+2. Correlate hooks to ZRemote sessions deterministically via the already-injected
+   `ZREMOTE_SESSION_ID` env var, instead of the process-detector loop mapping.
+3. Add a first-class **Codex** hook integration that reports both codex runtime
+   state (feeding RFC-011's state machine) and the codex session id, reusing the
+   claude hook infrastructure.
+4. Persist the captured native reference on the generic `sessions` table so it
+   survives agent restart and machine reboot.
+5. Provide a single, agent-aware resume-argv builder (consumed by RFC-013) that
+   treats the native id as data, never as shell text.
+6. Harden installation (version stamping, idempotent merge) and make transport
+   failures observable.
+
+## Non-Goals
+
+- Changing the agent runtime state machine (`idle` / `working` /
+  `waiting_for_input`). RFC-011 owns that. (This RFC does *feed* a new source —
+  codex hooks — into that existing machine via `AgentStateChanged`, revisiting
+  RFC-011's "no non-PTY codex state" non-goal, but it does not change the machine
+  itself.)
+- Implementing the relaunch/resume-on-attach flow. RFC-013 owns that.
+- Supporting agents other than `claude` and `codex`.
+- Restoring terminal scrollback (out of scope; see RFC-013 Non-Goals).
+
+## Current State
+
+### Installer (`crates/zremote-agent/src/hooks/installer.rs`)
+
+- Writes the forwarder script `~/.zremote/hooks/zremote-hook.sh`
+  (`installer.rs:145-173`) and edits `~/.claude/settings.json`
+  (`installer.rs:175-386`), merging with existing user hooks.
+- Registers 12 Claude events (`installer.rs:64-77,198-277`): `PreToolUse`,
+  `PostToolUse`, `Stop`, `Notification` (`idle_prompt`, `permission_prompt`),
+  `Elicitation`, `UserPromptSubmit`, `SessionStart`, `SubagentStart`,
+  `SubagentStop`, `StopFailure`, `FileChanged`, `CwdChanged`, plus a
+  `statusLine`.
+- Idempotency is **path-based only** (`is_already_installed()`,
+  `installer.rs:22-103`) — there is no version stamp, so a changed script body is
+  not re-installed.
+- The script reads the agent port from `~/.zremote/hooks-port`
+  (`installer.rs:149`) and forwards `CLAUDE_ENV_FILE` as header
+  `X-Claude-Env-File` (`installer.rs:156-166`). It does **not** forward
+  `ZREMOTE_SESSION_ID`.
+- **No Codex installation logic exists.**
+
+### Transport (`crates/zremote-agent/src/hooks/server.rs`)
+
+- HTTP server bound to `127.0.0.1:0` (`server.rs:75`), routes `/hooks`,
+  `/hooks/notification/{idle,permission}`, `/channel/*` (`server.rs:52-71`),
+  1 MB body limit. Port written to `~/.zremote/hooks-port` (`server.rs:81-83`).
+- On reconnect a new server overwrites the port file; the old one does not remove
+  it (`server.rs:91-94`). Failure modes are silent by design (script always
+  `exit 0`).
+
+### Handler & mapping (`crates/zremote-agent/src/hooks/handler.rs`, `mapper.rs`)
+
+- `try_capture_cc_session_id()` (`handler.rs:394-437`) emits
+  `ClaudeAgentMessage::SessionIdCaptured { claude_task_id, cc_session_id }`
+  (`crates/zremote-protocol/src/claude.rs:78-81`) **only** when
+  `mapper.get_claude_task_id(&session_id)` is `Some` — i.e. Claude-task sessions
+  only.
+- The `SessionStart` handler (`handler.rs:310-331`) writes an env file and
+  `watchPaths`, but does **not** capture `session_id`.
+- Hook→session correlation uses `SessionMapper` (`mapper.rs:200-230`) with a
+  5×1s retry against the agentic detector's loop registration.
+
+### Command building (`crates/zremote-agent/src/claude/mod.rs`)
+
+- `--resume <id>` / `--continue` are emitted from `resume_cc_session_id` /
+  `continue_last` (`claude/mod.rs:124-129`). **No Codex command builder exists.**
+
+### Detection & env (`agentic/detector.rs`, `pty/shell_integration.rs`)
+
+- Both `claude` and `codex` are detected by process name
+  (`detector.rs:12-13`).
+- Every spawned shell exports `ZREMOTE_TERMINAL=1` and
+  `ZREMOTE_SESSION_ID=<uuid>` (`shell_integration.rs:149-150`).
+
+### Database (`crates/zremote-core/migrations`)
+
+- `sessions` (001) has `id, host_id, shell, status, working_dir, pid,
+  exit_code, created_at, closed_at` (+ `suspended_at, tmux_name` from 011). It
+  has **no** native-agent columns.
+- `claude_sessions` (010) has `claude_session_id` and `resume_from`, scoped to
+  the Claude-task feature.
+- Latest migration is `028`.
+
+## Design
+
+### 1. Generic `AgentKind` + capture message
+
+Add an agent-kind enum and a generic capture message in the protocol, replacing
+the Claude-task-specific `SessionIdCaptured` over time.
+
+```rust
+// crates/zremote-protocol/src/agents.rs
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentKind {
+    Claude,
+    Codex,
+    #[serde(other)]
+    Unknown,
+}
+```
+
+```rust
+// agent -> server/core message (zremote-protocol)
+AgenticAgentMessage::AgentSessionRefCaptured {
+    session_id: SessionId,          // ZRemote session, from ZREMOTE_SESSION_ID
+    agent: AgentKind,
+    native_session_id: String,      // claude/codex native session id (data, not shell text)
+}
+```
+
+`SessionIdCaptured` is kept during the transition and emitted alongside the new
+message for Claude-task sessions only.
+
+### 2. Deterministic correlation via `ZREMOTE_SESSION_ID`
+
+Extend the forwarder script to send the ZRemote session id as a header on every
+event (it is already in the shell environment):
+
+```sh
+# added to ~/.zremote/hooks/zremote-hook.sh
+if [ -n "$ZREMOTE_SESSION_ID" ]; then
+  set -- "$@" -H "X-ZRemote-Session-Id: $ZREMOTE_SESSION_ID"
+fi
+```
+
+`server.rs` parses `X-ZRemote-Session-Id`; `handler.rs` validates it as a UUID
+and uses it as the authoritative session key for capture. This removes the
+dependency on the detector/loop mapping for the *capture* path (state detection
+in RFC-011 is unchanged).
+
+### 3. Capture for every session
+
+In `handler.rs`, capture the native id from the hook input's `session_id` field
+on `SessionStart` (and, as a fallback for agents that fire tools before a
+SessionStart reaches us, on the first `PreToolUse` / `UserPromptSubmit`):
+
+- Require a valid `X-ZRemote-Session-Id`.
+- Dedupe per `(zremote_session_id, agent, native_session_id)` using the existing
+  `sent_cc_session_ids`-style set, generalized to a `HashSet<(Uuid, AgentKind,
+  String)>`.
+- Emit `AgentSessionRefCaptured`. This path does **not** consult
+  `get_claude_task_id`.
+
+### 4. Persistence on `sessions`
+
+New migration `029_agent_session_ref.sql`:
+
+```sql
+ALTER TABLE sessions ADD COLUMN agent_kind TEXT;               -- 'claude' | 'codex' | NULL
+ALTER TABLE sessions ADD COLUMN agent_session_ref TEXT;        -- native session id
+ALTER TABLE sessions ADD COLUMN agent_session_updated_at TEXT; -- ISO 8601
+```
+
+Core/local processing handles `AgentSessionRefCaptured`:
+
+```sql
+UPDATE sessions
+   SET agent_kind = ?, agent_session_ref = ?, agent_session_updated_at = ?
+ WHERE id = ?;
+```
+
+A query helper `set_agent_session_ref(pool, session_id, kind, native_id, now)`
+lives in `crates/zremote-core/src/queries/sessions.rs`. This row is the durable
+record RFC-013 reads.
+
+### 5. Codex hooks (claude-compatible) for state + session capture
+
+Verified against `codex-cli 0.135.0` and the OpenAI Codex hooks docs
+(<https://developers.openai.com/codex/hooks>): Codex's hook system mirrors Claude
+Code closely, so the existing ZRemote hook infrastructure (installer, HTTP
+transport, handler, mapper) can be largely **reused** rather than replaced.
+
+- **Events** (same names/semantics as Claude): `SessionStart` (session/thread
+  scope); `PreToolUse`, `PostToolUse`, `PermissionRequest`, `UserPromptSubmit`,
+  `SubagentStart`, `SubagentStop`, `Stop`, `PreCompact`/`PostCompact` (turn
+  scope).
+- **Stdin JSON** carries `session_id`, `cwd`, `transcript_path`,
+  `hook_event_name`, `model`, `permission_mode`, and (turn-scoped) `turn_id`. The
+  native session id is delivered **directly by the hook** — no filesystem parsing
+  — and ZRemote learns codex state the same way it learns claude state.
+- **Config**: `~/.codex/config.toml` (`[features] hooks = true` + inline
+  `[[hooks.<Event>]]`) or `~/.codex/hooks.json` (identical JSON shape to claude).
+- **Output** matches claude (`hookSpecificOutput.additionalContext`,
+  `permissionDecision`, `continue`, ...), so context injection works too.
+
+Install the ZRemote forwarder into codex the same way as claude (same script,
+same `~/.zremote/hooks-port` transport, same `X-ZRemote-Session-Id` header),
+registering the events ZRemote already consumes. The handler emits both
+`AgentStateChanged` (RFC-011) and `AgentSessionRefCaptured { agent: Codex, .. }`
+from the hook's `session_id`. This closes the gap where codex state previously
+relied only on PTY/process fallback (RFC-011 non-goal revisited).
+
+**Trust.** Non-managed codex hooks require a one-time interactive trust (recorded
+against the hook hash) — the default, proven path. For zero-prompt / headless
+installs, register as a *managed* hook via `~/.codex/requirements.toml`
+(`[features] hooks = true`, `[[hooks.<Event>]]`), which is trusted by policy. Do
+not use `--dangerously-bypass-hook-trust` as a default (it must be passed at
+codex launch, which ZRemote does not control for manually-started codex).
+
+**Handler abstraction (`AgentIntegration` trait).** Rather than scatter
+`AgentKind` branches, introduce an `AgentIntegration` trait that encapsulates the
+per-agent specifics the handler currently hard-codes for claude (config/install
+location, hook event-name set, native session-id field, transcript-path root,
+task-name extraction, `resume_argv`). `handler.rs` and `mapper.rs` are refactored
+to be agent-agnostic and dispatch through `ClaudeIntegration` /
+`CodexIntegration` implementations. This is a larger refactor of a
+recently-changed critical file (see Risks) but yields a clean extension point for
+future agents.
+
+**Fallback (no hook trust).** If hooks are unavailable or untrusted, fall back to
+reading the session id from the newest rollout file
+(`~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO8601>-<UUID>.jsonl`, whose
+`session_meta` first line carries `id` + `cwd`; honor `CODEX_HOME`). This keeps
+resume working even without hook trust, but yields no live state.
+
+### 6. Shared resume-argv builder
+
+```rust
+// crates/zremote-agent/src/agents/resume.rs (new)
+pub fn resume_argv(agent: AgentKind, native_session_id: &str) -> Option<Vec<String>> {
+    match agent {
+        AgentKind::Claude => Some(vec!["claude".into(), "--resume".into(), native_session_id.into()]),
+        AgentKind::Codex  => Some(vec!["codex".into(), "resume".into(), native_session_id.into()]),
+        AgentKind::Unknown => None,
+    }
+}
+```
+
+The native id is always an argv element, never interpolated into a shell string
+(injection-safe). The Codex subcommand `codex resume <UUID>` is confirmed
+against `codex-cli 0.135.0`.
+
+### 7. Hardening
+
+- Stamp the installed script and settings entries with
+  `ZREMOTE_HOOK_VERSION=<n>`; re-install when the constant changes (not just when
+  the path is absent).
+- Keep the localhost-only transport; document the reconnect port-file overwrite
+  and add a debug log when a POST is dropped because the port file is missing.
+
+## Implementation Phases
+
+### Phase 1: Protocol
+
+Modify: `crates/zremote-protocol/src/agents.rs`,
+`crates/zremote-protocol/src/events.rs` (+ serde roundtrip tests).
+Add `AgentKind` and `AgenticAgentMessage::AgentSessionRefCaptured`. Keep
+`SessionIdCaptured`.
+
+### Phase 2: DB + core processing
+
+Create: `crates/zremote-core/migrations/029_agent_session_ref.sql`.
+Modify: `crates/zremote-core/src/processing/agentic.rs`,
+`crates/zremote-core/src/queries/sessions.rs`.
+Handle `AgentSessionRefCaptured` → `UPDATE sessions ...`; add
+`set_agent_session_ref` + tests.
+
+### Phase 3: Claude capture via `ZREMOTE_SESSION_ID`
+
+**Blocking prerequisite (see Open Questions #1):** make `ZREMOTE_SESSION_ID`
+unconditional. Today `apply_env_vars` (`pty/shell_integration.rs:148-151`) only
+runs when `shell_config` is `Some`, `config.export_env_vars` is `true`, and at
+least one integration feature is enabled (early `return Ok(None)` at
+`shell_integration.rs:124-126`). Export `ZREMOTE_SESSION_ID` for **every**
+spawned session (both `Daemon` and `None` backends) regardless of integration
+config, or the capture path silently fails for those sessions.
+
+Modify: `crates/zremote-agent/src/pty/shell_integration.rs` (unconditional env),
+`crates/zremote-agent/src/hooks/installer.rs` (script forwards
+`X-ZRemote-Session-Id`, version stamp), `crates/zremote-agent/src/hooks/server.rs`
+(parse header), `crates/zremote-agent/src/hooks/handler.rs` (capture on
+SessionStart/first-tool, generalized dedupe, emit new message).
+
+### Phase 4: `AgentIntegration` abstraction + Codex
+
+**4a — Abstraction.** Introduce an `AgentIntegration` trait
+(`crates/zremote-agent/src/agents/mod.rs`) capturing per-agent specifics:
+config/install paths, hook event-name set, native session-id extraction,
+transcript-path root, task-name extraction, and `resume_argv`. Refactor
+`crates/zremote-agent/src/hooks/handler.rs` and `mapper.rs` to dispatch through
+it; port the existing claude logic into `ClaudeIntegration` with behavior
+preserved (guarded by the existing hook tests).
+
+**4b — Codex.** Add `CodexIntegration`: install the forwarder into codex
+(`~/.codex/hooks.json` or `config.toml` with `[features] hooks = true`; default
+normal hook with one-time trust, optional managed `~/.codex/requirements.toml`
+for zero-prompt), map codex events, extract `session_id`, and emit
+`AgentStateChanged` + `AgentSessionRefCaptured`. Add the fallback rollout
+resolver (`agents/codex_rollout.rs`, newest `session_meta` `id` + `cwd`, honor
+`CODEX_HOME`) for when hooks are untrusted/unavailable.
+
+### Phase 5: Resume-argv builder
+
+Create: `crates/zremote-agent/src/agents/resume.rs`. Wire `AgentKind` through the
+agent crate. (Consumed by RFC-013.)
+
+### Phase 6: Tests & review
+
+Tests: protocol roundtrip; handler capture keyed by header for claude and codex;
+dedupe; migration applies; `resume_argv` argv-safety (`"abc; rm -rf /"` stays a
+single arg). Run `cargo fmt --check`, `cargo check --workspace`,
+`cargo test -p zremote-protocol`, `cargo test -p zremote-core`,
+`cargo test -p zremote-agent hooks`. Then `rust-reviewer`, `code-reviewer`, and
+`security-reviewer` (untrusted hook input + config-file writes).
+
+## Risks
+
+### Protocol churn
+Removing `SessionIdCaptured` immediately could break mixed deployments.
+Mitigation: add new message, consume it first, remove legacy only after all
+crates migrate.
+
+### Env var is shell-controllable
+`ZREMOTE_SESSION_ID` can be altered inside the shell. Mitigation: validate as a
+UUID; only use it to key an `UPDATE` on an existing `sessions` row; ignore
+unknown ids. The transport is localhost-only.
+
+### Codex hook surface drift
+Codex's hook event set / payload may change across versions (verified for
+`0.135.0`). Mitigation: keep `CodexIntegration` self-contained, depend only on
+the documented `session_id`/`cwd`/event fields, and fall back to the rollout
+resolver if hooks are absent or untrusted.
+
+### Handler refactor risk
+The `AgentIntegration` abstraction refactors `handler.rs` (84k) and `mapper.rs`,
+which were just reworked by the minimal-agent-state change. A regression here
+breaks claude state detection. Mitigation: port claude logic into
+`ClaudeIntegration` behavior-for-behavior, keep the existing hook tests green
+throughout (no test changes in the claude-only refactor step, Phase 4a), and land
+4a before adding codex in 4b.
+
+### Command injection on resume
+Mitigation: native ids are argv elements only, validated, never shell-interpolated
+(covered by `resume_argv` tests).
+
+### Re-install churn
+Version stamping must not rewrite settings on every boot. Mitigation: compare a
+single `ZREMOTE_HOOK_VERSION` constant; only rewrite on mismatch.
+
+## Acceptance Criteria
+
+- Typing `claude` (or `codex`) in any ZRemote terminal populates
+  `sessions.agent_kind` + `sessions.agent_session_ref` within one turn, without
+  the Claude-task feature.
+- Codex sessions are captured the same way as Claude.
+- Capture is correlated by `ZREMOTE_SESSION_ID`, not by the loop mapper.
+- `resume_argv` returns correct, injection-safe argv for both agents.
+- Installed hooks carry a version stamp and re-install only on version change.
+- Workspace formatting and the listed tests pass; all review findings fixed.
+
+## Resolved Decisions (2026-06-04)
+
+- **Codex is in scope, verified.** Confirmed (`codex-cli 0.135.0` + Codex hooks
+  docs): codex hooks mirror Claude (same events, `session_id` in stdin JSON, same
+  `hooks.json`/output shape). Capture **and** state come via a codex hook that
+  **reuses the claude hook infra**; trust is a one-time interactive accept (or a
+  managed `~/.codex/requirements.toml` for zero-prompt). Relaunch via
+  `codex resume <UUID>`. Filesystem rollout is a fallback when hooks are
+  untrusted/unavailable.
+- **Correlation via `ZREMOTE_SESSION_ID`**, which must be made unconditional
+  (Phase 3 prerequisite, Open Question #1).
+- **One ref per session (last-wins).** A single
+  `sessions.agent_session_ref` column; the most recently active agent wins. No
+  per-session ref history table in v1 (see RFC-013 decision F).
+- **Codex hook trust: normal hook by default.** Install a normal
+  `~/.codex/hooks.json` hook (one-time interactive trust); expose the managed
+  `~/.codex/requirements.toml` path as an opt-in for headless/server installs.
+  Never default to `--dangerously-bypass-hook-trust`.
+- **Full `AgentIntegration` trait abstraction.** Refactor `handler.rs` /
+  `mapper.rs` to dispatch through a per-agent trait rather than scattered
+  `AgentKind` branches, with `ClaudeIntegration` + `CodexIntegration` impls
+  (Phase 4a/4b). Larger refactor, accepted for a clean extension point.
+
+## Open Questions & Prerequisites
+
+1. **`ZREMOTE_SESSION_ID` must become unconditional** (verified gap at
+   `shell_integration.rs:124-126,148-151`). Engineering prerequisite for Phase 3,
+   not a design choice — without it the capture path silently no-ops for
+   sessions with shell integration disabled or `shell_config: None`.
+2. **Codex rollout fallback robustness.** The fallback resolver matches the
+   newest rollout `session_meta` by `cwd` (confirmed present). If two codex
+   sessions ran in the same directory, tie-break by the `session_meta.timestamp`
+   closest to (and after) the codex process start time.
+3. **Server-mode persistence path.** `AgentSessionRefCaptured` must be processed
+   into the correct database in both local mode (agent's `local.db`) and server
+   mode (server DB via the WS processing path). Phase 2 must wire both.

--- a/docs/rfc/rfc-013-resumable-sessions-after-restart.md
+++ b/docs/rfc/rfc-013-resumable-sessions-after-restart.md
@@ -1,0 +1,351 @@
+# RFC-013: Resumable Terminal Sessions After Agent Restart / Reboot
+
+## Status: Draft
+
+## Date: 2026-06-04
+
+## Problem Statement
+
+ZRemote terminal sessions survive an **agent restart** but not a **machine
+reboot**, and there is no way to continue an agent conversation afterward.
+
+Sessions run on a per-session PTY daemon that detaches with `setsid()`
+(`crates/zremote-agent/src/lib.rs:198`) and is recovered on agent restart by
+scanning `/tmp/zremote-pty-{uid}-{hash}/{session_id}.json` and checking
+`is_daemon_alive()` (`crates/zremote-agent/src/daemon/discovery.rs:254-294`).
+That liveness check is `kill(pid, 0)` plus a `/proc` start-time / `started_at`
+match. After a reboot the daemon process is gone, so the check returns `false`,
+recovery is skipped, and startup recovery downgrades the row from `active` →
+`suspended` → `closed` (`crates/zremote-agent/src/local/mod.rs:142-228`).
+
+When the GUI then tries to attach, `register_browser()`
+(`crates/zremote-agent/src/local/routes/terminal.rs:27-100`) finds no in-memory
+session and returns `"session is stale (server restarted)"` /
+`"session is <status>"`. **There is no code path that re-spawns a shell or
+relaunches the original command.** The user is left with a session that appears
+in history but is a dead end — exactly the reported symptom: *the session shows
+but cannot be continued.*
+
+The schema stores `working_dir` and `shell` but **not** the original command or
+argv (`migrations/001_initial.sql:15-25`), so even a generic shell cannot be
+re-created with its content, and nothing relaunches an agent.
+
+This RFC adds a `resumable` session state and a deterministic relaunch path that
+re-opens an agent session by running its native resume command, using the
+`agent_kind` + `agent_session_ref` persisted by **RFC-012**.
+
+## Goals
+
+1. After a restart or reboot, a terminal session that ran a supported agent
+   (Claude/Codex) can be re-opened and continue its native conversation by
+   relaunching the agent with its native resume command.
+2. Keep such sessions **visible and attachable** as `resumable` instead of
+   silently closing them.
+3. Make relaunch deterministic and safe (argv-based), runnable explicitly by the
+   user and, when configured, automatically on attach.
+4. (Optional, gated) Re-create a plain shell at the original `working_dir` for
+   non-agent sessions.
+
+## Non-Goals
+
+- Restoring live terminal scrollback / on-screen content across a reboot.
+  Verified: scrollback is **in-memory only** (`zremote-core/src/state.rs:22`,
+  100 KB cap) and is not persisted to the database — after a reboot it is gone.
+  Conversation continuity comes from the agent's own resume, not from replaying
+  pixels. Showing static prior screen content is explicitly dropped (decision C);
+  it would require new scrollback persistence for marginal benefit.
+- Persisting arbitrary long-running non-agent processes across reboot.
+- Capturing the native session id — that is RFC-012.
+
+## Current State
+
+- Default backend is `Daemon` (`crates/zremote-agent/src/config.rs:124-150`);
+  `SessionManager::create()` spawns it (`session.rs:60-122`).
+- State/socket files: `/tmp/zremote-pty-{uid}-{8-hex-hash}/{session_id}.{json,
+  sock,log}` (`daemon/mod.rs:46-55`); `DaemonStateFile` carries `shell,
+  shell_pid, daemon_pid, cols, rows, started_at, owner_id` (`daemon/mod.rs:26-39`).
+- `is_daemon_alive()` returns `false` after reboot (`discovery.rs:254-294`;
+  `kill(pid, 0)` fails).
+- Startup recovery: `active`→`suspended`, recover living daemons →`active`,
+  unrecovered `suspended`→`closed` (`local/mod.rs:142-228`).
+- Attach has no respawn path; returns a stale/closed error
+  (`terminal.rs:27-100`).
+- `list_sessions` returns rows `WHERE status != 'closed'`
+  (`crates/zremote-core/src/queries/sessions.rs:78-87`) — so a `closed` session
+  disappears from the normal list; a `resumable` one would remain.
+- `sessions` stores `working_dir` and `shell`, but **no original command/argv**
+  (`migrations/001_initial.sql:15-25`).
+- `/tmp` is frequently cleared on reboot, so state files cannot be relied on for
+  recovery; the DB is the source of truth.
+- **Depends on RFC-012**: `sessions.agent_kind`, `sessions.agent_session_ref`
+  (migration `029`) and the `resume_argv(agent, native_id)` builder.
+
+## Design
+
+### New lifecycle state: `resumable`
+
+Add a status value `resumable`, distinct from `suspended`/`closed`.
+
+Change startup recovery (`local/mod.rs`): when a session's daemon is **not**
+recovered, classify instead of blanket-closing:
+
+- `agent_session_ref IS NOT NULL` → mark **`resumable`** (an agent conversation
+  we can re-open).
+- else if `recreate_shell_on_restart` is enabled and `working_dir` is present →
+  mark **`resumable`** (a plain shell we can re-create at the same cwd).
+- else → `closed` (current behavior).
+
+`list_sessions` already includes everything `!= 'closed'`, so `resumable`
+sessions stay listed and clickable. No GUI dead-ends.
+
+### Relaunch engine
+
+Add `SessionManager::resume_session()` that re-creates a backend for an
+**existing** `sessions.id` (stable identity) and drives the agent's resume:
+
+```rust
+// crates/zremote-agent/src/session.rs
+pub async fn resume_session(
+    &mut self,
+    session_id: SessionId,
+    shell: &str,
+    working_dir: Option<&str>,
+    env: Option<&HashMap<String, String>>,
+    shell_config: Option<&ShellIntegrationConfig>,
+    resume: Option<ResumeInvocation>,   // Some(argv) for agent resume, None for plain shell
+    cols: u16,
+    rows: u16,
+) -> Result<u32, ...>;
+```
+
+Flow:
+
+1. `cleanup_stale_daemons()` for the id (defensive; state file may be gone).
+2. `create()` a fresh daemon/PTY with the **same** `session_id`, `working_dir`,
+   `shell`, and env (so `ZREMOTE_SESSION_ID` equals the original id — RFC-012
+   capture continues to work for the resumed process).
+3. If `resume` is `Some(argv)`, spawn the session with the resume command **as
+   the session's command** — the same mechanism the Claude-task spawn already
+   uses (`crates/zremote-agent/src/claude/mod.rs` builds `cd '<dir>' && claude
+   ...` as the spawned command). The shell runs `claude --resume <id>` /
+   `codex resume <id>` at start, so there is no prompt-readiness race and no
+   "type into a live shell" timing problem.
+4. Update the DB row `resumable` → `active`.
+
+`ResumeInvocation` is built from `resume_argv(agent_kind, agent_session_ref)`
+(RFC-012). The argv becomes the spawned session's command, shell-quoted when the
+command string is built; the native id remains a single token (injection-safe).
+
+### Attach path + explicit endpoint
+
+`register_browser()` (`terminal.rs`): when the session is not in memory and the
+DB status is `resumable`:
+
+- If `resume_agents_on_restart` (config) is **on**: load `agent_kind,
+  agent_session_ref, working_dir, shell` and call `resume_session(...)`, then
+  proceed with normal registration (no scrollback restore, decision C).
+- If **off**: return a typed, non-fatal `SessionResumable` result so the GUI can
+  offer an explicit "Continue" action instead of an error string.
+
+Add an explicit REST endpoint for user-initiated resume:
+
+```
+POST /api/hosts/:host_id/sessions/:id/resume  -> 200 { session }  (re-created, active)
+```
+
+(`crates/zremote-agent/src/local/routes/sessions.rs`.)
+
+### Reusing the session id
+
+Reuse the original `sessions.id` so GUI handles, history, and any
+`claude_sessions` linkage stay stable. The daemon state file is keyed by session
+id; recreation overwrites any stale file, and `started_at` PID-reuse protection
+(`discovery.rs:157-171`) still guards against collisions. Guard against
+double-launch: if a live daemon for that id somehow exists, attach instead of
+relaunching; ensure the resume command is spawned exactly once.
+
+### Unified resume engine & Claude-task reconciliation
+
+Decision D unifies resume on one mechanism. The shared low-level step is "spawn a
+session for an existing session id with the resume argv as its command" (see
+Relaunch engine). The existing Claude-task resume
+(`crates/zremote-agent/src/local/routes/claude_sessions.rs:225-353`,
+`POST /api/claude-tasks/:id/resume`) is refactored to call this shared engine
+instead of its own spawn path, so there is exactly one relaunch implementation
+and no risk of double-launching a conversation.
+
+Reconcile the two records on startup. Today recovery only touches the `sessions`
+table (`local/mod.rs:142-228`); `claude_sessions.status` is left untouched, so a
+Claude task stays `active`/`starting` in the sidebar
+(`crates/zremote-gui/src/views/sidebar.rs` loads it via `list_claude_tasks`) and
+maps to a now-dead terminal `session_id` — the observed "shows but cannot
+continue" symptom (Open Questions #1). On startup, when a terminal session
+backing a Claude task is marked `resumable`, mark the linked `claude_sessions`
+row accordingly so the sidebar entry reflects "resumable" and its click drives
+the shared resume engine instead of a failing attach.
+
+**In-place resume (decision 4).** Resuming a Claude task updates the existing
+`claude_sessions` row in place (status back to running, refresh
+`claude_session_id`) and reuses the same terminal `sessions.id`, instead of
+inserting a new task row. `insert_resumed_claude_task`
+(`crates/zremote-agent/src/local/routes/claude_sessions.rs`) is replaced by an
+in-place update — consistent with reusing the same session id (decision E) and
+last-wins (decision F). This changes the current "new task row per resume"
+behavior; total cost/tokens continue to accumulate on the single row.
+
+### Configuration
+
+Add to the session config (`crates/zremote-agent/src/config.rs`), mirroring the
+existing `PersistenceBackend` env handling — no silent invented defaults beyond
+the documented ones:
+
+- `resume_agents_on_restart: bool` (default `true`).
+- `recreate_shell_on_restart: bool` (default `false`).
+
+### GUI
+
+- A `resumable` session renders with a distinct badge and a clear affordance
+  ("Resumable — click to continue"), per the project UX bar (empty/error states
+  must carry an icon + message + action, never a bare dead terminal).
+- Clicking attaches and, with auto-resume on (decision B, default `true`),
+  immediately runs the resume command. On spawn failure (agent CLI missing on
+  `PATH`) the terminal shows an inline recoverable error and the row stays
+  `resumable`.
+- No terminal scrollback is restored (decision C); the resumed terminal starts
+  clean and the agent's `--resume` brings back the conversation.
+
+Touched views: `crates/zremote-gui/src/views/sidebar.rs`,
+`session_switcher.rs`, `terminal_panel.rs` (+ a `Resumable` state in the client
+session model, `crates/zremote-client`).
+
+## Implementation Phases
+
+### Phase 1: Status + startup classification
+
+Modify: `crates/zremote-agent/src/local/mod.rs` (classify dead sessions as
+`resumable` vs `closed`), session status enum/strings in
+`crates/zremote-protocol/src/status.rs` and `crates/zremote-core/src/state.rs`.
+No new migration (uses RFC-012's `029`). Tests: recovery marks an agent session
+`resumable`, a plain session `closed` (unless `recreate_shell_on_restart`).
+
+### Phase 2: Resume engine
+
+Modify: `crates/zremote-agent/src/session.rs` (+ `daemon/session.rs`). Add
+`resume_session()` that spawns a backend for the existing session id **with the
+resume argv as the session's command** (the Claude-task spawn mechanism). Tests:
+resume rebuilds a backend for the same id, runs the resume command exactly once,
+and the command string is shell-safe.
+
+### Phase 3: Attach + REST
+
+Modify: `crates/zremote-agent/src/local/routes/terminal.rs` (handle `resumable`
+in `register_browser`), `crates/zremote-agent/src/local/routes/sessions.rs` (add
+`POST .../sessions/:id/resume`), client SDK
+`crates/zremote-client/src/terminal.rs` (typed `SessionResumable`). Tests:
+attach to a `resumable` agent session triggers resume and transitions to
+`active`.
+
+### Phase 4: GUI
+
+Modify: `sidebar.rs`, `session_switcher.rs`, `terminal_panel.rs`, client session
+model. Add the `resumable` badge, click-to-continue (auto-resume on click), and
+inline spawn-failure state. UX review required.
+
+### Phase 5: Config
+
+Modify: `crates/zremote-agent/src/config.rs` (+ env parsing & docs in
+`CLAUDE.md` env table). Tests: defaults and overrides parse.
+
+### Phase 6: Tests & review
+
+End-to-end: simulate reboot (stop agent + kill daemons, restart agent) and assert
+a Claude/Codex session becomes `resumable`, then resume launches
+`claude --resume <id>` / `codex resume <id>` at the original `working_dir` and
+transitions to `active`. Run `cargo fmt --check`, `cargo check --workspace`,
+`cargo test -p zremote-agent`, `cargo test -p zremote-core`,
+`cargo check -p zremote-gui`. Then `rust-reviewer`, `code-reviewer`,
+`security-reviewer` (relaunch executes a command derived from stored data),
+and `/visual-test` for the resumable badge.
+
+## Risks
+
+### Double-launch / duplicate agent sessions
+Two attaches could both relaunch. Mitigation: serialize per session id; if a live
+daemon exists, attach; spawn the resume command exactly once per resumable
+session.
+
+### `/tmp` cleared on reboot
+Irrelevant for agent resume — relaunch is rebuilt from the DB, not from state
+files. Plain-shell re-create simply starts a fresh shell.
+
+### Wrong / missing `working_dir`
+If the original directory is gone (repo moved/deleted), spawn fails. Mitigation:
+fall back to `$HOME` with a visible warning; keep the row `resumable`.
+
+### Agent CLI not on `PATH` at resume time
+Mitigation: detect spawn/`exec` failure, surface an inline recoverable error,
+keep status `resumable` so the user can retry after fixing `PATH`.
+
+### Command injection on relaunch
+Mitigation: relaunch uses `resume_argv` argv tokens shell-quoted at injection;
+native id validated by RFC-012; never raw-interpolated.
+
+### Scrollback-continuity expectation
+Users may expect the old screen back. Mitigation: document that the agent resumes
+its *conversation*, not the terminal screen; show persisted history as static
+context when available.
+
+### Stale agent_session_ref
+The native id may reference a conversation the agent CLI can no longer resume
+(e.g. agent-side GC). Mitigation: on resume failure, surface the agent's own
+error in the terminal and keep the session `resumable` (the user can start fresh).
+
+## Acceptance Criteria
+
+- After a simulated reboot, a Claude or Codex session is listed as `resumable`
+  (not `closed`) and is clickable.
+- Resuming launches `claude --resume <id>` / `codex resume <id>` in a fresh PTY
+  at the original `working_dir`, reusing the same `sessions.id`, and the row
+  transitions to `active`.
+- No `"session is stale"` dead-end for agent sessions; the GUI offers an explicit
+  Continue action when auto-resume is disabled.
+- Relaunch is argv-based and injection-safe; resume runs exactly once per attach.
+- `resume_agents_on_restart` / `recreate_shell_on_restart` config flags work as
+  documented.
+- Workspace formatting and the listed tests pass; all review findings fixed.
+
+## Resolved Decisions (2026-06-04)
+
+- **Codex in scope (verified).** Relaunch via `codex resume <UUID>`
+  (`codex-cli 0.135.0`); capture per RFC-012 (filesystem rollout).
+- **Auto-resume default ON** (`resume_agents_on_restart = true`): clicking a
+  resumable session immediately runs the resume command.
+- **No scrollback restore** (verified in-memory only) — drop static history.
+- **One unified resume engine.** Claude-task resume is refactored to delegate to
+  the shared relaunch step; one implementation, no double-launch.
+- **Reuse the same `sessions.id`** on resume (stable handle + FK), guarded by
+  `cleanup_stale_daemons` + `started_at`.
+- **One ref per session (last-wins)** — single `agent_session_ref` column; no
+  ref history.
+- **Original command storage out of scope.** Non-agent recreate is a blank shell
+  at the original `working_dir`, gated by `recreate_shell_on_restart`
+  (default `false`).
+- **Resume command runs as the shell's command.** Spawn the session with
+  `claude --resume <id>` / `codex resume <id>` as its command (the proven
+  Claude-task spawn mechanism), avoiding any prompt-readiness / typing race.
+- **Claude-task resume is in-place.** Update the existing `claude_sessions` row
+  and reuse the same terminal `sessions.id`; no new task row per resume.
+
+## Open Questions & Prerequisites
+
+1. **Runtime reproduction (prerequisite, decision H).** Code analysis strongly
+   indicates the dead session surfaces through the **claude-tasks sidebar list**
+   (`claude_sessions.status` is not reconciled on reboot), not the filtered
+   `sessions` list. Confirm with a real restart before finalizing the visibility
+   fix: start `agent local`, create a Claude session, kill its daemon + the
+   agent, restart the agent, and inspect `GET /api/claude-tasks` vs
+   `GET /api/hosts/:id/sessions` and what the GUI lists.
+2. **`resumable` status rollout.** `SessionStatus` has `#[serde(other)]`
+   (`crates/zremote-protocol/src/status.rs:16`), so older peers tolerate the new
+   value as `Unknown` during a mixed deployment; confirm the GUI renders that
+   transitional state acceptably.


### PR DESCRIPTION
## Summary

Fixes the "a session shows in the UI but can't be continued after a reboot" problem. Agent sessions (Claude and Codex) now survive an agent restart or machine reboot and resume their **native conversation** via the agent's own resume command, instead of dead-ending on a gone PTY.

Implements two RFCs (`docs/rfc/rfc-012-*.md`, `docs/rfc/rfc-013-*.md`).

## RFC-012 — agent hooks hardening + universal native session capture

- New `AgentKind` + `AgenticAgentMessage::AgentSessionRefCaptured`; the native agent session id is persisted on the `sessions` table (migration `029`), wired in **both** local (`AgenticProcessor`) and server (`dispatch.rs`) processing paths.
- Captured for **every** terminal session that runs a supported agent — keyed by the now-unconditional `ZREMOTE_SESSION_ID` env var + an `X-ZRemote-Session-Id` hook header — no longer gated on the Claude-task feature.
- `AgentIntegration` trait abstraction; first-class **Codex** hook integration (`X-ZRemote-Agent` routing) with a filesystem rollout fallback when codex hooks are unavailable/untrusted.

## RFC-013 — resumable terminal sessions after restart/reboot

- New `SessionStatus::Resumable` + startup classification: an unrecovered session with a persisted agent ref becomes `resumable` (and its linked `claude_sessions` row is reconciled to `suspended`/`agent_restarted`); plain sessions stay `closed`.
- **argv-direct resume engine**: the agent is spawned as the session's own program (`claude --resume <id>` / `codex resume <id>`) with the native id as a single argv element — deterministic (no prompt-readiness race) and injection-safe.
- Resume on attach + `POST /api/hosts/:id/sessions/:id/resume`; the Claude-task resume is unified onto the shared engine with same-id **in-place** row update.
- GUI: "Resumable" badge + click-to-continue overlay (inline recoverable error on spawn failure).
- Config: `resume_agents_on_restart` (default true), `recreate_shell_on_restart` (default false).

## Verification

- `cargo fmt` / `cargo clippy --workspace --all-targets` / `cargo test --workspace` all green.
- rust + code + security review gates run per RFC; **all findings fixed** (incl. multibyte-slug panic, capture-loss on full channel, a path-traversal guard, cascade-close data-loss protection for resumable sessions, resume status guard, spawn/DB ordering rollback, and command-injection hardening).
- Visual: resumable badge rendered/screenshotted. Runtime: an end-to-end repro spawns a real `claude --resume` after a simulated reboot and transitions the row `resumable -> active`.

## Compatibility

Additive protocol changes only (`#[serde(other)]` on the new enums); existing message variants and migrations are untouched.
